### PR TITLE
Fix scrolling when chat messages have attachments

### DIFF
--- a/src/app/feature/chat/components/chat.page.html
+++ b/src/app/feature/chat/components/chat.page.html
@@ -64,7 +64,7 @@
       <ng-lottie *ngIf="botTyping" class="typing-anim" [options]="typingAnimOptions"></ng-lottie>
     </div>
     <div #normalChatEnd></div>
-    <div style="display: block; height: 100px"></div>
+    <div style="display: block; height: 50px"></div>
   </div>
   <plh-chat-responses
     *ngIf="lastReceivedMsg"

--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -201,9 +201,13 @@ export class ChatPage {
     } else {
       this.responseOptions = [];
     }
+    let scrollDelay = 100;
+    if (message.attachments && message.attachments.length > 0 || message.innerImageUrl) {
+      scrollDelay = 800;
+    }
     setTimeout(() => {
       this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
-    }, 50);
+    }, scrollDelay);
     this.cd.detectChanges();
   }
 

--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -203,14 +203,11 @@ export class ChatPage {
     }
     let scrollDelay = 100;
     if (message.attachments && message.attachments.length > 0 || message.innerImageUrl) {
-      scrollDelay = 800;
+      scrollDelay = 1000;
     }
     setTimeout(() => {
       this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
     }, scrollDelay);
-    setTimeout(() => {
-      this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
-    }, 2000);
     this.cd.detectChanges();
   }
 

--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -208,6 +208,9 @@ export class ChatPage {
     setTimeout(() => {
       this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
     }, scrollDelay);
+    setTimeout(() => {
+      this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
+    }, 2000);
     this.cd.detectChanges();
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

When a message has an image in it, wait slightly longer before scrolling to bottom of messages.
This is because images take 250 - 500ms to show up and create enough height for scrolling to the bottom work correctly.

## Git Issues

_Closes #160