### PR TITLE
Generate Rapid Pro flow UUIDs deterministically

### DIFF
--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -12,12 +12,28 @@ const flowType: string = "messaging";
 const defaultRevision: number = 0;
 const flowExpireAfterMinutes: number = 60;
 
+type EntityType = "flow" | "node" | "action" | "router" | "case" | "category" | "exit";
+
 export class ConversationParser implements AbstractParser {
-  private generateUUID() {
-    return uuidv4();
+
+  conversationSheet: FlowTypes.ConversationSheet;
+
+  flowEntityIdCounterMap: { [flowName: string]: { [entityType: string]: number } } = {};
+
+  private deterministicUUID(flowName: string, entityType: EntityType) {
+    if (!this.flowEntityIdCounterMap[flowName]) {
+      this.flowEntityIdCounterMap[flowName] = {};
+    }
+    if (!this.flowEntityIdCounterMap[flowName].hasOwnProperty(entityType)) {
+      this.flowEntityIdCounterMap[flowName][entityType] = 0;
+    } else {
+      this.flowEntityIdCounterMap[flowName][entityType]++;
+    }
+    return "uuid_" + flowName + "_" + entityType + "_" + this.flowEntityIdCounterMap[flowName][entityType];
   }
 
   public run(conversation: FlowTypes.ConversationSheet): RapidProFlowExport.RootObject {
+    this.conversationSheet = conversation;
     const rapidProExportObject: RapidProFlowExport.RootObject = {
       campaigns: [],
       fields: [],
@@ -33,7 +49,7 @@ export class ConversationParser implements AbstractParser {
       // TODO Also need to consider case of updating an existing flow.
       let flow: RapidProFlowExport.Flow = {
         name: conversation.flow_name,
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(conversation.flow_name, "flow"),
         // TODO This metadata should possibly be passed in from the "Content list" Excel sheet.
         spec_version: flowSpecVersion,
         language: flowLanguage,
@@ -50,7 +66,7 @@ export class ConversationParser implements AbstractParser {
       const nodesById: { [nodeId: string]: RapidProFlowExport.Node } = {};
       for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
         const row = rows[rowIndex];
-        let nodeId = this.generateUUID();
+        let nodeId = this.deterministicUUID(conversation.flow_name, "node");
         row.nodeUUIDForExit = nodeId;
 
         let actionNode: RapidProFlowExport.Node = {
@@ -91,13 +107,13 @@ export class ConversationParser implements AbstractParser {
             text: action_text,
             type: "send_msg",
             quick_replies: this.getRowChoices(row),
-            uuid: this.generateUUID(),
+            uuid: this.deterministicUUID(conversation.flow_name, "action"),
           });
           row._rapidProNode = actionNode;
           nodesById[nodeId] = actionNode;
           if (row.save_name) {
             let resultNode: RapidProFlowExport.Node = {
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(conversation.flow_name, "node"),
               actions: [],
               exits: [this.createEmptyExit()],
               router: {
@@ -106,7 +122,7 @@ export class ConversationParser implements AbstractParser {
                 cases: [],
                 categories: [
                   {
-                    uuid: this.generateUUID(),
+                    uuid: this.deterministicUUID(conversation.flow_name, "category"),
                     name: "All Responses",
                     exit_uuid: null,
                   },
@@ -124,10 +140,10 @@ export class ConversationParser implements AbstractParser {
             // The initial node exits to the resultNode
             actionNode.exits[0].destination_uuid = resultNode.uuid;
             let saveNode: RapidProFlowExport.Node = {
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(conversation.flow_name, "node"),
               actions: [
                 {
-                  uuid: this.generateUUID(),
+                  uuid: this.deterministicUUID(conversation.flow_name, "action"),
                   type: "set_contact_field",
                   field: {
                     // Can these be the same?
@@ -147,11 +163,10 @@ export class ConversationParser implements AbstractParser {
         } else if (row.type === "start_new_flow") {
           actionNode.actions.push({
             flow: {
-              name: row.message_text,
-              uuid: this.generateUUID(),
+              name: row.message_text
             },
             type: "enter_flow",
-            uuid: this.generateUUID(),
+            uuid: this.deterministicUUID(conversation.flow_name, "action"),
           });
           this.setEnterFlowRouterAndExits(actionNode);
           row._rapidProNode = actionNode;
@@ -167,15 +182,14 @@ export class ConversationParser implements AbstractParser {
           nodesById[nodeId] = actionNode;
           if (row.message_text) {
             let enterFlowNode: RapidProFlowExport.Node = {
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(conversation.flow_name, "node"),
               actions: [
                 {
                   flow: {
-                    name: row.message_text,
-                    uuid: this.generateUUID(),
+                    name: row.message_text
                   },
                   type: "enter_flow",
-                  uuid: this.generateUUID(),
+                  uuid: this.deterministicUUID(conversation.flow_name, "action"),
                 },
               ],
               exits: [this.createEmptyExit()],
@@ -244,35 +258,35 @@ export class ConversationParser implements AbstractParser {
   private setEnterFlowRouterAndExits(node: RapidProFlowExport.Node) {
     let exits: RapidProFlowExport.Exit[] = [
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "exit"),
         destination_uuid: null,
       },
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "exit"),
         destination_uuid: null,
       },
     ];
     let categories: RapidProFlowExport.Category[] = [
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "category"),
         name: "Complete",
         exit_uuid: exits[0].uuid,
       },
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "category"),
         name: "Expired",
         exit_uuid: exits[1].uuid,
       },
     ];
     let cases: RapidProFlowExport.RouterCase[] = [
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "case"),
         type: "has_only_text",
         arguments: ["completed"],
         category_uuid: categories[0].uuid,
       },
       {
-        uuid: this.generateUUID(),
+        uuid: this.deterministicUUID(this.conversationSheet.flow_name, "case"),
         type: "has_only_text",
         arguments: ["expired"],
         category_uuid: categories[1].uuid,
@@ -370,7 +384,7 @@ export class ConversationParser implements AbstractParser {
 
   private createEmptyExit(): RapidProFlowExport.Exit {
     let exit: RapidProFlowExport.Exit = {
-      uuid: this.generateUUID(),
+      uuid: this.deterministicUUID(this.conversationSheet.flow_name, "exit"),
       destination_uuid: null,
     };
     return exit;
@@ -382,12 +396,12 @@ export class ConversationParser implements AbstractParser {
     routerType: "switch" | string = "switch",
     defaultName: string = "All Responses"
   ): RapidProFlowExport.Node {
-    let nodeId = this.generateUUID();
+    let nodeId = this.deterministicUUID(this.conversationSheet.flow_name, "node");
     let emptyExit = this.createEmptyExit();
     let otherCategory = {
       exit_uuid: emptyExit.uuid,
       name: defaultName,
-      uuid: this.generateUUID(),
+      uuid: this.deterministicUUID(this.conversationSheet.flow_name, "category"),
     };
 
     let newRouterNode: RapidProFlowExport.Node = {
@@ -470,7 +484,7 @@ export class ConversationParser implements AbstractParser {
         choiceCategory = {
           exit_uuid: exit.uuid,
           name: row.condition,
-          uuid: this.generateUUID(),
+          uuid: this.deterministicUUID(this.conversationSheet.flow_name, "category"),
         };
         let choiceCases: RapidProFlowExport.RouterCase[] = [];
         // For "has_any_word" arguments is a list of length one with all words separate by spaces.
@@ -481,7 +495,7 @@ export class ConversationParser implements AbstractParser {
               arguments: conds,
               category_uuid: choiceCategory.uuid,
               type,
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(this.conversationSheet.flow_name, "case"),
             },
           ];
           // For phrases need one case per phrase linked to the same category. arguments is a list of length one with the phrase.
@@ -491,7 +505,7 @@ export class ConversationParser implements AbstractParser {
               arguments: [con],
               category_uuid: choiceCategory.uuid,
               type,
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(this.conversationSheet.flow_name, "case"),
             });
           }
         } else {
@@ -502,7 +516,7 @@ export class ConversationParser implements AbstractParser {
               arguments: conds,
               category_uuid: choiceCategory.uuid,
               type,
-              uuid: this.generateUUID(),
+              uuid: this.deterministicUUID(this.conversationSheet.flow_name, "case"),
             },
           ];
         }
@@ -624,7 +638,7 @@ export class ConversationParser implements AbstractParser {
 
   private createSaveAction(fieldName: string, value: string): RapidProFlowExport.Action {
     return {
-      uuid: this.generateUUID(),
+      uuid: this.deterministicUUID(this.conversationSheet.flow_name, "action"),
       type: "set_contact_field",
       field: {
         // Can these be the same?

--- a/src/app/feature/chat/services/offline/rapid-pro-export.model.ts
+++ b/src/app/feature/chat/services/offline/rapid-pro-export.model.ts
@@ -17,7 +17,9 @@ export namespace RapidProFlowExport {
     attachments?: string[];
     field?: { key: string; name: string };
     value?: string;
-    flow?: { uuid: string; name: string };
+    // This used to go to another flow. Rapid Pro uses flow unique id (uuid) to pick which flow to go to
+    // The IDEMS version uses name which we assume to be unique
+    flow?: { uuid?: string; name: string };
     name?: string;
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Generates Rapid Pro flow export UUID's (universally unique identifiers) in a deterministic way.
This means that when the spreadsheet to flowchart code is run on the same sheets the output will not be changed.

The UUID's now follow a format of

```
`uuid_${flowName}_${entityType}_${counter}
```

For example the first node in the flow example_main would have the id
uuid_example_main_node_0