### PR TITLE
Don't make short messages large font

### DIFF
--- a/src/app/feature/chat/components/chat.page.html
+++ b/src/app/feature/chat/components/chat.page.html
@@ -49,7 +49,7 @@
           >
           <path d="M15 20V0L0 10L15 20Z" fill="grey" />
           </svg>
-          <div class="msg-bubble" [ngClass]="{'large': msg.text.length < 3}">{{msg.text}}</div>
+          <div class="msg-bubble">{{msg.text}}</div>
           <svg
             *ngIf="msg.sender === 'user'"
             class="user-msg-triangle" 


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Removes code that makes messages that are 2 characters or less a larger font.
This was originally used for Emoji's in the emo check however these have been removed.