### PR TITLE
Story image and transition bug fixes

### DIFF
--- a/src/app/feature/chat/components/chat.page.scss
+++ b/src/app/feature/chat/components/chat.page.scss
@@ -50,7 +50,6 @@
 
   .block-image {
     border-radius: 30px;
-    width: 80%;
     max-height: 300px;
     margin-left: auto;
     margin-right: auto;

--- a/src/app/feature/chat/components/chat.page.ts
+++ b/src/app/feature/chat/components/chat.page.ts
@@ -71,7 +71,7 @@ export class ChatPage {
     public modalCtrl: ModalController,
     public alertController: AlertController,
     private contactFieldService: ContactFieldService
-  ) {}
+  ) { }
 
   /** Initialise chat configuration on page enter */
   ionViewDidEnter() {
@@ -208,11 +208,11 @@ export class ChatPage {
     if ((message.attachments && message.attachments.length > 0) || message.innerImageUrl) {
       scrollDelay = 1000;
     }
-    if (this.chatEndDiv) {
-      setTimeout(() => {
+    setTimeout(() => {
+      if (this.chatEndDiv) {
         this.chatEndDiv.nativeElement.scrollIntoView({ behavior: "smooth", block: "end" });
-      }, scrollDelay);
-    }
+      }
+    }, scrollDelay);
     this.cd.detectChanges();
   }
 

--- a/src/app/feature/chat/services/offline/offline-chat.service.ts
+++ b/src/app/feature/chat/services/offline/offline-chat.service.ts
@@ -105,10 +105,7 @@ export class OfflineChatService implements IChatService {
     this.flowStatus$.subscribe((events) => {
       try {
         console.log("Flow status change", events);
-        if (events.length 
-          
-          
-          > 0) {
+        if (events.length > 0) {
           console.log("Flow stacks before event:", this.flowsStack.length);
           let latest = events[events.length - 1];
           console.log("latest status:", latest.status);
@@ -133,7 +130,7 @@ export class OfflineChatService implements IChatService {
           if (latest.status === "completed") {
             this.chatActions.logActionToDB({ flow_name: flow.name, type: "completed" });
             // remove the completed flow from the stack
-            this.flowsStack.pop();
+            this.flowsStack = this.flowsStack.filter((f) => f.name != flow.name);
             // Check if there are any other flows remaining,
             // if yes resume them
             if (this.flowsStack.length > 0) {


### PR DESCRIPTION
- Fix white border on sides of story images
- Fix using type=exit to transition to next flow

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes story image margin causing white edges.

Fixes using exit spreadsheet row type to transition to next flow. This was failing due to the previous flow end not having a subflow router. 
As a result instead of removing the finished flow from the flow stack, the flow that was just meant to start is removed, 
then the finished flow is removed resulting in no flows running.
The fix is when a flow is completed the flow stack removes that flow by name (instead of just the flow at the top of the stack).

## Git Issues

_Closes #301 #302
