### PR TITLE
Go_to actions (template nav)

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from "@angular/core";
+import { FlowTypes } from "scripts/types";
+import { TemplateContainerComponent } from "../template-container.component";
+
+@Injectable({
+  providedIn: "root",
+})
+/**
+ *
+ * Note - currently this does not need to be provided as a service as containers typically still provide their own
+ * references when calling functions (as a global service would have incorrect references for route and routers)
+ */
+export class TemplateNavService {
+  public handleGoToAction(
+    action: FlowTypes.TemplateRowAction,
+    templateContainer: TemplateContainerComponent
+  ) {
+    const { router, name } = templateContainer;
+    const [templatename] = action.args;
+    const nav_parent_triggered_by = action._triggeredBy;
+    const queryParams: INavQueryParams = { nav_parent: name, nav_parent_triggered_by };
+    return router.navigate(["template", templatename], {
+      queryParams,
+      queryParamsHandling: "merge",
+    });
+  }
+
+  /**
+   * Sometimes we navigate from one template to another and lose hiearchy from the stack of rendered templates
+   * Query parameters are therefore used to track if one template has been navigated to from another, and any
+   * particular actions to carry out on the original template following return
+   * @param nav_child_emit given by query parameters, completed/uncompleted emitted from child
+   */
+  public async handleActionsFromParent(
+    params: INavQueryParams,
+    templateContainer: TemplateContainerComponent
+  ) {
+    const { nav_child_emit, nav_parent_triggered_by, nav_child } = params;
+    // only process nav events for parent if a nav_child has been set
+    if (nav_child) {
+      const { router, template } = templateContainer;
+      // remove query param
+      const queryParams: INavQueryParams = {
+        nav_child_emit: null,
+        nav_child: null,
+        nav_parent: null,
+        nav_parent_triggered_by: null,
+      };
+      router.navigate([], {
+        queryParams,
+        replaceUrl: true,
+        queryParamsHandling: "merge",
+      });
+      // trigger any further actions defined on the nav_parent row that initiated the go_to action,
+      // matching the trigger emitted by the nav_child template
+      if (nav_child_emit) {
+        const triggerRow = template.rows.find((r) => r.name === nav_parent_triggered_by);
+        const triggeredActions = triggerRow.action_list.filter((a) => a.trigger === nav_child_emit);
+        await templateContainer.handleActions(triggeredActions, nav_child);
+        // back history will have changed (2 duplicate pages), so nav back to restore correct back button
+        history.back();
+      }
+    }
+  }
+
+  /**
+   * If the template was created following a go_to action provide additional query params on action completion
+   * to be tracked by parent
+   */
+  public async handleNavActionsFromChild(
+    actions: FlowTypes.TemplateRowAction[],
+    templateContainer: TemplateContainerComponent
+  ) {
+    const { route, router } = templateContainer;
+    const params = route.snapshot.queryParams as INavQueryParams;
+    const { nav_parent } = params;
+    // only process nav events for child if a nav_parent has been set
+    if (nav_parent) {
+      // only pass back completed/uncompleted emit actions
+      const navExitAction = actions.find(
+        (a) => a.action_id === "emit" && ["completed", "uncompleted"].includes(a.args[0])
+      );
+      const nav_child_emit = navExitAction?.args?.[0] || null;
+      const nav_child = nav_child_emit ? templateContainer.name : null;
+      const queryParams: INavQueryParams = { nav_child_emit, nav_child, nav_parent: null };
+      router.navigate(["../", nav_parent], {
+        relativeTo: route,
+        queryParams,
+        replaceUrl: true,
+        queryParamsHandling: "merge",
+      });
+    }
+  }
+}
+
+/** When using go_to statements various nav query params are added for maintaining relationships between templates */
+export interface INavQueryParams {
+  nav_child_emit?: string; // when returning from a go_to statement the final emit from the nav child (completed/uncompleted)
+  nav_child?: string; // the name of the nav child, for parent reference
+  nav_parent?: string; // the name of the nav parent, for child reference
+  nav_parent_triggered_by?: string; // the name of the parent row that triggered go_to action
+}

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -4,6 +4,7 @@ import { takeUntil, takeWhile } from "rxjs/operators";
 import { BehaviorSubject, Subject } from "scripts/node_modules/rxjs";
 import { TEMPLATE } from "../../services/data/data.service";
 import { FlowTypes, ITemplateContainerProps } from "./models";
+import { INavQueryParams, TemplateNavService } from "./services/template-nav.service";
 import { TemplateService } from "./services/template.service";
 
 interface ILocalVariables {
@@ -54,16 +55,22 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
   constructor(
     private templateService: TemplateService,
-    private router: Router,
-    private route: ActivatedRoute
+    public router: Router,
+    public route: ActivatedRoute,
+    private templateNavService: TemplateNavService
   ) {
-    // subscribe to query params to indicate if debugMode is enabled
-    this.route.queryParamMap
+    this.route.queryParams // subscribe to query params to indicate if debugMode is enabled
       .pipe(takeUntil(this.componentDestroyed$))
-      .subscribe((paramMap) => (this.debugMode = paramMap.get("debugMode") === "true"));
+      .subscribe(async (params: IQueryParams) => {
+        this.debugMode = params.debugMode ? true : false;
+        // allow templateNavService to process actions based on query param change
+        if (!this.parent) {
+          await this.templateNavService.handleActionsFromParent(params, this);
+        }
+      });
   }
 
-  ngOnInit() {
+  async ngOnInit() {
     this.initialiseTemplate();
     // const { name, templatename, parent, row, templateBreadcrumbs } = this;
     // console.log("template initialised", { name, templatename, parent, row, templateBreadcrumbs });
@@ -84,10 +91,12 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
     unhandledActions.forEach((action) => this.actionsQueue.push({ ...action, _triggeredBy }));
     const res = await this.processActionQueue();
     await this.handleActionsCallback([...unhandledActions], res);
-    this.handleNavActions(actions);
+    if (!this.parent) {
+      await this.templateNavService.handleNavActionsFromChild(actions, this);
+    }
   }
   /** Optional method child component can add to handle post-action callback */
-  public async handleActionsCallback(actions: FlowTypes.TemplateRowAction[], results: any) { }
+  public async handleActionsCallback(actions: FlowTypes.TemplateRowAction[], results: any) {}
 
   /** Optional method child component can filter action list to handle outside of default handlers */
   public async handleActionsInterceptor(
@@ -96,29 +105,8 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
     return actions;
   }
 
-  private handleNavActions(actions: FlowTypes.TemplateRowAction[] = []) {
-    console.log("handle nav actions", {
-      actions,
-      name: this.name,
-      parent: this.parent,
-      row: this.row,
-    });
-    const previousTemplate = this.route.snapshot.queryParamMap.get("from_template");
-    const navExitAction = actions.find(
-      (a) => a.action_id === "emit" && (a.trigger === "completed" || a.trigger === "uncompleted")
-    );
-
-    if (!this.parent && previousTemplate && navExitAction) {
-      this.router.navigate(["../", previousTemplate], {
-        relativeTo: this.route,
-        queryParams: { nav_emit: navExitAction.args[0] },
-        replaceUrl: true,
-      });
-    }
-  }
-
   public setDebugMode(debugMode: boolean) {
-    const queryParams = { debugMode: debugMode || null };
+    const queryParams: IQueryParams = { debugMode: debugMode || null };
     this.router.navigate([], { relativeTo: this.route, queryParams, queryParamsHandling: "merge" });
   }
   /**
@@ -160,11 +148,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
         console.log("Setting global variable", key, value);
         return this.templateService.setGlobal(key, value);
       case "go_to":
-        const [templatename] = action.args;
-        return this.router.navigate(["template", templatename], {
-          queryParams: { from_template: this.name },
-          queryParamsHandling: "merge",
-        });
+        return this.templateNavService.handleGoToAction(action, this);
       case "pop_up":
         /*** WiP */
         console.warn("No handler for action", { action_id, args });
@@ -280,10 +264,11 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
         VARIABLE_FIELDS.forEach((field) => {
           if (r[field]) {
             // don't override values that have otherwise been set from parent or nested properties
-            // local variables within r[field] are parsed 
-            variables[name][field] = variables[name][field] || this.parseLocalVariables(r[field], localvariables);
+            // local variables within r[field] are parsed
+            variables[name][field] =
+              variables[name][field] || this.parseLocalVariables(r[field], localvariables);
             // local variables on a given excel sheet are managed together
-            localvariables[name][field] = localvariables[name][field] || variables[name][field]
+            localvariables[name][field] = localvariables[name][field] || variables[name][field];
           }
         });
       }
@@ -461,8 +446,8 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
       return parsedExpression;
     } else {
-      return variable
-    };
+      return variable;
+    }
   }
   /** When using ngFor loop track by  */
   public trackByRow(index: number, row: FlowTypes.TemplateRow) {
@@ -516,3 +501,7 @@ const NOT_FOUND_TEMPLATE = (name: string): FlowTypes.Template => ({
   rows: [{ type: "title", value: `Template "${name}" not found` }],
   status: "released",
 });
+
+type IQueryParams = INavQueryParams & {
+  debugMode?: boolean | string;
+};


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
This PR improves the handling of navigation from templates via actions such as `go_to`. When go_to is triggered from `button_1` in `template_a`, with a go_to template `template_b` the following happens

1. Navigate to template_b with url parameters `nav_parent` and `nav_parent_triggered_by` to retain both the name (template_a) and row (button_1) that initiated the action
2. Listen for actions to be emitted from the child template. If emit completed or uncompleted navigate back to the previous template, with url parameters `nav_child` and `nav_child_emit` to retain both the name (template_b) and emit (e.g completed) of the second template
3. On return to template_a use the url parameters to lookup the go_to initiator and process any actions on the row that also match the emit trigger.

Test with `example_go_to_1` - although note as per my understanding the button text is not actually accurate for the intended behaviour (except for go_to_3 which was updated), and none can be fully demonstrated themselves unless within another parent/go_to statement (to check on return to the template how the completed/uncompleted emit is handled).

But console logs can be used to check the actions

![image](https://user-images.githubusercontent.com/10515065/112544619-22594100-8daf-11eb-9b11-d745b7e09c22.png)

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
