### PR TITLE
Support @fields in templates

### DIFF
--- a/src/app/feature/chat/services/offline/contact-field.service.ts
+++ b/src/app/feature/chat/services/offline/contact-field.service.ts
@@ -13,6 +13,7 @@ export class ContactFieldService {
   }
 
   async setDefaultValues() {
+    this.setContactField("group_name", "Church Group");
     for (var flowName of environment.variableNameFlows) {
       const flow = conversation
         .map((rpExport) => rpExport.flows[0])
@@ -30,6 +31,10 @@ export class ContactFieldService {
   }
 
   async getContactField(key: string): Promise<string> {
+    return this.localStorageService.getString("rp-contact-field." + key);
+  }
+
+  getContactFieldSync(key: string): string {
     return this.localStorageService.getString("rp-contact-field." + key);
   }
 

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from "@angular/core";
 import { takeWhile } from "rxjs/operators";
 import { BehaviorSubject } from "scripts/node_modules/rxjs";
+import { ContactFieldService } from "src/app/feature/chat/services/offline/contact-field.service";
 import { TEMPLATE } from "../../services/data/data.service";
 import { FlowTypes, ITemplateContainerProps } from "./models";
 
@@ -40,6 +41,10 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
   debugMode = false;
   private actionsQueue: FlowTypes.TemplateRowAction[] = [];
   private actionsQueueProcessing$ = new BehaviorSubject<boolean>(false);
+
+  constructor(private contactFieldService: ContactFieldService) {
+
+  }
 
   ngOnInit() {
     this.initialiseTemplate();
@@ -243,8 +248,9 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
         case "local":
           parsedValue = this.localVariables[fieldName]?.value || "";
           break;
-        // case 'fields':
-        // TODO
+        case 'fields':
+          parsedValue = this.contactFieldService.getContactFieldSync(fieldName);
+          break;
         default:
           console.error("No evaluator for dynamic field:", evaluator.matchedExpression);
           parsedValue = evaluator.matchedExpression;


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Replace @fields.var_name in templates using the contact field service used for chatbot implementation.

Work in progress as we need to support a way of populating these values from content code.