### PR TITLE
<icon> in message text becomes inline image

### DIFF
--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -122,9 +122,18 @@ export class ConversationParser implements AbstractParser {
           if (hasMediaUrls) {
             add_texts.push("choiceMediaUrls=" + encodeURIComponent(JSON.stringify(choiceMediaUrls)));
           }
+
+          // Allow use of <icon> to place media image inline with message text
+          let mediaAttachments = this.getMediaAttachments(row.media);
+          if (mediaAttachments.length > 0 && action_text.indexOf("<icon>") > -1) {
+            const imageUrl = "assets/plh_assets/" + mediaAttachments[0].replace("image:", "");
+            action_text = action_text.replace("<icon>", `<img class="inline-img" src="${imageUrl}">`);
+            mediaAttachments = [];
+          }
+          
           if (add_texts.length > 0) action_text += " " + link_text + add_texts.join("&");
           actionNode.actions.push({
-            attachments: this.getMediaAttachments(row.media),
+            attachments: mediaAttachments,
             text: action_text,
             type: "send_msg",
             quick_replies: this.getRowChoices(row),

--- a/src/app/feature/chat/components/chat.page.html
+++ b/src/app/feature/chat/components/chat.page.html
@@ -38,7 +38,7 @@
           <path d="M15 20V0L0 10L15 20Z" fill="grey" />
           </svg>
           <div class="msg-bubble">
-            <div *ngIf="!msg.hideText">{{msg.text}}</div>
+            <div *ngIf="!msg.hideText" [innerHTML]="msg.text"></div>
             <img *ngIf="msg.innerImageUrl" [src]="msg.innerImageUrl">
           </div>
           <svg


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

<icon> In message text becomes inline image using media column image. 
This removes the media image from the normal list of attachments that appear below a message.

## Git Issues

_Closes #_

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/3285072/103779538-cdb5ed80-502b-11eb-92aa-c636ef9fdc83.png)

