### PR TITLE
make routing more consistent

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,12 +9,17 @@ const FeatureRoutes: Routes = [
     pathMatch: "full",
   },
   {
+    path: "home",
+    redirectTo: "module_list",
+    pathMatch: "full",
+  },
+  {
     path: "module_list",
     loadChildren: () =>
       import("./feature/module_list/module-list.module").then((m) => m.ModuleListModule),
   },
   {
-    path: "module_page/:flow_name",
+    path: "module_page",
     loadChildren: () =>
       import("./feature/module_page/module-page.module").then((m) => m.ModulePageModule),
   },
@@ -29,7 +34,7 @@ const FeatureRoutes: Routes = [
   },
 
   {
-    path: "tips/flow/:flow_name",
+    path: "tips",
     loadChildren: () => import("./feature/tips/tips.module").then((m) => m.TipsModule),
   },
   {
@@ -47,6 +52,10 @@ const FeatureRoutes: Routes = [
   {
     path: "chat",
     loadChildren: () => import("./feature/chat/chat.module").then((m) => m.ChatPageModule),
+  },
+  {
+    path: "toolbox/topic/:topicId",
+    loadChildren: () => import("./feature/tips/tips.module").then((m) => m.TipsModule),
   },
 ];
 

--- a/src/app/feature/_deprecated/home/home.page.ts
+++ b/src/app/feature/_deprecated/home/home.page.ts
@@ -22,7 +22,7 @@ export class HomePage implements OnInit {
   ngOnInit(): void {
     if (!this.localStorageService.getBoolean(LocalStorageService.OPENED_APP_BEFORE)) {
       this.localStorageService.setBoolean(LocalStorageService.OPENED_APP_BEFORE, true);
-      this.router.navigateByUrl("/chat/flow/first_app_opening");
+      this.router.navigateByUrl("/conversation/first_app_opening");
     }
   }
 

--- a/src/app/feature/chat/chat-routing.module.ts
+++ b/src/app/feature/chat/chat-routing.module.ts
@@ -2,22 +2,22 @@ import { NgModule } from "@angular/core";
 import { Routes, RouterModule } from "@angular/router";
 import { ChatActionComponent } from "./components/chat-action/chat-action.component";
 import { ChatPage } from "./components/chat.page";
-import { CanDeactivateChat } from './guards/can-deactivate-chat';
+import { CanDeactivateChat } from "./guards/can-deactivate-chat";
 
 const routes: Routes = [
   // default chat page flow
   {
     path: "",
-    redirectTo: "flow/chat_content_flow",
-  },
-  {
-    path: "flow/:flowName",
-    component: ChatPage,
-    canDeactivate: [CanDeactivateChat]
+    redirectTo: "chat_content_flow",
   },
   {
     path: "action/:actionType",
     component: ChatActionComponent,
+  },
+  {
+    path: ":flowName",
+    component: ChatPage,
+    canDeactivate: [CanDeactivateChat],
   },
 ];
 

--- a/src/app/feature/module_page/module-page-routing.module.ts
+++ b/src/app/feature/module_page/module-page-routing.module.ts
@@ -5,7 +5,7 @@ import { ModulePageComponent } from "./module-page";
 
 const routes: Routes = [
   {
-    path: "",
+    path: ":flow_name",
     component: ModulePageComponent,
   },
 ];

--- a/src/app/feature/module_page/module-page.ts
+++ b/src/app/feature/module_page/module-page.ts
@@ -16,7 +16,12 @@ export class ModulePageComponent implements OnInit {
 
   ngOnInit() {
     const { flow_name } = this.route.snapshot.params;
-    this.modulePageFlow = MODULE_PAGE.find((m) => m.flow_name === flow_name);
-    this.dataLoaded = true;
+    const modulePageFlow = MODULE_PAGE.find((m) => m.flow_name === flow_name);
+    if (modulePageFlow) {
+      this.modulePageFlow = modulePageFlow;
+      this.dataLoaded = true;
+    } else {
+      throw new Error(`Module Page Flow Not Found: ${flow_name}`);
+    }
   }
 }

--- a/src/app/feature/tips/tips-routing.module.ts
+++ b/src/app/feature/tips/tips-routing.module.ts
@@ -4,7 +4,7 @@ import { TipsComponent } from "./tips";
 
 const routes: Routes = [
   {
-    path: "",
+    path: ":flow_name",
     component: TipsComponent,
   },
 ];

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -55,7 +55,7 @@
     (onSettingChange)="onSettingChange($event)"
   ></plh-user-setting>
   <ion-item>
-    <ion-button (click)="navigateByUrl('/chat/flow/example_main')">Open Testing Flow</ion-button>
+    <ion-button (click)="navigateByUrl('/chat/example_main')">Open Testing Flow</ion-button>
   </ion-item>
   <ion-item>
     <ion-button (click)="openWelcomeFlow()">Open Welcome Flow</ion-button>

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -56,7 +56,7 @@ export class SettingsPage {
   openWelcomeFlow() {
     this.localStorageService.setBoolean("weclome_skipped", false);
     this.localStorageService.setBoolean("weclome_finished", false);
-    this.router.navigateByUrl("/chat/flow/Welcome_Intro");
+    this.router.navigateByUrl("/chat/Welcome_Intro");
   }
 
   selectThemeName(themeName: string) {
@@ -80,9 +80,9 @@ export class SettingsPage {
   }
 
   launchFlowByName(flowName: string) {
-    this.router.navigateByUrl("/chat/flow/" + flowName);
+    this.router.navigateByUrl("/chat/" + flowName);
   }
   launchTipFlowByName(flowName: string) {
-    this.router.navigateByUrl("/tips/flow/" + flowName);
+    this.router.navigateByUrl("/tips/" + flowName);
   }
 }

--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -92,7 +92,7 @@ export class TaskService {
     if (!flow_name || !flow_type) {
       throw new Error("flow type or name not specified");
     }
-    this.router.navigate([flow_type, "flow", flow_name]);
+    this.router.navigate([flow_type, flow_name]);
   }
 
   private async handleGiveAwardAction(task: FlowTypes.Task_listRow) {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
- Add additional redirect to `home` route to keep legacy functionality
- Make tip and conversation flows appear at `/[tip/conversation]/:flow_name` (without additional /flow) to make more consistent with module list and page routing, and make more obvious for authors

## TODO
Before this is merged, we should:
- check content team are happy with the proposed changes to URL structures and happy to update existing flows
- check scripts still identify invalid routes in task actions
- create an issue to automate process for checking valid routes in conversations parser (exit links)
- update chat service to support relative routes in spreadsheets (e.g. defined as `tips/my_tips` in the sheet, and retaining the same path during conversation parser for an app build, but appending web URL for rapidpro build (as mentioned in #216))

@michaelclapham - good to get your thoughts on this and the above todos

## Git Issues

_Closes #235_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
