### PR TITLE
refactor debug toggle to standalone menu component

### DIFF
--- a/src/app/shared/components/debug-toggle.ts
+++ b/src/app/shared/components/debug-toggle.ts
@@ -1,0 +1,79 @@
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
+
+@Component({
+  selector: "plh-debug-toggle",
+  template: ` <div
+    class="debug-toggle-container"
+    [attr.data-enabled]="debugMode"
+    *ngIf="showDebugToggle"
+  >
+    <ion-icon name="bug-outline"></ion-icon>
+    <ion-toggle
+      class="debug-toggle"
+      #debugToggle
+      (ionChange)="setDebugMode(debugToggle.checked)"
+      [checked]="debugMode"
+    ></ion-toggle>
+  </div>`,
+  styles: [
+    `
+      .debug-toggle {
+        padding-inline: 8px;
+        --background: rgba(255, 255, 255, 0.8);
+        --handle-background: white;
+        --background-checked: var(--ion-color-secondary);
+        --handle-background-checked: white;
+      }
+      .debug-toggle-container {
+        display: flex;
+        align-items: center;
+      }
+      .debug-toggle-container {
+        margin-left: auto;
+        opacity: 0.8;
+      }
+      .debug-toggle-container[data-enabled="true"] {
+        opacity: 1;
+      }
+    `,
+  ],
+})
+export class PLHDebugToggleComponent implements OnInit, OnDestroy {
+  debugMode = false;
+  showDebugToggle = true;
+  componentDestroyed$ = new Subject();
+  constructor(private router: Router, private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.subscribeToQueryParamChanges();
+  }
+  ngOnDestroy() {
+    this.componentDestroyed$.next();
+    this.componentDestroyed$.unsubscribe();
+  }
+
+  public setDebugMode(debugMode: boolean) {
+    this.debugMode = debugMode;
+    const queryParams: IQueryParams = { debugMode: debugMode ? "true" : null };
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      queryParamsHandling: "merge",
+      replaceUrl: true,
+    });
+  }
+  private subscribeToQueryParamChanges() {
+    this.route.queryParams
+      .pipe(takeUntil(this.componentDestroyed$))
+      .subscribe(async (params: any) => {
+        this.debugMode = params.debugMode ? true : false;
+      });
+  }
+}
+
+interface IQueryParams {
+  debugMode?: "true";
+}

--- a/src/app/shared/components/plh-main-header.ts
+++ b/src/app/shared/components/plh-main-header.ts
@@ -17,8 +17,11 @@ import { Subscription } from "rxjs";
         <ion-icon src="assets/images/star.svg" style="margin: -1px 8px"></ion-icon>
         <span>{{ title }}</span>
       </ion-title>
-      <ion-buttons slot="end" routerLink="/reminders">
-        <ion-button><ion-icon slot="icon-only" name="notifications-outline"></ion-icon></ion-button>
+      <ion-buttons slot="end">
+        <plh-debug-toggle *ngIf="showDebugToggle"></plh-debug-toggle>
+        <ion-button routerLink="/reminders"
+          ><ion-icon slot="icon-only" name="notifications-outline"></ion-icon
+        ></ion-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>`,
@@ -26,6 +29,8 @@ import { Subscription } from "rxjs";
 export class PLHMainHeaderComponent implements OnInit, OnDestroy {
   isHomePage = true;
   @Input() title: string = "ParentApp";
+  // TODO - link debug toggle to build environment or advanced setting (hide for general users)
+  showDebugToggle = true;
   routeChanges$: Subscription;
   /** track if navigation has been used to handle back button click behaviour */
   hasBackHistory = false;

--- a/src/app/shared/components/template/template-container.component.html
+++ b/src/app/shared/components/template/template-container.component.html
@@ -5,18 +5,10 @@
   [attr.data-isChild]="parent ? true : false"
 >
   <!-- Debug Toggle -->
-  <div class="debug-container" *ngIf="showDebugToggle" [attr.data-enabled]="debugMode">
+  <div class="debug-container" [attr.data-enabled]="debugMode">
     <div *ngIf="debugMode && !parent" class="debug-name">
       <div>template: {{ templatename || "(undefined)" }}</div>
       <div>name: {{ name || "(undefined)" }}</div>
-    </div>
-    <div *ngIf="!parent" class="debug-toggle-container" [attr.data-enabled]="debugMode">
-      <ion-icon name="bug-outline"></ion-icon>
-      <ion-toggle
-        #debugToggle
-        (ionChange)="setDebugMode(debugToggle.checked)"
-        [checked]="debugMode"
-      ></ion-toggle>
     </div>
   </div>
 

--- a/src/app/shared/components/template/template-container.component.scss
+++ b/src/app/shared/components/template/template-container.component.scss
@@ -24,18 +24,11 @@
   overflow: auto;
 }
 
-.debug-container,
-.debug-toggle-container {
+.debug-container {
   display: flex;
   align-items: center;
 }
-.debug-toggle-container {
-  margin-left: auto;
-  opacity: 0.2;
-}
-.debug-toggle-container[data-enabled="true"] {
-  opacity: 1;
-}
+
 .debug-name {
   padding: 4px;
   font-size: small;

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -51,8 +51,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   localVariables: ILocalVariables = {};
   componentDestroyed$ = new Subject();
   debugMode: boolean;
-  // TODO - link debug toggle to build environment or advanced setting (hide for general users)
-  showDebugToggle = true;
   private actionsQueue: FlowTypes.TemplateRowAction[] = [];
   private actionsQueueProcessing$ = new BehaviorSubject<boolean>(false);
 
@@ -99,10 +97,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
     return actions;
   }
 
-  public setDebugMode(debugMode: boolean) {
-    const queryParams: IQueryParams = { debugMode: debugMode || null };
-    this.router.navigate([], { relativeTo: this.route, queryParams, queryParamsHandling: "merge" });
-  }
   /**
    * To avoid actions potentially trying to write to same db records at the same time,
    * all actions are added to a queue and processed in order of addition
@@ -468,7 +462,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   private subscribeToQueryParamChanges() {
     this.route.queryParams
       .pipe(takeUntil(this.componentDestroyed$))
-      .subscribe(async (params: IQueryParams) => {
+      .subscribe(async (params: any) => {
         this.debugMode = params.debugMode ? true : false;
         // allow templateNavService to process actions based on query param change
         await this.templateNavService.handleQueryParamChange(params, this);
@@ -522,7 +516,3 @@ const NOT_FOUND_TEMPLATE = (name: string): FlowTypes.Template => ({
   rows: [{ type: "title", value: `Template "${name}" not found` }],
   status: "released",
 });
-
-type IQueryParams = INavQueryParams & {
-  debugMode?: boolean | string;
-};

--- a/src/app/shared/components/template/template.module.ts
+++ b/src/app/shared/components/template/template.module.ts
@@ -13,7 +13,14 @@ import { NouisliderModule } from "ng2-nouislider";
 import { AngularSvgIconModule } from "angular-svg-icon";
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, SharedPipesModule, NouisliderModule, AngularSvgIconModule.forRoot()],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    SharedPipesModule,
+    NouisliderModule,
+    AngularSvgIconModule.forRoot(),
+  ],
   exports: [...TEMPLATE_COMPONENTS, TemplateContainerComponent],
   declarations: [
     TmplCompHostDirective,
@@ -21,7 +28,6 @@ import { AngularSvgIconModule } from "angular-svg-icon";
     TooltipDirective,
     ...TEMPLATE_COMPONENTS,
     TemplateContainerComponent,
-    // LocalVarsReplacePipe,
   ],
 })
 export class TemplateComponentsModule {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,10 +11,9 @@ import { RouterModule } from "@angular/router";
 import { TemplateComponentsModule } from "./components/template/template.module";
 import { ANIMATION_COMPONENTS } from "./components/animations";
 import { AnimationComponent } from "./components/animations/animation.component";
-import { RoundIconButtonComponent } from "./components/template/components/round-icon-button/round-icon-button.component";
-import { TooltipModule } from "./components/common/directives/tooltip.directive";
 import { ComboBoxModalComponent } from "./components/common/components/combo-box-modal/combo-box-modal.component";
 import { ReactiveFormsModule } from "@angular/forms";
+import { PLHDebugToggleComponent } from "./components/debug-toggle";
 
 const Components = [
   BlobComponent,
@@ -23,6 +22,7 @@ const Components = [
   StressedMultiHandAnimComponent,
   PLHMainHeaderComponent,
   PLHMainTabsComponent,
+  PLHDebugToggleComponent,
   AnimationComponent,
   ComboBoxModalComponent,
   ...ANIMATION_COMPONENTS,


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Refactor the debug mode toggle to standalone code to tidy template container component
- Move to menu bar to allow use throughout app, make easier to remove later and not take up space in template components

## Git Issues

_Closes #_

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/10515065/113476702-f4da5a80-9474-11eb-854f-d5f525c496d0.png)

![image](https://user-images.githubusercontent.com/10515065/113476627-94e3b400-9474-11eb-99aa-b84e9584fd45.png)



