### PR TITLE
Prevent @fields from showing in response options

### DIFF
--- a/src/app/feature/chat/services/offline/chat.flow.ts
+++ b/src/app/feature/chat/services/offline/chat.flow.ts
@@ -263,12 +263,16 @@ export class RapidProOfflineFlow {
     const messages = this.messages$.getValue();
     const text = await this.parseMessageTemplate(action.text);
     let parsedAttachmentUrls = await Promise.all(action.attachments.map(this.parseMessageTemplate));
+    let parsedQuickReplies: string[] = [];
+    if (action.quick_replies && action.quick_replies.length > 0) {
+      parsedQuickReplies = await Promise.all(action.quick_replies.map(this.parseMessageTemplate));
+    }
     const rapidProMessage: IRapidProMessage = {
       message: text,
       message_id: action.uuid,
       title: "",
       type: "rapidpro",
-      quick_replies: JSON.stringify(action.quick_replies ? action.quick_replies : []),
+      quick_replies: JSON.stringify(parsedQuickReplies),
       attachments: parsedAttachmentUrls,
       wasTapped: false,
     };


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Actually parse rapid pro variables in quick responses.
This should prevent seeing things like Talk to @fields.guide in the list of response options.