### PR TITLE
Script path fix

### DIFF
--- a/scripts/src/plh-data-convert/index.ts
+++ b/scripts/src/plh-data-convert/index.ts
@@ -126,7 +126,8 @@ function mergePLHData(jsons: { json: any; xlsxPath: string }[]) {
               console.log(chalk.yellow("duplicate flow:", flow_name));
             }
             // console.log(chalk.green("+", flow_name));
-            const _xlsxPath = path.relative(INPUT_FOLDER, xlsxPath);
+            // Ensure all paths use / to match HTTP style paths
+            const _xlsxPath = path.relative(INPUT_FOLDER, xlsxPath).replace("\\", "/");
             merged[flow_name] = { ...contents, rows: json[flow_name], _xlsxPath };
           } else {
             console.log(chalk.red("No Contents:", flow_name));


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Ensures all file paths in xlsxPath are / (same as HTTP / mac / linux) even when generated on Windows.

Going with / instead of \\ is largely because pasting in a / path in Windows explorer will still open the folder, however doing the reverse in a web browser or mac / linux file browser does not.