### PR TITLE
<story-img> to place block image in msg bubble

### DIFF
--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -123,8 +123,10 @@ export class ConversationParser implements AbstractParser {
             add_texts.push("choiceMediaUrls=" + encodeURIComponent(JSON.stringify(choiceMediaUrls)));
           }
 
-          if (row.type === "story_message" || row.message_text.indexOf("<story-img>") > -1) {
+          let isStory = false;
+          if (row.type === "story_message" || row.message_text.indexOf("<story-image>") > -1) {
             add_texts.push("isStory=true");
+            isStory = true;
           }
 
           let mediaAttachments = this.getMediaAttachments(row.media);
@@ -148,6 +150,13 @@ export class ConversationParser implements AbstractParser {
                 break;
               }
             }
+          }
+
+          if (isStory) {
+            action_text = action_text
+              .split("\n")
+              .map((line) => "<p>" + line + "</p>")
+              .join("\n");
           }
 
           if (add_texts.length > 0) action_text += " " + link_text + add_texts.join("&");

--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -135,7 +135,7 @@ export class ConversationParser implements AbstractParser {
           // to place media image wihin message text
           if (mediaAttachments.length > 0 && action_text) {
             let imageTagToClass = {
-              "<icon>": "icon-image",
+              "<icon>": "icon",
               "<story-image>": "story-image",
               "<inline-image>": "inline-image",
               "<block-image>": "block-image"

--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -135,7 +135,7 @@ export class ConversationParser implements AbstractParser {
           // to place media image wihin message text
           if (mediaAttachments.length > 0 && action_text) {
             let imageTagToClass = {
-              "<icon>": "inline-image",
+              "<icon>": "icon-image",
               "<story-image>": "story-image",
               "<inline-image>": "inline-image",
               "<block-image>": "block-image"

--- a/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
+++ b/scripts/src/plh-data-convert/parsers/conversation/conversation.parser.ts
@@ -99,7 +99,7 @@ export class ConversationParser implements AbstractParser {
           let link_text = "https://plh-demo1.idems.international/chat/msg-info?";
           let add_texts: string[] = [];
           let attachmentUrls: string[] = [];
-          if (row.type === "story_message") add_texts.push("isStory=true");
+
           if (row.character) add_texts.push("character=" + row.character);
           if (row.choose_multi) add_texts.push("chooseMulti=true");
           if (row.display_as_tick) add_texts.push("displayAsTick=true");
@@ -123,14 +123,33 @@ export class ConversationParser implements AbstractParser {
             add_texts.push("choiceMediaUrls=" + encodeURIComponent(JSON.stringify(choiceMediaUrls)));
           }
 
-          // Allow use of <icon> to place media image inline with message text
-          let mediaAttachments = this.getMediaAttachments(row.media);
-          if (mediaAttachments.length > 0 && action_text.indexOf("<icon>") > -1) {
-            const imageUrl = "assets/plh_assets/" + mediaAttachments[0].replace("image:", "");
-            action_text = action_text.replace("<icon>", `<img class="inline-img" src="${imageUrl}">`);
-            mediaAttachments = [];
+          if (row.type === "story_message" || row.message_text.indexOf("<story-img>") > -1) {
+            add_texts.push("isStory=true");
           }
-          
+
+          let mediaAttachments = this.getMediaAttachments(row.media);
+        
+          // Allow use of <icon>, <story-img>, or <inline-img> or <block-img>
+          // to place media image wihin message text
+          if (mediaAttachments.length > 0 && action_text) {
+            let imageTagToClass = {
+              "<icon>": "inline-image",
+              "<story-image>": "story-image",
+              "<inline-image>": "inline-image",
+              "<block-image>": "block-image"
+            };
+            const imageTags = Object.keys(imageTagToClass);
+            for (let imageTag of imageTags) {
+              if (action_text.indexOf(imageTag) > -1 && mediaAttachments[0]) {
+                const imageUrl = "assets/plh_assets/" + mediaAttachments[0].replace("image:", "");
+                const className = imageTagToClass[imageTag];
+                action_text = action_text.replace(imageTag, `<img class="${className}" src="${imageUrl}">`);
+                mediaAttachments = [];
+                break;
+              }
+            }
+          }
+
           if (add_texts.length > 0) action_text += " " + link_text + add_texts.join("&");
           actionNode.actions.push({
             attachments: mediaAttachments,

--- a/src/app/feature/chat/components/chat.page.html
+++ b/src/app/feature/chat/components/chat.page.html
@@ -75,12 +75,7 @@
   <!-- <ion-button *ngIf="showFlowSkip" class="skip-button" (click)="skipFlow()">Skip</ion-button> -->
 </div>
 <div *ngIf="lastReceivedMsg?.isStory" class="story-chat">
-  <h1>{{lastReceivedMsg.text}}</h1>
-  <img
-    class="story-image"
-    *ngIf="lastReceivedMsg?.attachments[0]?.type === 'image'"
-    [src]="lastReceivedMsg?.attachments[0].url"
-  />
+  <div class="story-msg-text" [innerHTML]="lastReceivedMsg.text"></div>
   <div class="response-options">
     <div *ngFor="let option of responseOptions" class="response-option">
       <div *ngIf="option.text.toLowerCase() === 'previous'" (click)="onStoryPreviousClicked()">

--- a/src/app/feature/chat/components/chat.page.scss
+++ b/src/app/feature/chat/components/chat.page.scss
@@ -29,6 +29,12 @@
   display: block;
 }
 
+.story-msg-text {
+  p {
+    text-align: center;
+  }
+}
+
 .story-chat {
   flex-grow: 1;
   overflow-y: auto;

--- a/src/app/feature/chat/components/chat.page.scss
+++ b/src/app/feature/chat/components/chat.page.scss
@@ -20,6 +20,15 @@
   overflow-y: auto;
 }
 
+.story-image {
+  border-radius: 30px;
+  width: 80%;
+  max-height: 300px;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}
+
 .story-chat {
   flex-grow: 1;
   overflow-y: auto;
@@ -29,15 +38,6 @@
   animation-iteration-count: 1;
   animation-timing-function: ease-in;
   animation-duration: 1s;
-
-  .story-image {
-    border-radius: 30px;
-    width: 80%;
-    max-width: 300px;
-    margin-left: auto;
-    margin-right: auto;
-    display: block;
-  }
 
   h1 {
     margin: 30px;

--- a/src/app/feature/chat/components/chat.page.scss
+++ b/src/app/feature/chat/components/chat.page.scss
@@ -136,8 +136,13 @@
       max-height: 30px;
     }
 
-    .icon-image {
+    .icon {
       max-height: 30px;
+    }
+
+    .block-image {
+      display: block;
+      max-height: 100px;
     }
 
     &.large {

--- a/src/app/feature/chat/components/chat.page.scss
+++ b/src/app/feature/chat/components/chat.page.scss
@@ -132,6 +132,14 @@
       height: 100px;
     }
 
+    .inline-image {
+      max-height: 30px;
+    }
+
+    .icon-image {
+      max-height: 30px;
+    }
+
     &.large {
       font-size: 40px;
     }

--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectorRef, Input, ViewChild, ElementRef } from "@angular/core";
+import { Component, ChangeDetectorRef, Input, ViewChild, ElementRef, ViewEncapsulation } from "@angular/core";
 import { AnimationOptions } from "ngx-lottie";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ChatMessage, ChatResponseOption, ResponseCustomAction, IChatService } from "../models";
@@ -15,6 +15,7 @@ import { ContactFieldService } from "../services/offline/contact-field.service";
   selector: "app-chat",
   templateUrl: "./chat.page.html",
   styleUrls: ["./chat.page.scss"],
+  encapsulation: ViewEncapsulation.None
 })
 export class ChatPage {
   messages: ChatMessage[] = [];
@@ -45,7 +46,7 @@ export class ChatPage {
   character: "guide" | "egg" = "guide";
   messageSubscription: Subscription;
   chatViewType: "normal" | "story" = "normal";
-  chatService: IChatService;
+  chatService: OfflineChatService;
   isModal: boolean;
   latestFlowEvent: FlowStatusChange;
   showFlowName: boolean = false;
@@ -92,7 +93,7 @@ export class ChatPage {
       // 2020-11-25 - Online chat disabled here and in settings until tested working
       // const useOfflineChat = await this.settingsService.getUserSetting("USE_OFFLINE_CHAT").toPromise();
       const useOfflineChat = true;
-      this.chatService = useOfflineChat ? this.offlineChatService : this.onlineChatService;
+      this.chatService = useOfflineChat ? this.offlineChatService : this.onlineChatService as any;
     }
     this.offlineChatService.botTyping$.subscribe((botTyping) => {
       this.botTyping = botTyping;
@@ -207,9 +208,11 @@ export class ChatPage {
     if ((message.attachments && message.attachments.length > 0) || message.innerImageUrl) {
       scrollDelay = 1000;
     }
-    setTimeout(() => {
-      this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
-    }, scrollDelay);
+    if (this.chatEndDiv) {
+      setTimeout(() => {
+        this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
+      }, scrollDelay);
+    }
     this.cd.detectChanges();
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Use <story-image> in message text to allow story mode to have text above and below image.

Should be working after running `npm run sync-plh-content`

Demo by visiting /chat/example_story1

Example spreadsheet here: https://docs.google.com/spreadsheets/d/1xhM6ed9kyiy6vT-bZzLSASu1TBh-KdqRWBbiO7g1rBQ/edit#gid=2080729684

## Git Issues

_Closes #242

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/3285072/104253623-e16ab500-546c-11eb-81cb-5aec88e409b5.png)

