### PR TITLE
Make home screen buttons fit on shorter screens

### DIFF
--- a/src/app/feature/home/home-buttons/home-buttons.component.scss
+++ b/src/app/feature/home/home-buttons/home-buttons.component.scss
@@ -43,3 +43,17 @@
     background-color: var(--theme-var-myPlansButton, #5652A3);
   }
 }
+
+@media only screen and (max-height: 590px) {
+  .container {
+    padding: 5px;
+  }
+
+  .menu-button {
+    padding: 5px;
+  }
+
+  .menu-button.my-journey {
+    padding: 5px;
+  }
+}

--- a/src/app/feature/home/home.page.html
+++ b/src/app/feature/home/home.page.html
@@ -1,9 +1,4 @@
 <ion-content [fullscreen]="true" [scrollY]="false">
-  <ion-header collapse="condense">
-    <ion-toolbar>
-      <ion-title size="large">Home</ion-title>
-    </ion-toolbar>
-  </ion-header>
   <plh-home-indoor-blobs *ngIf="homeScreenOption === 'indoors-blobs'"></plh-home-indoor-blobs>
   <plh-home-buttons *ngIf="homeScreenOption === 'buttons'"></plh-home-buttons>
 </ion-content>


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Make the home screen buttons have tighter padding when on a device with a short screen (like an iPhone 4).

Also removed Home header from iOS home screen.

