### PR TITLE
WIP: Show text input alert when user is supposed to type in custom response

### DIFF
--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -3,7 +3,7 @@ import { AnimationOptions } from "ngx-lottie";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ChatMessage, ChatResponseOption, ResponseCustomAction, IChatService } from "../models";
 import { Subscription } from "rxjs";
-import { ModalController } from "@ionic/angular";
+import { AlertController, ModalController } from "@ionic/angular";
 import { Capacitor } from "@capacitor/core";
 import { ChatActionService } from "../services/common/chat-action.service";
 import { FlowStatusChange, OfflineChatService } from "../services/offline/offline-chat.service";
@@ -66,7 +66,8 @@ export class ChatPage {
     private settingsService: SettingsService,
     private offlineChatService: OfflineChatService,
     private onlineChatService: OnlineChatService,
-    public modalCtrl: ModalController
+    public modalCtrl: ModalController,
+    public alertController: AlertController
   ) {}
 
   /** Initialise chat configuration on page enter */
@@ -105,6 +106,24 @@ export class ChatPage {
       });
     }
     console.log(`%cUsing ${this.chatService.type} chat `, "color: #9c9c9c");
+  }
+
+  private async showCustomInputAlert() {
+    const alert = await this.alertController.create({
+      header: this.lastReceivedMsg.text,
+      inputs: [
+        {
+          type: "text"
+        }
+      ],
+      buttons: [{
+        text: 'Submit',
+        handler: (value) => {
+          this.sendCustomOption(value[0]);
+        }
+      }]
+    });
+    await alert.present();
   }
 
   /** The chat page can sometimes be displayed in a modal. Check if it is, and assign variable to handle close button display */
@@ -168,6 +187,9 @@ export class ChatPage {
     }
     if (message.sender === "bot") {
       this.responseOptions = message.responseOptions ? message.responseOptions : [];
+      if (message.showTextInput) {
+        this.showCustomInputAlert();
+      }
     } else {
       this.responseOptions = [];
     }

--- a/src/app/feature/chat/models/chat-msg.model.ts
+++ b/src/app/feature/chat/models/chat-msg.model.ts
@@ -18,6 +18,8 @@ export interface ChatMessage {
   responseOptions?: ChatResponseOption[];
   attachments?: ChatAttachment[];
 
+  showTextInput?: boolean;
+
   // Configurable by /chat/msg-info
   isStory?: boolean;
   character?: CharacterId;


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Show alert with text input for user to type their response when a message has no quick replies and the current or next node has a wait for response router.

## Git Issues

_Closes #222

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/3285072/101920587-e6b1b700-3bc3-11eb-98a5-07fe0f271bfd.png)
