### PR TITLE
Fix value on begin_nested_properties not setting

### DIFF
--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -160,7 +160,7 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
       let { name, value, rows, type } = r;
       // TODO - set_variable / set_nested_properties should have consistent naming
       // set_variable is actually setting the _value field, so should be called accordingly
-      if (type === "set_variable") {
+      if (type === "set_variable" || type === "nested_properties") {
         variables[name] = variables[name] || {};
         // handle merging updated properties
         VARIABLE_FIELDS.forEach((field) => {


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

This issue was the value on the begin_nested_properties row was not being set.
The values inside were being set but not the value on the begin_nested_properties.

This was causing the content_box in workshop_activity to show undefined template not found.

In this example video_help variable on the context box was set, but the context_box variable on the workshop_activity template was not being set.
![image](https://user-images.githubusercontent.com/3285072/110978012-c1674d00-835a-11eb-96cf-a5940588569e.png)
