### PR TITLE
Script to sync single workbook (to save time and bandwidth)

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -32,7 +32,7 @@ const SCRIPT_NAMES = [
 async function start() {
   loadConfig();
   const args = process.argv;
-  const scriptToRun = args[2] ? args[2] : await promptOptions(SCRIPT_NAMES);
+  const scriptToRun = args[2] ? args.slice(2).join(" ") : await promptOptions(SCRIPT_NAMES);
   spawnSync(`npm run ${scriptToRun}`, {
     stdio: ["inherit", "inherit", "inherit"],
     shell: true,

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,8 @@
     "plh-copy-app-data": "ts-node src/plh-copy-app-data.ts",
     "sync-plh-content": "npm run gdrive-download && npm run plh-data-convert && npm run plh-copy-app-data",
     "version": "ts-node  src/version.ts",
-    "xlsx-to-json": "ts-node  src/plh-xlsx-to-json/index.ts"
+    "xlsx-to-json": "ts-node  src/plh-xlsx-to-json/index.ts",
+    "sync-single": "ts-node src/sync-single.ts"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/src/plh-copy-app-data.ts
+++ b/scripts/src/plh-copy-app-data.ts
@@ -7,11 +7,11 @@ const DATA_INPUT_FOLDER = path.join(__dirname, "./plh-data-convert/output");
 const ASSETS_INPUT_FOLDER = path.join(__dirname, "./gdrive-download/output/plh_assets");
 const APP_DATA_DIR = `../src/data`;
 const APP_PLH_ASSETS_DIR = "../src/assets/plh_assets";
-fs.ensureDirSync(APP_DATA_DIR);
-fs.emptyDirSync(APP_DATA_DIR);
 
 /** A simple script to copy data exported from gdrive and processed for plh into the app data folder */
 export function main(doAssetFolderCheck = true) {
+  fs.ensureDirSync(APP_DATA_DIR);
+  fs.emptyDirSync(APP_DATA_DIR);
   if (doAssetFolderCheck) {
     fs.ensureDirSync(APP_PLH_ASSETS_DIR);
     fs.emptyDirSync(APP_PLH_ASSETS_DIR);
@@ -24,7 +24,9 @@ export function main(doAssetFolderCheck = true) {
     const appOutputTs = generateAppTsOutput(localTsFile);
     fs.writeFileSync(`${APP_DATA_DIR}/${flow_type}.ts`, appOutputTs);
   }
-  fs.copySync(ASSETS_INPUT_FOLDER, APP_PLH_ASSETS_DIR);
+  if (fs.existsSync(ASSETS_INPUT_FOLDER)) {
+    fs.copySync(ASSETS_INPUT_FOLDER, APP_PLH_ASSETS_DIR);
+  }
   console.log(chalk.green("Data Copied to App"));
 }
 

--- a/scripts/src/plh-copy-app-data.ts
+++ b/scripts/src/plh-copy-app-data.ts
@@ -9,11 +9,13 @@ const APP_DATA_DIR = `../src/data`;
 const APP_PLH_ASSETS_DIR = "../src/assets/plh_assets";
 fs.ensureDirSync(APP_DATA_DIR);
 fs.emptyDirSync(APP_DATA_DIR);
-fs.ensureDirSync(APP_PLH_ASSETS_DIR);
-fs.emptyDirSync(APP_PLH_ASSETS_DIR);
 
 /** A simple script to copy data exported from gdrive and processed for plh into the app data folder */
-function main() {
+export function main(doAssetFolderCheck = true) {
+  if (doAssetFolderCheck) {
+    fs.ensureDirSync(APP_PLH_ASSETS_DIR);
+    fs.emptyDirSync(APP_PLH_ASSETS_DIR);
+  }
   console.log(chalk.yellow("Copying Data To App"));
   const localTsFiles = fs.readdirSync(DATA_INPUT_FOLDER);
   for (const filepath of localTsFiles) {
@@ -25,7 +27,10 @@ function main() {
   fs.copySync(ASSETS_INPUT_FOLDER, APP_PLH_ASSETS_DIR);
   console.log(chalk.green("Data Copied to App"));
 }
-main();
+
+if (process.argv[1] && process.argv[1].indexOf("sync-single") < 0) {
+  main();
+}
 
 /**
  * When copying to the app simply replace the path to local typings imported to

--- a/scripts/src/plh-data-convert/index.ts
+++ b/scripts/src/plh-data-convert/index.ts
@@ -25,7 +25,7 @@ const DEPLOY_TARGET: "app" | "rapidpro" = "app";
  * Reads xlsx files from gdrive-download output and converts to json
  * objects representing sheet names and data values
  */
-async function main() {
+export async function main() {
   console.log(chalk.yellow("Converting PLH Data"));
   fs.ensureDirSync(INPUT_FOLDER);
   fs.ensureDirSync(INTERMEDIATES_FOLDER);
@@ -60,12 +60,15 @@ async function main() {
   });
   console.log(chalk.yellow("Conversion Complete"));
 }
-main()
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  })
-  .then(() => console.log(chalk.green("PLH Data Converted")));
+
+if (process.argv[1] && process.argv[1].indexOf("sync-single") < 0) {
+  main()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then(() => console.log(chalk.green("PLH Data Converted")));
+}
 
 function applyDataParsers(
   dataByFlowType: { [type in FlowTypes.FlowType]: FlowTypes.FlowTypeWithData[] }

--- a/scripts/src/sync-single.ts
+++ b/scripts/src/sync-single.ts
@@ -1,0 +1,19 @@
+import { main as download } from "./gdrive-download";
+import { main as convert } from "./plh-data-convert";
+import { main as copy } from "./plh-copy-app-data";
+
+async function main() {
+  await download(process.argv[2]);
+  await convert();
+  copy(false);
+}
+
+if (process.argv.length > 2) {
+  main();
+} else {
+  console.warn("Incorrect usage");
+  console.log("Usage is either");
+  console.log("npm run scripts sync-single -- sheet-name");
+  console.log("npm run sync-single -- sheet-name");
+  process.exit(0);
+}


### PR DESCRIPTION
- Download single workbook
- Check if assets folder exists before copy

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Allows syncing of only a single workbook (or workbooks) by file name by using command
```
npm run scripts sync-single -- workbook_name
```

**You must run npm run scripts sync-plh-content once before running this command**

## Git Issues

_Closes #409
