### PR TITLE
Store user settings in backend so that user settings can be changed remotely for user testing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -88,7 +88,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "app:build"
+            "browserTarget": "app:build",
+            "proxyConfig": "src/proxy.config.json"
           },
           "configurations": {
             "production": {

--- a/src/app/feature/settings/settings.page.html
+++ b/src/app/feature/settings/settings.page.html
@@ -35,8 +35,8 @@
   <ion-item>
     <ion-label [routerLink]="['/theme-editor']">Theme Editor</ion-label>
   </ion-item>
-  <ion-list-header>Act On Behalf of User</ion-list-header>
-  <ion-select [value]="selectedOboUid" okText="Select" cancelText="Cancel"
+  <ion-list-header *ngIf="usersICanObo?.length > 0">Act On Behalf of User</ion-list-header>
+  <ion-select *ngIf="usersICanObo?.length > 0" [value]="selectedOboUid" okText="Select" cancelText="Cancel"
     (ionChange)="selectOBOUser($event.detail.value)">
     <ion-select-option *ngFor="let user of usersICanObo" [value]="user.uid">
       {{user.displayName}}

--- a/src/app/feature/settings/settings.page.html
+++ b/src/app/feature/settings/settings.page.html
@@ -7,21 +7,11 @@
 <ion-content>
   <ion-item *ngFor="let userSetting of userSettings">
     <ion-label>{{userSetting.name}}</ion-label>
-    <ion-toggle *ngIf="!userSetting.options && userSetting.type === 'boolean'"
-      [checked]="userSetting.value === 'true'"
-      (ionChange)="toggleUserSetting(userSetting)"
-    ></ion-toggle>
-    <ion-select
-      *ngIf="userSetting.options"
-      [value]="userSetting.value"
-      okText="Select"
-      cancelText="Cancel"
-      (ionChange)="selectSettingOption(userSetting, $event.detail.value)"
-    >
-      <ion-select-option
-        *ngFor="let option of userSetting.options"
-        [value]="option.value"
-      >
+    <ion-toggle *ngIf="!userSetting.options && userSetting.type === 'boolean'" [checked]="userSetting.value === 'true'"
+      (ionChange)="toggleUserSetting(userSetting)"></ion-toggle>
+    <ion-select *ngIf="userSetting.options" [value]="userSetting.value" okText="Select" cancelText="Cancel"
+      (ionChange)="selectSettingOption(userSetting, $event.detail.value)">
+      <ion-select-option *ngFor="let option of userSetting.options" [value]="option.value">
         {{option.name}}
       </ion-select-option>
     </ion-select>
@@ -37,18 +27,19 @@
   </ion-item>
   <ion-item>
     <ion-label>Theme</ion-label>
-    <ion-select
-      [value]="currentThemeName"
-      okText="Okay"
-      cancelText="Dismiss"
-      (ionChange)="selectThemeName($event.detail.value)"
-    >
-      <ion-select-option *ngFor="let themeName of themeNames" value="{{themeName}}"
-        >{{themeName}}</ion-select-option
-      >
+    <ion-select [value]="currentThemeName" okText="Okay" cancelText="Dismiss"
+      (ionChange)="selectThemeName($event.detail.value)">
+      <ion-select-option *ngFor="let themeName of themeNames" value="{{themeName}}">{{themeName}}</ion-select-option>
     </ion-select>
   </ion-item>
   <ion-item>
     <ion-label [routerLink]="['/theme-editor']">Theme Editor</ion-label>
   </ion-item>
+  <ion-list-header>Act On Behalf of User</ion-list-header>
+  <ion-select [value]="selectedOboUid" okText="Select" cancelText="Cancel"
+    (ionChange)="selectOBOUser($event.detail.value)">
+    <ion-select-option *ngFor="let user of usersICanObo" [value]="user.uid">
+      {{user.displayName}}
+    </ion-select-option>
+  </ion-select>
 </ion-content>

--- a/src/app/feature/settings/settings.page.ts
+++ b/src/app/feature/settings/settings.page.ts
@@ -21,6 +21,9 @@ export class SettingsPage {
 
   public userSettings: UserSetting[] = [];
 
+  public selectedOboUid: string;
+  public usersICanObo: { displayName: string, uid: string, email: string}[] = [];
+
   constructor(
     private localStorageService: LocalStorageService,
     private router: Router,
@@ -33,6 +36,11 @@ export class SettingsPage {
     this.currentThemeName = this.themeService.getCurrentTheme().name;
     this.settingsService.getAllUserSettings().subscribe((userSettings) => {
       this.userSettings = userSettings.filter((setting) => Capacitor.isNative || !setting.nativeOnly)
+    });
+    this.settingsService.getUsersICanObo().subscribe((users) => {
+      this.usersICanObo = users;
+    }, (err) => {
+      console.log("Could not get On behalf of users ", err);
     });
   }
 
@@ -67,5 +75,10 @@ export class SettingsPage {
     this.dbService.db.delete().then(() => {
       location.reload();
     });
+  }
+
+  selectOBOUser(uid: string) {
+    console.log("Select OBO user ", uid);
+    this.settingsService.setOboUserId(uid);
   }
 }

--- a/src/app/feature/settings/settings.service.ts
+++ b/src/app/feature/settings/settings.service.ts
@@ -1,4 +1,6 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { AngularFireAuth } from '@angular/fire/auth';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { LocalStorageService } from 'src/app/shared/services/local-storage/local-storage.service';
@@ -13,12 +15,24 @@ export class SettingsService {
 
   private userSettings$: BehaviorSubject<UserSetting[]>;
 
-  constructor(private localStorageService: LocalStorageService) {
+  constructor(private localStorageService: LocalStorageService, private http: HttpClient, private afAuth: AngularFireAuth) {
     const lsPopulatedSettings = BASE_USER_SETTINGS.map((setting) => {
       const lsValue = localStorageService.getString(this.lsPrefix + setting.id);
       return { ...setting, value: lsValue === null ? setting.value : lsValue };
     });
     this.userSettings$ = new BehaviorSubject(lsPopulatedSettings);
+    /* Get user settings from server */
+    this.afAuth.idToken.subscribe((firebaseToken) => {
+      this.http.get("/user-api/current-user/settings", {
+        headers: {
+          authorization: "Bearer " + firebaseToken
+        }
+      }).subscribe((serverSettings: UserSetting[]) => {
+        for (let serverSetting of serverSettings) {
+          this.setUserSetting(serverSetting.id, serverSetting.value, false);
+        }
+      });
+    });
   }
 
   getAllUserSettings(): Observable<UserSetting[]> {
@@ -35,7 +49,7 @@ export class SettingsService {
     );
   }
 
-  setUserSetting(id: UserSettingId, value: string) {
+  setUserSetting(id: UserSettingId, value: string, sendToServer = true) {
     this.localStorageService.setString(this.lsPrefix + id, value);
     const settings = this.userSettings$.getValue();
     const updatedSettings = settings.map((setting) => {
@@ -45,5 +59,19 @@ export class SettingsService {
       return setting;
     });
     this.userSettings$.next(updatedSettings);
+    if (sendToServer) {
+      this.afAuth.idToken.subscribe((firebaseToken) => {
+        this.http.post(
+          "/user-api/current-user/settings",
+          this.userSettings$.getValue(),
+          {
+            headers: {
+              authorization: "Bearer " + firebaseToken
+            }
+          }).subscribe((postResult) => {
+            console.log(`Updated user setting ${id} saved on server `, postResult);
+          });
+      });
+    }
   }
 }

--- a/src/proxy.config.json
+++ b/src/proxy.config.json
@@ -1,0 +1,6 @@
+{
+    "/user-api": {
+      "target": "https://plh-demo1.idems.international/",
+      "secure": false
+    }
+}


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

This PR is a proof of concept for using a MongoDB driven backend + Firebase authentication to store user settings.
Backend is messy but reasonably secure here: https://github.com/michaelclapham/firebase-mongo-server
Hosted at https://plh-demo1.idems.international/user-api/

It supports an On Behalf of (OBO) feature where OBO Admins are entitled to act on behalf of any other user who has logged in. This allows them to modify another users settings. This could be used by the user testing team to toggle options in the app between different versions we want to test.

## Screenshots/Videos

Change settings for yourself or for another logged in user.
![image](https://user-images.githubusercontent.com/3285072/100387268-9c570480-301f-11eb-82ac-82f572573ea6.png)
