### PR TITLE
Implement global variables

### DIFF
--- a/src/app/shared/components/template/services/template.service.spec.ts
+++ b/src/app/shared/components/template/services/template.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { LocalStorageService } from 'src/app/shared/services/local-storage/local-storage.service';
+import { TemplateService } from 'src/app/shared/services/template/template.service';
+
+fdescribe('TemplateService', () => {
+  let service: TemplateService;
+
+  let mockLocalStorageService: LocalStorageService = jasmine.createSpyObj("LocalStorageService", ["setString", "getString"]);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: LocalStorageService, useValue: mockLocalStorageService }
+      ]
+    });
+    service = TestBed.inject(TemplateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should use local storage to set template global variables', () => {
+    service.setGlobal("test_name", "test_value");
+    expect(mockLocalStorageService).toHaveBeenCalledOnceWith("template_global.test_name", "test_value");
+  });
+
+  it('should use local storage to get template global variables', () => {
+    spyOn(mockLocalStorageService, "getString").and.returnValue("mock_result");
+    const result = service.getGlobal("test_name");
+    expect(result).toEqual("mock_result");
+    expect(mockLocalStorageService).toHaveBeenCalledOnceWith("template_global.test_name");
+  });
+});

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -1,13 +1,35 @@
-import { Injectable } from "@angular/core";
+import { Injectable } from '@angular/core';
+import { TEMPLATE } from 'src/app/shared/services/data/data.service';
+import { LocalStorageService } from 'src/app/shared/services/local-storage/local-storage.service';
 
-@Injectable({ providedIn: "root" })
-/**
- * Note - currently this service is not required as just holds legacy code
- * (which may be useful in the future)
- */
+@Injectable({
+  providedIn: 'root'
+})
 export class TemplateService {
-  constructor() {}
+
+  constructor(private localStorageService: LocalStorageService) {
+    this.initialiseGlobals();
+  }
+
+  initialiseGlobals() {
+    TEMPLATE.forEach((template) => {
+      template.rows?.forEach((row) => {
+        if (row.type === "set_global") {
+          this.setGlobal(row.name, row.value);
+        }
+      });
+    });
+  }
+
+  getGlobal(key: string): string {
+    return this.localStorageService.getString("template_global." + key);
+  }
+
+  setGlobal(key: string, value: string) {
+    this.localStorageService.setString("template_global." + key, value);
+  }
 }
+
 
 // if (this.row) {
 //   if (typeof this.row.hidden === "string") {

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from "scripts/node_modules/rxjs";
 import { ContactFieldService } from "src/app/feature/chat/services/offline/contact-field.service";
 import { TEMPLATE } from "../../services/data/data.service";
 import { FlowTypes, ITemplateContainerProps } from "./models";
+import { TemplateService } from "./services/template.service";
 
 type ILocalVariables = { [name: string]: any };
 
@@ -46,7 +47,7 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
 
   showTemplates = false;
 
-  constructor(private contactFieldService: ContactFieldService) {
+  constructor(private contactFieldService: ContactFieldService, private templateService: TemplateService) {
     if (location.href.indexOf("showTemplates=true") > -1) {
       this.showTemplates = true;
     }
@@ -104,12 +105,15 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
     const { action_id, args } = action;
     //part of temporary fix
     let actionsForEmittedEvent = [];
+    const [key, value] = args;
     switch (action_id) {
       case "set_local":
       case "set_value":
-        const [key, value] = args;
         console.log("Setting local variable", key, value);
         return this.setLocalVariable(key, value);
+      case "set_global":
+        console.log("Setting global variable", key, value);
+        return this.templateService.setGlobal(key, value);
       case "emit":
         // TODO - handle DB writes or similar for emit handling
         if (this.parent) {
@@ -287,6 +291,9 @@ export class TemplateContainerComponent implements OnInit, ITemplateContainerPro
         case "fields":
           parsedValue = this.contactFieldService.getContactFieldSync(fieldName);
           break;
+        case "global":
+            parsedValue = this.templateService.getGlobal(fieldName);
+            break;
         default:
           console.error("No evaluator for dynamic field:", evaluator.matchedExpression);
           parsedValue = evaluator.matchedExpression;

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -370,7 +370,7 @@ export namespace FlowTypes {
   export interface TemplateRowDynamicEvaluator {
     fullExpression: string;
     matchedExpression: string;
-    type: "local" | "fields";
+    type: "local" | "fields" | "global";
     fieldName: string;
   }
   export interface TemplateRowAction {

--- a/src/app/shared/services/template/template.service.ts
+++ b/src/app/shared/services/template/template.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { TEMPLATE } from '../data/data.service';
+import { LocalStorageService } from '../local-storage/local-storage.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TemplateService {
+
+  constructor(private localStorageService: LocalStorageService) {
+    this.initialiseGlobals();
+  }
+
+  initialiseGlobals() {
+    TEMPLATE.forEach((template) => {
+      template.rows?.forEach((row) => {
+        if (row.type === "set_global") {
+          this.setGlobal(row.name, row.value);
+        }
+      });
+    });
+  }
+
+  getGlobal(key: string): string {
+    return this.localStorageService.getString("template_global." + key);
+  }
+
+  setGlobal(key: string, value: string) {
+    this.localStorageService.setString("template_global." + key, value);
+  }
+}

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -1616,6 +1616,11 @@
         "type": "set_global",
         "name": "debug_variable_1",
         "value": "Value of the first debug variable"
+      },
+      {
+        "type": "text",
+        "name": "text_1",
+        "value": "Global value is @global.debug_variable_1"
       }
     ],
     "_xlsxPath": "plh_sheets_beta\\plh_templating\\debug_templates\\debug_small_issues.xlsx"


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Goes through all template sheets and any rows with set_global are saved to local storage on viewing of first template.

@global.global_var_name in text is implemented as demonstrated in /template/debug_set_global_1

Action set_global should also work but still being tested.

## Git Issues

_Closes #360