### PR TITLE
Fix end of flow errors

### DIFF
--- a/src/app/feature/chat/services/offline/offline-chat.service.ts
+++ b/src/app/feature/chat/services/offline/offline-chat.service.ts
@@ -70,6 +70,7 @@ export class OfflineChatService implements IChatService {
   public startFlowByName(flowName: string) {
     this.messages$ = new BehaviorSubject([]);
     const flow = this.rpFlowsByName[flowName];
+    this.flowsStack = [];
     if (flow) {
       const { name, uuid } = flow;
       const status: FlowStatusChange = { name, uuid, status: "start" };


### PR DESCRIPTION
- Deal with flow end from router node
- Clear flows stack when starting new flow
- Fix flow continuation

PR Checklist

- [x] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Fixes exceptions happenning when a flow should have eneded but didn't, causing it to try to enter a null node.

## Git Issues

_Closes #159