### PR TITLE
Toolbox pages + spreadsheet to JSON conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@ionic-native/device": "^5.28.0",
     "@ionic-native/http": "^5.28.0",
     "@ionic-native/media": "^5.25.0",
+    "@ionic-native/splash-screen": "^5.28.0",
+    "@ionic-native/status-bar": "^5.28.0",
     "@ionic/angular": "^5.0.0",
     "@ionic/pwa-elements": "^3.0.1",
     "capacitor-firebase-auth": "^2.3.2",

--- a/scripts/plh-spreadsheet/plh-spreadsheet.model.ts
+++ b/scripts/plh-spreadsheet/plh-spreadsheet.model.ts
@@ -4,11 +4,13 @@ export interface ContentIndexRow {
     Sheet_Name: string,
     Content_Type: "Conversation" | "Toolbox",
     Character?: "Friend" | "Guide",
-    Entry_Condition?: string
+    Entry_Condition?: string,
+    Topic_Id?: string
 }
 
 export interface ToolboxExcelSheet {
     sheetName: string,
+    topicId: string,
     rows: ToolboxExcelRow[]
 }
 

--- a/scripts/plh-spreadsheet/process-content-spreadsheet.ts
+++ b/scripts/plh-spreadsheet/process-content-spreadsheet.ts
@@ -46,7 +46,7 @@ export function processWorkbook(workbook: xlsx.WorkBook, outputFolderPaths: stri
     console.log("Content list", contentList);
 
     const conversationSheets: ConversationExcelSheet[] = contentList
-        .filter((contentListItem) => contentListItem.Content_Type === "Conversation")
+        .filter((contentListItem) => contentListItem.Content_Type.trim() === "Conversation")
         .filter((contentListItem) => workbook.Sheets[contentListItem.Sheet_Name])
         .map((contentListItem) => {
             const rows: ConversationExcelRow[] = xlsx.utils.sheet_to_json(workbook.Sheets[contentListItem.Sheet_Name]);
@@ -66,12 +66,13 @@ export function processWorkbook(workbook: xlsx.WorkBook, outputFolderPaths: stri
 
     
     const toolboxSheets: ToolboxExcelSheet[] = contentList
-        .filter((contentListItem) => contentListItem.Content_Type === "Toolbox")
+        .filter((contentListItem) => contentListItem.Content_Type.trim() === "Toolbox")
         .filter((contentListItem) => workbook.Sheets[contentListItem.Sheet_Name])
         .map((contentListItem) => {
             const rows: ToolboxExcelRow[] = xlsx.utils.sheet_to_json(workbook.Sheets[contentListItem.Sheet_Name]);
             return {
                 sheetName: contentListItem.Sheet_Name,
+                topicId: contentListItem.Topic_Id,
                 rows: rows
             };
         });

--- a/scripts/plh-spreadsheet/process-content-spreadsheet.ts
+++ b/scripts/plh-spreadsheet/process-content-spreadsheet.ts
@@ -55,7 +55,7 @@ export function processWorkbook(workbook: xlsx.WorkBook, outputFolderPaths: stri
                 rows: rows
             };
         });
-    console.log("Conversation Sheets: ", conversationSheets);
+    console.log("Conversation Sheets: ", JSON.stringify(conversationSheets));
 
     const conversationTranslator = new ConversationTranslator();
     const rapidProExportObject = conversationTranslator.from(conversationSheets);

--- a/scripts/plh-spreadsheet/toolbox-content.model.ts
+++ b/scripts/plh-spreadsheet/toolbox-content.model.ts
@@ -1,2 +1,0 @@
-/* Yet to be defined! */
-export type ToolboxContent = any;

--- a/scripts/plh-spreadsheet/toolbox.translator.ts
+++ b/scripts/plh-spreadsheet/toolbox.translator.ts
@@ -1,13 +1,46 @@
+import { Dictionary } from '@fullcalendar/angular';
+import { toolboxTopicNames } from 'src/app/shared/services/toolbox/toolbox-topic-metadata';
+import { ToolboxExport, ToolboxSection, ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from '../../src/app/shared/services/toolbox/toolbox.model';
 import { ToolboxExcelSheet } from './plh-spreadsheet.model';
-import { ToolboxContent } from './toolbox-content.model';
 
 export class ToolboxTranslator {
 
-    public from(toolboxSheets: ToolboxExcelSheet[]): ToolboxContent {
-        return {};
+    private getTopicMetadata(id: string): ToolboxTopicMetadata {
+        return toolboxTopicNames.find((topicMetadata) => topicMetadata.type === id);
     }
-    
-    public to(toolboxContent: ToolboxContent): ToolboxExcelSheet[] {
+
+    public from(toolboxSheets: ToolboxExcelSheet[]): ToolboxExport {
+        let topicByType: { [type: string]: ToolboxTopic } = {};
+        for (let sheet of toolboxSheets) {
+            let topicMetadata = this.getTopicMetadata(sheet.topicId);
+            if (topicMetadata) {
+                if (!topicByType[topicMetadata.type]) {
+                    topicByType[topicMetadata.type] = {
+                        metadata: topicMetadata,
+                        contentSections: []
+                    }
+                }
+            }
+        }
+        let topicTypes: ToolboxTopicType[] = Object.keys(topicByType) as ToolboxTopicType[];
+        return {
+            topics: topicTypes.map((type) => topicByType[type])
+        };
+    }
+
+    public sheetToContentSection(sheet: ToolboxExcelSheet): ToolboxSection {
+        let topic: ToolboxTopic = {
+            metadata: metadata,
+            contentSections: []
+        };
+        for (let row of sheet.rows) {
+            switch (row.Type) {
+                case "Title": 
+            }
+        }
+    }
+
+    public to(toolboxExport: ToolboxExport): ToolboxExcelSheet[] {
         return [];
     }
 

--- a/scripts/plh-spreadsheet/toolbox.translator.ts
+++ b/scripts/plh-spreadsheet/toolbox.translator.ts
@@ -89,7 +89,7 @@ export class ToolboxTranslator {
         }
         return {
             elements: elements,
-            title: sheet.sheetName
+            title: title
         };
     }
 

--- a/scripts/plh-spreadsheet/toolbox.translator.ts
+++ b/scripts/plh-spreadsheet/toolbox.translator.ts
@@ -29,15 +29,10 @@ export class ToolboxTranslator {
     }
 
     public sheetToContentSection(sheet: ToolboxExcelSheet): ToolboxSection {
-        let topic: ToolboxTopic = {
-            metadata: metadata,
-            contentSections: []
+        return {
+            elements: [],
+            title: sheet.sheetName
         };
-        for (let row of sheet.rows) {
-            switch (row.Type) {
-                case "Title": 
-            }
-        }
     }
 
     public to(toolboxExport: ToolboxExport): ToolboxExcelSheet[] {

--- a/src/app/feature/calendar/calendar.page.spec.ts
+++ b/src/app/feature/calendar/calendar.page.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FullCalendarModule } from '@fullcalendar/angular';
 import { IonicModule } from '@ionic/angular';
 
 import { CalendarPage } from './calendar.page';
@@ -10,7 +11,7 @@ describe('CalendarPage', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ CalendarPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), FullCalendarModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CalendarPage);

--- a/src/app/feature/calendar/calendar.page.ts
+++ b/src/app/feature/calendar/calendar.page.ts
@@ -30,9 +30,6 @@ export class CalendarPage implements OnInit, OnDestroy, AfterViewInit {
     contentHeight: "100%",
     viewHeight: "100%",
     headerToolbar: { start: "title", center: "", end: "prev,next" },
-    dateClick: (d) => {
-      console.log("date clicked", d);
-    },
     events: [
       {
         id: "a",

--- a/src/app/feature/chat/chat.page.ts
+++ b/src/app/feature/chat/chat.page.ts
@@ -70,7 +70,9 @@ export class ChatPage implements OnInit, OnDestroy {
       } else {
         this.character = "guide";
       }
-      this.sendCustomOption(this.character === "guide" ? "guide" : "chat");
+      setTimeout(() => {
+        this.sendCustomOption(this.character === "guide" ? "guide" : "chat");
+      }, 500);
     });
     this.messageSubscription = this.chatService.messages$
       .asObservable()

--- a/src/app/feature/chat/chat.page.ts
+++ b/src/app/feature/chat/chat.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectorRef, ViewChild } from "@angular/core";
+import { Component, OnInit, ChangeDetectorRef, ViewChild, OnDestroy } from "@angular/core";
 import { AnimationOptions } from "ngx-lottie";
 import { IonContent } from "@ionic/angular";
 import { IRapidProMessage, NotificationService } from 'src/app/shared/services/notification/notification.service';
@@ -7,13 +7,14 @@ import { IfStmt } from '@angular/compiler';
 import { ChatMessage, ChatResponseOption, ResponseCustomAction } from 'src/app/shared/services/chat/chat-msg.model';
 import { OfflineChatService } from 'src/app/shared/services/chat/offline/offline-chat.service';
 import { OnlineChatService } from 'src/app/shared/services/chat/online/online-chat.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: "app-chat",
   templateUrl: "./chat.page.html",
   styleUrls: ["./chat.page.scss"],
 })
-export class ChatPage implements OnInit {
+export class ChatPage implements OnInit, OnDestroy {
   messages: ChatMessage[] = [];
   allMessages: ChatMessage[] = [];
   responseOptions: ChatResponseOption[] = [];
@@ -53,6 +54,7 @@ export class ChatPage implements OnInit {
   showingAllMessages = true;
 
   character: "guide" | "egg" = "guide";
+  messageSubscription: Subscription;
 
   constructor(
     private cd: ChangeDetectorRef,
@@ -68,8 +70,9 @@ export class ChatPage implements OnInit {
       } else {
         this.character = "guide";
       }
+      this.sendCustomOption(this.character === "guide" ? "guide" : "chat");
     });
-    this.chatService.messages$
+    this.messageSubscription = this.chatService.messages$
       .asObservable()
       .subscribe((messages) => {
         console.log("from chat service ", messages);
@@ -77,6 +80,10 @@ export class ChatPage implements OnInit {
           this.onNewMessage(messages[messages.length - 1]);
         }
       });
+  }
+
+  ngOnDestroy() {
+    this.messageSubscription.unsubscribe();
   }
 
   onReceiveRapidProMessage(rapidMsg: IRapidProMessage) {

--- a/src/app/feature/toolbox/toolbox-routing.module.ts
+++ b/src/app/feature/toolbox/toolbox-routing.module.ts
@@ -7,7 +7,12 @@ const routes: Routes = [
   {
     path: '',
     component: ToolboxPage
+  },
+  {
+    path: 'topic',
+    loadChildren: () => import('./toolbox-topic/toolbox-topic.module').then( m => m.ToolboxTopicPageModule)
   }
+
 ];
 
 @NgModule({

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic-routing.module.ts
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { ToolboxTopicPage } from './toolbox-topic.page';
+
+const routes: Routes = [
+  {
+    path: ':type',
+    component: ToolboxTopicPage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class ToolboxTopicPageRoutingModule {}

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.module.ts
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { ToolboxTopicPageRoutingModule } from './toolbox-topic-routing.module';
+
+import { ToolboxTopicPage } from './toolbox-topic.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    ToolboxTopicPageRoutingModule
+  ],
+  declarations: [ToolboxTopicPage]
+})
+export class ToolboxTopicPageModule {}

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.html
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.html
@@ -1,9 +1,31 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>toolbox-topic {{type}}</ion-title>
+    <ion-title>{{topic?.metadata?.name}}</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
-
+  <div *ngIf="topic">
+    <div *ngFor="let section of topic.contentSections" class="tb-section">
+      <h2 class="tb-title">{{section.title}}</h2>
+      <div *ngFor="let element of section.elements">
+        <div *ngIf="element.type === 'CORE_TIP'" class="tb-element core-tip">
+          <h1>💡</h1>
+          {{element.text}}
+        </div>
+        <div *ngIf="element.type === 'TEXT'" class="tb-element text">
+          {{element.text}}
+        </div>
+        <div *ngIf="element.type === 'LIST'" class="tb-element list">
+          <h3>{{element.intro}}</h3>
+          <ul>
+            <li *ngFor="let item of element.items">
+              <h4>{{item.heading}}</h4>
+              <p>{{item.body}}</p>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
 </ion-content>

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.html
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.html
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>toolbox-topic {{type}}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+
+</ion-content>

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.scss
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.scss
@@ -1,0 +1,32 @@
+.tb-section {
+    background-image: url('/assets/images/punched_paper_1.png');
+    background-repeat: repeat-y;
+    margin: 20px;
+    max-width: 359px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.tb-title {
+    margin-left: 40px;
+    margin-right: 20px;
+}
+
+.tb-element {
+
+    padding: 20px;
+    margin-left: 40px;
+    margin-right: 20px;
+
+    &.core-tip {
+        color: white;
+        background-color: crimson;
+        border-radius: 20px;
+        padding: 20px;
+    }
+}
+
+
+ion-content {
+    --ion-background-color: #f3d668;
+}

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.spec.ts
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { ToolboxTopicPage } from './toolbox-topic.page';
+
+describe('ToolboxTopicPage', () => {
+  let component: ToolboxTopicPage;
+  let fixture: ComponentFixture<ToolboxTopicPage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ToolboxTopicPage ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ToolboxTopicPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.ts
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ToolboxTopicType } from 'src/app/shared/services/toolbox/toolbox.model';
+
+@Component({
+  selector: 'plh-toolbox-topic',
+  templateUrl: './toolbox-topic.page.html',
+  styleUrls: ['./toolbox-topic.page.scss'],
+})
+export class ToolboxTopicPage implements OnInit {
+
+  type: ToolboxTopicType = "ONE_ON_ONE_TIME";
+
+  constructor(private activatedRoute: ActivatedRoute) {
+    this.activatedRoute.params.subscribe((params) => {
+      this.type = params["type"];
+    });
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.ts
+++ b/src/app/feature/toolbox/toolbox-topic/toolbox-topic.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { ToolboxTopicType } from 'src/app/shared/services/toolbox/toolbox.model';
+import { ToolboxTopic, ToolboxTopicType } from 'src/app/shared/services/toolbox/toolbox.model';
+import { ToolboxService } from 'src/app/shared/services/toolbox/toolbox.service';
 
 @Component({
   selector: 'plh-toolbox-topic',
@@ -10,10 +11,14 @@ import { ToolboxTopicType } from 'src/app/shared/services/toolbox/toolbox.model'
 export class ToolboxTopicPage implements OnInit {
 
   type: ToolboxTopicType = "ONE_ON_ONE_TIME";
+  topic: ToolboxTopic;
 
-  constructor(private activatedRoute: ActivatedRoute) {
+  constructor(private activatedRoute: ActivatedRoute, private toolboxService: ToolboxService) {
     this.activatedRoute.params.subscribe((params) => {
-      this.type = params["type"];
+      this.type = params["type"] as ToolboxTopicType;
+      this.toolboxService.getTopic(this.type).subscribe((topic) => {
+        this.topic = topic;
+      });
     });
   }
 

--- a/src/app/feature/toolbox/toolbox.page.html
+++ b/src/app/feature/toolbox/toolbox.page.html
@@ -1,7 +1,10 @@
 <ion-content class="ion-padding">
   <!--<p>You don't have any tools in your toolbox at the moment. Talk to the guide to find out how to get some!</p>-->
-  <div *ngFor="let topic of toolboxTopics" class="toolbox-button" [ngStyle]="{ 'background-color': topic.buttonColor}"
-    (click)="onClickTopic(topic.type)">
-    <span class="toolbox-button-label">{{topic.name}}</span>
+  <div *ngFor="let topicMetadata of toolboxTopicMetadatas" class="toolbox-button-container"
+    (click)="onClickTopic(topicMetadata)">
+    <div *ngIf="!topicMetadata.unlocked" class="locked-cover"></div>
+    <div class="toolbox-button-body"  [ngStyle]="{ 'background-color': topicMetadata.buttonColor}">
+      <span class="toolbox-button-label">{{topicMetadata.name}}</span>
+    </div>
   </div>
 </ion-content>

--- a/src/app/feature/toolbox/toolbox.page.html
+++ b/src/app/feature/toolbox/toolbox.page.html
@@ -1,3 +1,7 @@
 <ion-content class="ion-padding">
-  <p>You don't have any tools in your toolbox at the moment. Talk to the guide to find out how to get some!</p>
+  <!--<p>You don't have any tools in your toolbox at the moment. Talk to the guide to find out how to get some!</p>-->
+  <div *ngFor="let topic of toolboxTopics" class="toolbox-button" [ngStyle]="{ 'background-color': topic.buttonColor}"
+    (click)="onClickTopic(topic.type)">
+    <span class="toolbox-button-label">{{topic.name}}</span>
+  </div>
 </ion-content>

--- a/src/app/feature/toolbox/toolbox.page.scss
+++ b/src/app/feature/toolbox/toolbox.page.scss
@@ -1,0 +1,17 @@
+.toolbox-button {
+
+    border-radius: 20px;
+    box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.384);
+    padding: 20px;
+    margin: 14px;
+
+    .toolbox-button-label {
+        color: white;
+        font-size: 24px;
+    }
+
+}
+
+ion-content {
+    --ion-background-color:#F3D668; 
+}

--- a/src/app/feature/toolbox/toolbox.page.scss
+++ b/src/app/feature/toolbox/toolbox.page.scss
@@ -28,7 +28,7 @@
 
     .toolbox-button-label {
         color: white;
-        font-size: 24px;
+        font-size: 22px;
         top: 10px;
         position: relative;
         left: 20px;
@@ -39,8 +39,4 @@
             font-size: 18px;
         }
     }
-}
-
-ion-content {
-    --ion-background-color: #f3d668;
 }

--- a/src/app/feature/toolbox/toolbox.page.scss
+++ b/src/app/feature/toolbox/toolbox.page.scss
@@ -1,17 +1,46 @@
-.toolbox-button {
+.toolbox-button-container {
+    position: relative;
+    height: 50px;
 
     border-radius: 20px;
     box-shadow: 2px 2px 6px rgba(0, 0, 0, 0.384);
-    padding: 20px;
     margin: 14px;
+    max-width: 500px;
+    margin-left: auto;
+    margin-right: auto;
+
+    .locked-cover {
+        border-radius: 20px;
+        background-color: black;
+        opacity: 0.5;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        z-index: 10;
+    }
+
+    .toolbox-button-body {
+        border-radius: 20px;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+    }
 
     .toolbox-button-label {
         color: white;
         font-size: 24px;
+        top: 10px;
+        position: relative;
+        left: 20px;
     }
 
+    @media screen and (max-width: 390px) {
+        .toolbox-button-label {
+            font-size: 18px;
+        }
+    }
 }
 
 ion-content {
-    --ion-background-color:#F3D668; 
+    --ion-background-color: #f3d668;
 }

--- a/src/app/feature/toolbox/toolbox.page.ts
+++ b/src/app/feature/toolbox/toolbox.page.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from 'src/app/shared/services/toolbox/toolbox.model';
+import { ToolboxService } from 'src/app/shared/services/toolbox/toolbox.service';
 
 @Component({
   selector: 'plh-toolbox',
@@ -7,9 +10,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ToolboxPage implements OnInit {
 
-  constructor() { }
+  toolboxTopics: ToolboxTopicMetadata[] = [];
+
+  constructor(private toolboxService: ToolboxService, private router: Router) {
+    this.toolboxService.getTopicMetadatas().subscribe((topics) => {
+      this.toolboxTopics = topics;
+    });
+  }
 
   ngOnInit() {
+  }
+
+  onClickTopic(type: ToolboxTopicType) {
+    this.router.navigateByUrl("/toolbox/topic/" + type);
   }
 
 }

--- a/src/app/feature/toolbox/toolbox.page.ts
+++ b/src/app/feature/toolbox/toolbox.page.ts
@@ -10,19 +10,21 @@ import { ToolboxService } from 'src/app/shared/services/toolbox/toolbox.service'
 })
 export class ToolboxPage implements OnInit {
 
-  toolboxTopics: ToolboxTopicMetadata[] = [];
+  toolboxTopicMetadatas: ToolboxTopicMetadata[] = [];
 
   constructor(private toolboxService: ToolboxService, private router: Router) {
     this.toolboxService.getTopicMetadatas().subscribe((topics) => {
-      this.toolboxTopics = topics;
+      this.toolboxTopicMetadatas = topics;
     });
   }
 
   ngOnInit() {
   }
 
-  onClickTopic(type: ToolboxTopicType) {
-    this.router.navigateByUrl("/toolbox/topic/" + type);
+  onClickTopic(topicMetadata: ToolboxTopicMetadata) {
+    if (topicMetadata.unlocked) {
+      this.router.navigateByUrl("/toolbox/topic/" + topicMetadata.type);
+    }
   }
 
 }

--- a/src/app/shared/services/chat/online/online-chat.service.ts
+++ b/src/app/shared/services/chat/online/online-chat.service.ts
@@ -15,11 +15,10 @@ export class OnlineChatService implements ChatService {
   constructor(private notificationService: NotificationService, private toolboxService: ToolboxService) {
     this.notificationService.messages$.subscribe((messages) => {
       let lastMessage = messages[messages.length - 1];
-      if (!this.isVisibleMessage(lastMessage)) {
+      if (this.isControlMessage(lastMessage)) {
         this.executeControlMessage(lastMessage);
       }
       let chatMessages = messages
-        .filter(this.isVisibleMessage)
         .map(this.convertFromRapidProMsg);
       this.messages$.next(chatMessages);
     },
@@ -32,12 +31,12 @@ export class OnlineChatService implements ChatService {
     return from(this.notificationService.sendRapidproMessage(message.text));
   }
 
-  private isVisibleMessage(rpMsg: IRapidProMessage): boolean {
-    return rpMsg.message.indexOf("UNLOCK_TOPIC,") < -1;
+  private isControlMessage(rpMsg: IRapidProMessage): boolean {
+    return rpMsg.message.indexOf("UNLOCK_TOPIC,") > -1;
   }
 
   private executeControlMessage(rpMsg: IRapidProMessage) {
-    if (rpMsg.message.indexOf("UNLOCK_TOPIC,") < -1) {
+    if (rpMsg.message.indexOf("UNLOCK_TOPIC,") > -1) {
       let topicTypeString = rpMsg.message.split(",")[1];
       this.toolboxService.getTopicMetadatas().subscribe((topicMetadatas) => {
         let topicMetadata = topicMetadatas.find((tmd) => tmd.type === topicTypeString);

--- a/src/app/shared/services/chat/online/online-chat.service.ts
+++ b/src/app/shared/services/chat/online/online-chat.service.ts
@@ -14,17 +14,21 @@ export class OnlineChatService implements ChatService {
 
   constructor(private notificationService: NotificationService, private toolboxService: ToolboxService) {
     this.notificationService.messages$.subscribe((messages) => {
-      let lastMessage = messages[messages.length - 1];
-      if (this.isControlMessage(lastMessage)) {
-        this.executeControlMessage(lastMessage);
+      if (messages.length > 0) {
+        let lastMessage = messages[messages.length - 1];
+        if (this.isControlMessage(lastMessage)) {
+          this.executeControlMessage(lastMessage);
+        } else {
+          let chatMessages = messages
+            .filter((rpMsg) => !this.isControlMessage(rpMsg))
+            .map(this.convertFromRapidProMsg);
+          this.messages$.next(chatMessages);
+        }
       }
-      let chatMessages = messages
-        .map(this.convertFromRapidProMsg);
-      this.messages$.next(chatMessages);
     },
-    (err) => {
-      this.messages$.error(err);
-    });
+      (err) => {
+        this.messages$.error(err);
+      });
   }
 
   public sendMessage(message: ChatMessage): Observable<any> {

--- a/src/app/shared/services/local-storage/local-storage.service.spec.ts
+++ b/src/app/shared/services/local-storage/local-storage.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LocalStorageService } from './local-storage.service';
+
+describe('LocalStorageService', () => {
+  let service: LocalStorageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LocalStorageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/local-storage/local-storage.service.ts
+++ b/src/app/shared/services/local-storage/local-storage.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LocalStorageService {
+
+  constructor() { }
+
+  getString(key: string): string {
+    return localStorage.getItem(key);
+  }
+
+  setString(key: string, value: string) {
+    return localStorage.setItem(key, value);
+  }
+
+  getJSON(key: string): any {
+    let jsonString = localStorage.getItem(key);
+    try {
+      return JSON.parse(jsonString);
+    } catch (ex) {
+      return null;
+    }
+  }
+
+  setJSON(key: string, value: any): any {
+    try {
+      let jsonString = JSON.stringify(value);
+      localStorage.setItem(key, jsonString);
+    } catch (ex) {
+      return null;
+    }
+  }
+}

--- a/src/app/shared/services/toolbox/one-one-one-time.ts
+++ b/src/app/shared/services/toolbox/one-one-one-time.ts
@@ -20,6 +20,22 @@ export const oneOnOneTimeElements: ToolboxElement[] = [
             {
                 heading: "Step 2. Let your teen choose the activity",
                 body: "Tell your teen that you would like to spend some time with them and that they can choose what to do or talk about. Your teen might think this is weird at first, but will come to enjoy having this dedicated time with you!"
+            },
+            {
+                heading: "Step 3. Follow your teen's lead",
+                body: "Remember this is your teen's activity. Accept their suggestions, show interest, and say something nice."
+            },
+            {
+                heading: "Step 4. Give your teen all of your attention. ",
+                body: "Look at your teen. Nodding or saying “I see” shows you are really paying attention. Accept what they are saying without judging them."
+            },
+            {
+                heading: "Step 5. Show your teen you are really listening",
+                body: "To make them feel supported, you can even try rephrasing what they said: “Yeah, I see that you find that difficult/fun/confusing/exciting.”"
+            },
+            {
+                heading: "Step 6. Have fun!",
+                body: "One-on-One Time with your teen can be fun for you, too! It might even make you feel less stressed."
             }
         ]
     }

--- a/src/app/shared/services/toolbox/one-one-one-time.ts
+++ b/src/app/shared/services/toolbox/one-one-one-time.ts
@@ -1,0 +1,26 @@
+import { ToolboxElement } from './toolbox.model';
+
+export const oneOnOneTimeElements: ToolboxElement[] = [
+    {
+        type: "TEXT",
+        text: "When we have difficult relationships with our teenagers, we spend a lot of time disciplining or complaining about them."
+    },
+    {
+        type: "CORE_TIP",
+        text: "One-on-One Time helps build a positive, trusting relationship. When you really show interest in them, you make them feel valued and appreciated."
+    },
+    {
+        type: "LIST",
+        intro: "Here are 6 tips to make One-on-One Time a positive experience for you and your teen:",
+        items: [
+            {
+                heading: "Step 1. Do it every day",
+                body: "Set aside a time each day when you and our teen will not be interrupted and when your teen does not have something else they want to do. Switch off television and phones so you will not be interrupted."
+            },
+            {
+                heading: "Step 2. Let your teen choose the activity",
+                body: "Tell your teen that you would like to spend some time with them and that they can choose what to do or talk about. Your teen might think this is weird at first, but will come to enjoy having this dedicated time with you!"
+            }
+        ]
+    }
+];

--- a/src/app/shared/services/toolbox/toolbox-topic-metadata.ts
+++ b/src/app/shared/services/toolbox/toolbox-topic-metadata.ts
@@ -1,6 +1,6 @@
-import { ToolboxTopic } from './toolbox.model';
+import { ToolboxTopicMetadata } from './toolbox.model';
 
-export const toolboxTopicNames: ToolboxTopic[] = [
+export const toolboxTopicNames: ToolboxTopicMetadata[] = [
     {
         type: "ONE_ON_ONE_TIME",
         languageCode: "en",

--- a/src/app/shared/services/toolbox/toolbox-topics.ts
+++ b/src/app/shared/services/toolbox/toolbox-topics.ts
@@ -1,0 +1,52 @@
+import { ToolboxTopic } from './toolbox.model';
+
+export const toolboxTopicNames: ToolboxTopic[] = [
+    {
+        type: "ONE_ON_ONE_TIME",
+        languageCode: "en",
+        name: "One-on-One Time",
+        buttonColor: "#F7911E"
+    },
+    {
+        type: "PRAISE_AND_POSITIVE_REINFORCEMENT",
+        languageCode: "en",
+        name: "Praise & Positive Reinforcement",
+        buttonColor: "#ED1651"
+    },
+    {
+        type: "MANAGING_ANGER_AND_STRESS",
+        languageCode: "en",
+        name: "Managing Anger & Stress",
+        buttonColor: "#5652A3"
+    },
+    {
+        type: "FAMILY_BUDGETING",
+        languageCode: "en",
+        name: "Family Budgeting",
+        buttonColor: "#8885D1"
+    },
+    {
+        type: "RULES_AND_ROUTINES",
+        languageCode: "en",
+        name: "Rules & Routines",
+        buttonColor: "#54C5D0"
+    },
+    {
+        type: "ACCEPTING_RESPONSIBILITY",
+        languageCode: "en",
+        name: "Accepting Responsibilities",
+        buttonColor: "#0F8AB2"
+    },
+    {
+        type: "PROBLEM_SOLVING",
+        languageCode: "en",
+        name: "Problem Solving",
+        buttonColor: "#2E9E48"
+    },
+    {
+        type: "RISK_MAPPING_AND_DEALING_WITH_CRISIS",
+        languageCode: "en",
+        name: "Risk Mapping & Dealing with Crisis",
+        buttonColor: "#227535"
+    }
+];

--- a/src/app/shared/services/toolbox/toolbox.model.ts
+++ b/src/app/shared/services/toolbox/toolbox.model.ts
@@ -44,7 +44,9 @@ export type ToolboxTextElement = {
     text: string
 }
 
-export type ToolboxElement = ToolboxListElement | ToolboxCoreTipElement | ToolboxTextElement
+export type ToolboxElementType = "LIST" | "CORE_TIP" | "TEXT"
+
+export type ToolboxElement = { type: ToolboxElementType } & ToolboxListElement | ToolboxCoreTipElement | ToolboxTextElement
 
 export interface ToolboxExport {
     topics: ToolboxTopic[]

--- a/src/app/shared/services/toolbox/toolbox.model.ts
+++ b/src/app/shared/services/toolbox/toolbox.model.ts
@@ -7,18 +7,20 @@ export type ToolboxTopicType = "ONE_ON_ONE_TIME"
     | "PROBLEM_SOLVING"
     | "RISK_MAPPING_AND_DEALING_WITH_CRISIS"
 
-export interface ToolboxTopic {
+export interface ToolboxTopicMetadata {
     type: ToolboxTopicType,
     languageCode: string,
     name: string,
     unlocked?: boolean,
     buttonColor?: string,
-    pages?: ToolboxPage[]
 }
 
-export type ToolboxContentType = ""
+export type ToolboxTopic = {
+    metadata: ToolboxTopicMetadata,
+    contentSections: ToolboxSection[]
+}
 
-export interface ToolboxPage {
+export interface ToolboxSection {
     title: string,
     elements: ToolboxElement[]
 }

--- a/src/app/shared/services/toolbox/toolbox.model.ts
+++ b/src/app/shared/services/toolbox/toolbox.model.ts
@@ -1,0 +1,50 @@
+export type ToolboxTopicType = "ONE_ON_ONE_TIME"
+    | "PRAISE_AND_POSITIVE_REINFORCEMENT"
+    | "MANAGING_ANGER_AND_STRESS"
+    | "FAMILY_BUDGETING"
+    | "RULES_AND_ROUTINES"
+    | "ACCEPTING_RESPONSIBILITY"
+    | "PROBLEM_SOLVING"
+    | "RISK_MAPPING_AND_DEALING_WITH_CRISIS"
+
+export interface ToolboxTopic {
+    type: ToolboxTopicType,
+    languageCode: string,
+    name: string,
+    unlocked?: boolean,
+    buttonColor?: string,
+    pages?: ToolboxPage[]
+}
+
+export type ToolboxContentType = ""
+
+export interface ToolboxPage {
+    title: string,
+    elements: ToolboxElement[]
+}
+
+export type ToolboxListElement = {
+    type: "LIST",
+    intro: string,
+    items: {
+        heading: string,
+        body: string
+    }[]
+}
+
+export type ToolboxCoreTipElement = {
+    type: "CORE_TIP",
+    text: string
+}
+
+export type ToolboxTextElement = {
+    type: "TEXT",
+    text: string
+}
+
+export type ToolboxElement = ToolboxListElement | ToolboxCoreTipElement | ToolboxTextElement
+
+export interface ToolboxExport {
+    topics: ToolboxTopic[]
+}
+

--- a/src/app/shared/services/toolbox/toolbox.model.ts
+++ b/src/app/shared/services/toolbox/toolbox.model.ts
@@ -25,28 +25,17 @@ export interface ToolboxSection {
     elements: ToolboxElement[]
 }
 
-export type ToolboxListElement = {
-    type: "LIST",
-    intro: string,
-    items: {
+export type ToolboxElementType = "LIST" | "CORE_TIP" | "TEXT"
+
+export type ToolboxElement = {
+    type: ToolboxElementType,
+    intro?: string,
+    text?: string,
+    items?: {
         heading: string,
         body: string
     }[]
 }
-
-export type ToolboxCoreTipElement = {
-    type: "CORE_TIP",
-    text: string
-}
-
-export type ToolboxTextElement = {
-    type: "TEXT",
-    text: string
-}
-
-export type ToolboxElementType = "LIST" | "CORE_TIP" | "TEXT"
-
-export type ToolboxElement = { type: ToolboxElementType } & ToolboxListElement | ToolboxCoreTipElement | ToolboxTextElement
 
 export interface ToolboxExport {
     topics: ToolboxTopic[]

--- a/src/app/shared/services/toolbox/toolbox.service.spec.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { fstat } from 'fs';
+import { ToolboxTopic } from './toolbox.model';
+
+import { ToolboxService } from './toolbox.service';
+
+describe('ToolboxService', () => {
+  let service: ToolboxService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ToolboxService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  let expectedInitialTopics: ToolboxTopic[] = [{ "type": "ONE_ON_ONE_TIME", "languageCode": "en", "name": "One-on-One Time", "buttonColor": "#F7911E", "unlocked": false, "pages": [] }, { "type": "PRAISE_AND_POSITIVE_REINFORCEMENT", "languageCode": "en", "name": "Praise & Positive Reinforcement", "buttonColor": "#ED1651", "unlocked": false, "pages": [] }, { "type": "MANAGING_ANGER_AND_STRESS", "languageCode": "en", "name": "Managing Anger & Stress", "buttonColor": "#5652A3", "unlocked": false, "pages": [] }, { "type": "FAMILY_BUDGETING", "languageCode": "en", "name": "Family Budgeting", "buttonColor": "#8885D1", "unlocked": false, "pages": [] }, { "type": "RULES_AND_ROUTINES", "languageCode": "en", "name": "Rules & Routines", "buttonColor": "#54C5D0", "unlocked": false, "pages": [] }, { "type": "ACCEPTING_RESPONSIBILITY", "languageCode": "en", "name": "Accepting Responsibilities", "buttonColor": "#0F8AB2", "unlocked": false, "pages": [] }, { "type": "PROBLEM_SOLVING", "languageCode": "en", "name": "Problem Solving", "buttonColor": "#2E9E48", "unlocked": false, "pages": [] }, { "type": "RISK_MAPPING_AND_DEALING_WITH_CRISIS", "languageCode": "en", "name": "Risk Mapping & Dealing with Crisis", "buttonColor": "#227535", "unlocked": false, "pages": [] }]
+
+  it('should return the topics as all locked', () => {
+    service.getTopics().subscribe((topics) => {
+      expect(topics).toEqual(expectedInitialTopics);
+    });
+  });
+});

--- a/src/app/shared/services/toolbox/toolbox.service.spec.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { fstat } from 'fs';
-import { ToolboxTopic } from './toolbox.model';
+import { ToolboxTopic, ToolboxTopicMetadata } from './toolbox.model';
 
 import { ToolboxService } from './toolbox.service';
 
@@ -16,11 +16,27 @@ describe('ToolboxService', () => {
     expect(service).toBeTruthy();
   });
 
-  let expectedInitialTopics: ToolboxTopic[] = [{ "type": "ONE_ON_ONE_TIME", "languageCode": "en", "name": "One-on-One Time", "buttonColor": "#F7911E", "unlocked": false, "pages": [] }, { "type": "PRAISE_AND_POSITIVE_REINFORCEMENT", "languageCode": "en", "name": "Praise & Positive Reinforcement", "buttonColor": "#ED1651", "unlocked": false, "pages": [] }, { "type": "MANAGING_ANGER_AND_STRESS", "languageCode": "en", "name": "Managing Anger & Stress", "buttonColor": "#5652A3", "unlocked": false, "pages": [] }, { "type": "FAMILY_BUDGETING", "languageCode": "en", "name": "Family Budgeting", "buttonColor": "#8885D1", "unlocked": false, "pages": [] }, { "type": "RULES_AND_ROUTINES", "languageCode": "en", "name": "Rules & Routines", "buttonColor": "#54C5D0", "unlocked": false, "pages": [] }, { "type": "ACCEPTING_RESPONSIBILITY", "languageCode": "en", "name": "Accepting Responsibilities", "buttonColor": "#0F8AB2", "unlocked": false, "pages": [] }, { "type": "PROBLEM_SOLVING", "languageCode": "en", "name": "Problem Solving", "buttonColor": "#2E9E48", "unlocked": false, "pages": [] }, { "type": "RISK_MAPPING_AND_DEALING_WITH_CRISIS", "languageCode": "en", "name": "Risk Mapping & Dealing with Crisis", "buttonColor": "#227535", "unlocked": false, "pages": [] }]
+  let expectedInitialTopics: ToolboxTopicMetadata[] = [{ "type": "ONE_ON_ONE_TIME", "languageCode": "en", "name": "One-on-One Time", "buttonColor": "#F7911E", "unlocked": false }, { "type": "PRAISE_AND_POSITIVE_REINFORCEMENT", "languageCode": "en", "name": "Praise & Positive Reinforcement", "buttonColor": "#ED1651", "unlocked": false }, { "type": "MANAGING_ANGER_AND_STRESS", "languageCode": "en", "name": "Managing Anger & Stress", "buttonColor": "#5652A3", "unlocked": false }, { "type": "FAMILY_BUDGETING", "languageCode": "en", "name": "Family Budgeting", "buttonColor": "#8885D1", "unlocked": false }, { "type": "RULES_AND_ROUTINES", "languageCode": "en", "name": "Rules & Routines", "buttonColor": "#54C5D0", "unlocked": false }, { "type": "ACCEPTING_RESPONSIBILITY", "languageCode": "en", "name": "Accepting Responsibilities", "buttonColor": "#0F8AB2", "unlocked": false }, { "type": "PROBLEM_SOLVING", "languageCode": "en", "name": "Problem Solving", "buttonColor": "#2E9E48", "unlocked": false }, { "type": "RISK_MAPPING_AND_DEALING_WITH_CRISIS", "languageCode": "en", "name": "Risk Mapping & Dealing with Crisis", "buttonColor": "#227535", "unlocked": false }];
 
   it('should return the topics as all locked', () => {
-    service.getTopics().subscribe((topics) => {
+    service.getTopicMetadatas().subscribe((topics) => {
       expect(topics).toEqual(expectedInitialTopics);
     });
   });
+
+  it('should return object for topic ONE_ON_ONE_TIME', () => {
+    let expectedTopic: ToolboxTopic = {
+      metadata: {
+        type: "ONE_ON_ONE_TIME",
+        languageCode: "en",
+        name: "One-on-One Time",
+        buttonColor: "#F7911E",
+        unlocked: false
+      },
+      contentSections: []
+    };
+    service.getTopic("ONE_ON_ONE_TIME").subscribe((topic) => {
+      expect(topic).toEqual(expectedTopic);
+    });
+  })
 });

--- a/src/app/shared/services/toolbox/toolbox.service.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { toolboxTopicNames } from './toolbox-topics';
-import { ToolboxTopic } from './toolbox.model';
+import { toolboxTopicNames } from './toolbox-topic-metadata';
+import { ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from './toolbox.model';
 
 @Injectable({
   providedIn: 'root'
@@ -10,10 +10,20 @@ export class ToolboxService {
 
   constructor() { }
 
-  getTopics(): Observable<ToolboxTopic[]> {
-    let toolboxTopics: ToolboxTopic[] = toolboxTopicNames
-      .map((topic) => ({ ...topic, unlocked: false, pages: [] }))
-    return of(toolboxTopics);
+  getTopicMetadatas(): Observable<ToolboxTopicMetadata[]> {
+    let toolboxTopicMetadatas: ToolboxTopicMetadata[] = toolboxTopicNames
+      .map((topic) => ({ ...topic, unlocked: false }));
+    return of(toolboxTopicMetadatas);
+  }
+
+  getTopic(type: ToolboxTopicType): Observable<ToolboxTopic> {
+    let topicMetadata: ToolboxTopicMetadata = toolboxTopicNames
+      .map((topicMetadata) => ({ ...topicMetadata, unlocked: false }))
+      .find((topicMetadata) => topicMetadata.type === type)
+    return of({
+      metadata: topicMetadata,
+      contentSections: []
+    });
   }
 
 }

--- a/src/app/shared/services/toolbox/toolbox.service.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { toolboxTopicNames } from './toolbox-topics';
+import { ToolboxTopic } from './toolbox.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ToolboxService {
+
+  constructor() { }
+
+  getTopics(): Observable<ToolboxTopic[]> {
+    let toolboxTopics: ToolboxTopic[] = toolboxTopicNames
+      .map((topic) => ({ ...topic, unlocked: false, pages: [] }))
+    return of(toolboxTopics);
+  }
+
+}

--- a/src/app/shared/services/toolbox/toolbox.service.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.ts
@@ -1,18 +1,23 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
+import { LocalStorageService } from '../local-storage/local-storage.service';
 import { toolboxTopicNames } from './toolbox-topic-metadata';
 import { ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from './toolbox.model';
+
+const UNLOCKED_TOPICS_LS_KEY = "toolbox.unlocked_topics";
 
 @Injectable({
   providedIn: 'root'
 })
 export class ToolboxService {
 
-  constructor() { }
+  
+
+  constructor(private localStorageService: LocalStorageService) { }
 
   getTopicMetadatas(): Observable<ToolboxTopicMetadata[]> {
     let toolboxTopicMetadatas: ToolboxTopicMetadata[] = toolboxTopicNames
-      .map((topic) => ({ ...topic, unlocked: false }));
+      .map((topic) => ({ ...topic, unlocked: this.isTopicUnlocked(topic.type) }));
     return of(toolboxTopicMetadatas);
   }
 
@@ -24,6 +29,23 @@ export class ToolboxService {
       metadata: topicMetadata,
       contentSections: []
     });
+  }
+
+  isTopicUnlocked(type: ToolboxTopicType) {
+    let unlockedTopicMap: Object = this.localStorageService.getJSON(UNLOCKED_TOPICS_LS_KEY);
+    if (unlockedTopicMap) {
+      return unlockedTopicMap.hasOwnProperty(type);
+    }
+    return false;
+  }
+
+  unlockTopic(type: ToolboxTopicType) {
+    let unlockedTopicMap: Object = this.localStorageService.getJSON(UNLOCKED_TOPICS_LS_KEY);
+    if (!unlockedTopicMap) {
+      unlockedTopicMap = {};
+    }
+    unlockedTopicMap[type] = true;
+    return this.localStorageService.setJSON(UNLOCKED_TOPICS_LS_KEY, unlockedTopicMap);
   }
 
 }

--- a/src/app/shared/services/toolbox/toolbox.service.ts
+++ b/src/app/shared/services/toolbox/toolbox.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { LocalStorageService } from '../local-storage/local-storage.service';
+import { oneOnOneTimeElements } from './one-one-one-time';
 import { toolboxTopicNames } from './toolbox-topic-metadata';
-import { ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from './toolbox.model';
+import { ToolboxElement, ToolboxTopic, ToolboxTopicMetadata, ToolboxTopicType } from './toolbox.model';
 
 const UNLOCKED_TOPICS_LS_KEY = "toolbox.unlocked_topics";
 
@@ -25,6 +26,18 @@ export class ToolboxService {
     let topicMetadata: ToolboxTopicMetadata = toolboxTopicNames
       .map((topicMetadata) => ({ ...topicMetadata, unlocked: false }))
       .find((topicMetadata) => topicMetadata.type === type)
+    if (topicMetadata.type === "ONE_ON_ONE_TIME") {
+      
+      return of({
+        metadata: topicMetadata,
+        contentSections: [
+          {
+            title: "One on One Time Tips",
+            elements: oneOnOneTimeElements
+          }
+        ]
+      });
+    }
     return of({
       metadata: topicMetadata,
       contentSections: []

--- a/src/assets/images/punched_paper_1.png
+++ b/src/assets/images/punched_paper_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c5cea5a0f334939e5fa5d94173f29462c5e2a71487a2fd225d336407221d70
+size 29036

--- a/src/assets/images/punched_paper_left1.png
+++ b/src/assets/images/punched_paper_left1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68eefbbc795065aa5d98f86695fbeda40bd6d9df6b32390adfed20291f62fc0e
-size 19822
+oid sha256:a861f7f8cc710e5cf07ea159bd647d8e5974a2736ddab3c955bb202e767423f7
+size 21347

--- a/src/assets/images/punched_paper_left1.png
+++ b/src/assets/images/punched_paper_left1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68eefbbc795065aa5d98f86695fbeda40bd6d9df6b32390adfed20291f62fc0e
+size 19822

--- a/src/assets/sheet-content/toolbox-export.json
+++ b/src/assets/sheet-content/toolbox-export.json
@@ -1,0 +1,57 @@
+{
+    "topics": [
+        {
+            "metadata": {
+                "type": "ONE_ON_ONE_TIME",
+                "languageCode": "en",
+                "name": "One-on-One Time",
+                "buttonColor": "#F7911E"
+            },
+            "contentSections": [
+                {
+                    "elements": [
+                        {
+                            "type": "TEXT",
+                            "text": "When we have difficult relationships with our teenagers, we spend a lot of time disciplining or complaining about them."
+                        },
+                        {
+                            "type": "CORE_TIP",
+                            "text": "One-on-One Time helps build a positive, trusting relationship. When you really show interest in them, you make them feel valued and appreciated."
+                        },
+                        {
+                            "type": "LIST",
+                            "intro": "Here are 6 tips to make One-on-One Time a positive experience for you and your teen:",
+                            "items": [
+                                {
+                                    "heading": "Step 1. Do it every day",
+                                    "body": "Set aside a time each day when you and our teen will not be interrupted and when your teen does not have something else they want to do. Switch off television and phones so you will not be interrupted."
+                                },
+                                {
+                                    "heading": "Step 2. Let your teen choose the activity",
+                                    "body": "Tell your teen that you would like to spend some time with them and that they can choose what to do or talk about. Your teen might think this is weird at first, but will come to enjoy having this dedicated time with you!"
+                                },
+                                {
+                                    "heading": "Step 3. Follow your teen's lead",
+                                    "body": "Remember this is your teen's activity. Accept their suggestions, show interest, and say something nice."
+                                },
+                                {
+                                    "heading": "Step 4. Give your teen all of your attention. ",
+                                    "body": "Look at your teen. Nodding or saying “I see” shows you are really paying attention. Accept what they are saying without judging them."
+                                },
+                                {
+                                    "heading": "Step 5. Show your teen you are really listening",
+                                    "body": "To make them feel supported, you can even try rephrasing what they said: “Yeah, I see that you find that difficult/fun/confusing/exciting.”"
+                                },
+                                {
+                                    "heading": "Step 6. Have fun!",
+                                    "body": "One-on-One Time with your teen can be fun for you, too! It might even make you feel less stressed."
+                                }
+                            ]
+                        }
+                    ],
+                    "title": "One-on-One Time"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This includes changes to allow

- Export of toolbox content from content spreadsheet as a JSON file
- Reading of that JSON file by an Angular service
- App page with list of topics
- App page for each topic
- Unlocking of toolbox topics via Rapid Pro control message

Still needs full unit tests.