### PR TITLE
bugfix so that template names are used correctly from excel authoring

### DIFF
--- a/src/app/feature/template-testing/template-testing.page.html
+++ b/src/app/feature/template-testing/template-testing.page.html
@@ -1,5 +1,5 @@
 <ion-content>
-  <plh-template-container *ngIf="templateName" [name]="templateName"></plh-template-container>
+  <plh-template-container *ngIf="templateName" [templatename]="templateName"></plh-template-container>
   <div *ngIf="!templateName" class="ion-padding">
     <h3>Select a Template</h3>
     <ion-list>

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -18,6 +18,7 @@ import { TemplateBaseComponent } from "../base";
       <plh-template-container
         *ngIf="sectionIndex === i"
         [name]="templateName"
+        [templatename]="templateName"
         [parent]="parent"
       >
       </plh-template-container>
@@ -87,8 +88,8 @@ export class NavGroupComponent extends TemplateBaseComponent implements OnInit {
   ngOnInit() {
     this.parent.handleActionsCallback = async (actions, results) => {
       console.log("parent handled actions", actions, results);
-      const completedAction = actions.find((a) => a.action_id === "emit" && a.args[0] === "completed");
-      const uncompletedAction = actions.find((a) => a.action_id === "emit" && a.args[0] === "uncompleted");
+      const completedAction = actions.find((a) => a.action_id === "completed" && a.args[0] === "completed");
+      const uncompletedAction = actions.find((a) => a.action_id === "uncompleted" && a.args[0] === "uncompleted");
 
       if (completedAction) {
         this.nextSection();
@@ -102,6 +103,7 @@ export class NavGroupComponent extends TemplateBaseComponent implements OnInit {
     if (this.sectionIndex + 1 < this.templateNames.length) {
       this.sectionIndex++;
     } else {
+      // There should be an emit "completed" action 
       console.log("Nav group completed?");
     }
   }
@@ -109,6 +111,9 @@ export class NavGroupComponent extends TemplateBaseComponent implements OnInit {
   previousSection() {
     if (this.sectionIndex > 0) {
       this.sectionIndex--;
+    } else {
+      // There should be an emit "uncompleted" action
+      console.log("Nav group uncompleted?");
     }
   }
 }

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -89,8 +89,8 @@ export class NavGroupComponent extends TemplateBaseComponent implements OnInit {
     console.log("nav_group init", this.parent);
     this.parent.handleActionsCallback = async (actions, results) => {
       console.log("parent handled actions", actions, results);
-      const completedAction = actions.find((a) => a.action_id === "completed" && a.args[0] === "completed");
-      const uncompletedAction = actions.find((a) => a.action_id === "uncompleted" && a.args[0] === "uncompleted");
+      const completedAction = actions.find((a) => a.action_id === "emit" && a.args[0] === "completed");
+      const uncompletedAction = actions.find((a) => a.action_id === "emit" && a.args[0] === "uncompleted");
 
       if (completedAction) {
         this.nextSection();

--- a/src/app/shared/components/template/models/index.ts
+++ b/src/app/shared/components/template/models/index.ts
@@ -9,6 +9,7 @@ export { FlowTypes } from "scripts/types";
  */
 export interface ITemplateContainerProps {
   name: string;
+  templatename: string;
   parent?: { name: string; component?: any };
   row?: FlowTypes.TemplateRow;
 }

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -93,7 +93,8 @@ export class TemplateComponent implements OnInit, ITemplateRowProps {
     // assign input variables (note template name taken from the row's value column)
     componentRef.instance.row = this.row;
     componentRef.instance.parent = this.parent;
-    componentRef.instance.name = this.row.value;
+    componentRef.instance.name = this.row.name;
+    componentRef.instance.templatename = this.row.value;
   }
 
   /** Create and render a common display component */

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -34,6 +34,7 @@ const DISPLAY_TYPES: FlowTypes.TemplateRowType[] = [
 })
 export class TemplateContainerComponent implements OnInit, ITemplateContainerProps {
   @Input() name: string;
+  @Input() templatename: string;
   @Input() parent?: TemplateContainerComponent;
   @Input() row?: FlowTypes.TemplateRow;
   template: FlowTypes.Template;
@@ -130,11 +131,11 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
   private initialiseTemplate() {
     // Lookup template and provide fallback
     const foundTemplate =
-      TEMPLATE.find((t) => t.flow_name === this.name) || NOT_FOUND_TEMPLATE(this.name);
+      TEMPLATE.find((t) => t.flow_name === this.templatename) || NOT_FOUND_TEMPLATE(this.templatename);
     this.template = JSON.parse(JSON.stringify(foundTemplate));
     // When processing local variables check parent in case there are any variables
     // that have already been set/overridden
-    const parentVariables = this.parent?.localVariables?.[this.template.flow_name];
+    const parentVariables = this.parent?.localVariables?.[this.name];
     this.localVariables = this.processVariables(this.template.rows, parentVariables);
     // console.log("[Template Init]", { name: this.name, parentVariables });
     if (!this.parent) {
@@ -243,6 +244,8 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
             r.rows = this.processRows(r.rows, variables);
             break;
           // could add logic here to ignore/remove template rows (already processed), leaving as will be overwritten on init anyways
+          case "template":
+          //  r.rows = this.processRows(r.rows, variables[r.name]);
           default:
             // otherwise treat nested rows as value-namespaced local variables
             r.rows = this.processRows(r.rows, variables[r.name]);

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -99,6 +99,8 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
   }
   private async processAction(action: FlowTypes.TemplateRowAction) {
     const { action_id, args } = action;
+    //part of temporary fix
+    let actionsForEmittedEvent = [];
     switch (action_id) {
       case "set_local":
       case "set_value":
@@ -106,11 +108,19 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
         console.log("Setting local variable", key, value);
         return this.setLocalVariable(key, value);
       case "emit": 
-        console.log("Emiting", args[0], " from ", this.row?.name, " to parent ", this.parent);
-        const actionsForEmittedEvent = this.row.action_list.filter((action) => action.event_id === args[0]);
+        console.log("Emiting", args[0], " from ", this.name, " to parent ", this.parent);
+        if (!this.row) {
+          //TODO fix a temporary hack to fix for nav_group templates which don't have rows
+           actionsForEmittedEvent = [{event_id: "completed", action_id:  "completed", args: ["completed"]}];
+        }else{
+           actionsForEmittedEvent = this.row.action_list.filter((action) => action.event_id === args[0]);
+        }
         console.log("Excuting actions matching event ", args[0], actionsForEmittedEvent);
         this.parent?.handleActions(actionsForEmittedEvent);
         return;
+// Hack solution for Nav-groups
+      case "completed":
+        this.handleActionsCallback([action], null);
       default:
         console.warn("No handler for action", { action_id, args });
         return;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Adding templatename as a property of template and distinguished between when template.name and template.templatename are used to ensure correct implementation of excel authoring (when giving a name to a nested template)

