### PR TITLE
Add support for local template row references

### DIFF
--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -34,4 +34,14 @@ export class TemplateBaseComponent implements ITemplateRowProps {
     const actionsForTrigger = action_list.filter((a) => a.trigger === trigger);
     this.parent.handleActions(actionsForTrigger, this._row.name);
   }
+
+  /** Update the current value of the row by setting a local variable that matches */
+  setValue(value: any) {
+    const action: FlowTypes.TemplateRowAction = {
+      action_id: "set_local",
+      args: [this._row.name, value],
+      trigger: "click",
+    };
+    return this.parent.handleActions([action], this._row.name);
+  }
 }

--- a/src/app/shared/components/template/components/radio-group/radio-group.component.html
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.html
@@ -11,9 +11,9 @@
           <input
             #el
             type="radio"
-            [value]="item.text"
+            [value]="item.name"
             [checked]="el.value === value"
-            [(ngModel)]="_row.value"
+            (click)="setValue(el.value)"
             [name]="_row.name"
           />
           {{ item.text }}
@@ -36,9 +36,9 @@
           <input
             #el
             type="radio"
-            [value]="item.text"
+            [value]="item.name"
             [checked]="el.value === value"
-            [(ngModel)]="_row.value"
+            (click)="setValue(el.value)"
             [name]="_row.name"
           />
           {{ item.text }}
@@ -58,9 +58,9 @@
           <input
             #el
             type="radio"
-            [value]="item.text"
+            [value]="item.name"
             [checked]="el.value === value"
-            [(ngModel)]="_row.value"
+            (click)="setValue(el.value)"
             [name]="_row.name"
           />
           <span> {{ item.text }} </span>

--- a/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.ts
+++ b/src/app/shared/components/template/components/round-icon-button/round-icon-button.component.ts
@@ -1,12 +1,12 @@
 import { Component, Input, OnInit } from "@angular/core";
-import { FlowTypes } from 'src/app/shared/model/flowTypes';
+import { FlowTypes } from "src/app/shared/model/flowTypes";
 import { ITemplateRowProps } from "../../models";
 import { TemplateContainerComponent } from "../../template-container.component";
 import { TemplateBaseComponent } from "../base";
 @Component({
-  selector: 'plh-round-button',
-  templateUrl: './round-icon-button.component.html',
-  styleUrls: ['./round-icon-button.component.scss'],
+  selector: "plh-round-button",
+  templateUrl: "./round-icon-button.component.html",
+  styleUrls: ["./round-icon-button.component.scss"],
 })
 export class RoundIconButtonComponent extends TemplateBaseComponent implements ITemplateRowProps {
   @Input() parent: TemplateContainerComponent;
@@ -14,16 +14,5 @@ export class RoundIconButtonComponent extends TemplateBaseComponent implements I
 
   onClick() {
     console.log("Templating action handling to be implemented");
-    /*
-    if (this.row && this.row.action_list) {
-      for (let actionString of this.row.action_list) {
-        let parts = actionString.split("|").map((part) => part.trim());
-        let actionId = parts[0];
-        switch (actionId) {
-          case "set_value": this.setValue(parts[1], parts[2]);
-        }
-      }
-    }
-    */
   }
 }

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -394,7 +394,6 @@ export namespace FlowTypes {
     // TODO - 2021-03-11 - most of list needs reconsideration/implementation
     action_id:
       | "" // TODO document this property for stop propogation
-      | "set_value" // This currently is same as set_local (remove?)
       | "set_field"
       | "set_local"
       | "set_global"

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -5289,6 +5289,74 @@
   },
   {
     "flow_type": "template",
+    "flow_name": "example_component_variables",
+    "status": "released",
+    "rows": [
+      {
+        "type": "text",
+        "name": "example_1a",
+        "value": "Basic Example"
+      },
+      {
+        "type": "text",
+        "name": "example_1b",
+        "value": "The text above is: @local.example_1a"
+      },
+      {
+        "name": "answer_list",
+        "value": [
+          "name:name_var_1 | text:Option 1",
+          "name:name_var_2 | text: Option 2",
+          "name:name_var_3 | text: Option 3"
+        ],
+        "type": "set_variable"
+      },
+      {
+        "type": "radio_group",
+        "name": "option_buttons",
+        "parameter_list": {
+          "radio_button_type": "btn_text",
+          "answer_list": "@local.answer_list",
+          "style": "passive"
+        }
+      },
+      {
+        "type": "text",
+        "name": "text_with_option",
+        "value": "The option currently selecte is @local.option_buttons"
+      },
+      {
+        "type": "text",
+        "name": "text_option_1",
+        "value": "This is the text to show if option 1 is selected",
+        "hidden": "@local.option_buttons==\"name_var_1\""
+      },
+      {
+        "type": "text",
+        "name": "text_option_2",
+        "value": "This is the text to show if option 2 is selected",
+        "hidden": "@local.option_buttons==\"name_var_2\""
+      },
+      {
+        "type": "text",
+        "name": "text_option_3",
+        "value": "This is the text to show if option 3 is selected",
+        "hidden": "@local.option_buttons==\"name_var_3\""
+      },
+      {
+        "name": "output_fieldname",
+        "value": "this_will_be_overwritten",
+        "type": "set_variable"
+      },
+      {
+        "type": "radio_group",
+        "name": "option_buttons_2"
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/example_templates/example_component_variables.xlsx"
+  },
+  {
+    "flow_type": "template",
     "flow_name": "example_double_ref_comp_var",
     "status": "released",
     "rows": [
@@ -6440,15 +6508,7 @@
       {
         "type": "text_box",
         "name": "text_box",
-        "action_list": [
-          {
-            "trigger": "click",
-            "action_id": "set_value",
-            "args": [],
-            "_raw": "set_value",
-            "_cleaned": "click | set_value"
-          }
-        ],
+        "action_list": [],
         "parameter_list": {
           "blank_display_text": "@local.blank_display_text",
           "help": "some help text"
@@ -11561,7 +11621,7 @@
                 "name": "workshop_activity",
                 "rows": [
                   {
-                    "name": "intro_text_together",
+                    "name": "intro_text",
                     "value": "You’ve completed this week’s workshop. \n\nNext week’s workshop will celebrate you all, and plan support for everyone going forward. \n\nWhy don’t you plan some party food together, and have some music ready if you like to dance!",
                     "hidden": "!@field.do_workshops_together",
                     "type": "set_variable"


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
- Provide access to sibling component variables through @local syntax
- Add method to update own row value via actions
- Update radio group to update own value for use in other components

## Known Issues and TODOs
- Only able to access one level of depth (e.g. @local.some_component not @local.some_component.nested_child)
- Only support for the `value` field to be returned (not parameters etc.)
- Issue identified when comparing strings explict quotation marks required (e.g. "@local.some_value"=="some_val")

## Git Issues

Closes #488 

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/10515065/113790693-d062d480-9739-11eb-84d2-51ec0d8bddc1.png)

