### PR TITLE
Fix goto then go back in embedded template

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -49,11 +49,11 @@ export class TemplateNavService {
     action: FlowTypes.TemplateRowAction,
     container: TemplateContainerComponent
   ) {
-    const { router, name } = container;
+    const parentName = container.row ? container.row.value : container.name;
     const [templatename] = action.args;
     const nav_parent_triggered_by = action._triggeredBy;
-    const queryParams: INavQueryParams = { nav_parent: name, nav_parent_triggered_by };
-    return router.navigate(["template", templatename], {
+    const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
+    return container.router.navigate(["template", templatename], {
       queryParams,
       queryParamsHandling: "merge",
     });

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -49,7 +49,8 @@ export class TemplateNavService {
     action: FlowTypes.TemplateRowAction,
     container: TemplateContainerComponent
   ) {
-    const parentName = container.row ? container.row.value : container.name;
+    // TODO: Find more elegant way to get current root level template name
+    const parentName = location.pathname.replace("/template/", "");
     const [templatename] = action.args;
     const nav_parent_triggered_by = action._triggeredBy;
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -68,6 +68,11 @@
     "rows": [
       {
         "type": "declare_global_constant",
+        "name": "parent_app",
+        "value": "ParentApp"
+      },
+      {
+        "type": "declare_global_constant",
         "name": "weekly_workshops",
         "value": "Weekly Workshops"
       },
@@ -303,7 +308,7 @@
         "type": "declare_global_constant",
         "name": "w_self_care_short",
         "value": "Self-Care",
-        "comments": "ETW 1 -- done"
+        "comments": "pop-ups done"
       },
       {
         "type": "declare_global_constant",
@@ -314,8 +319,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_1on1_short",
-        "value": "One-on-One Time",
-        "comments": "ETW 3 -- done"
+        "value": "One-on-One Time"
       },
       {
         "type": "declare_global_constant",
@@ -326,8 +330,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_praise_short",
-        "value": "Praise",
-        "comments": "ETW 4 -- done"
+        "value": "Praise"
       },
       {
         "type": "declare_global_constant",
@@ -338,8 +341,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_instruct_short",
-        "value": "Positive Instructions",
-        "comments": "ETW 2 -- done"
+        "value": "Positive Instructions"
       },
       {
         "type": "declare_global_constant",
@@ -350,8 +352,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_stress_short",
-        "value": "Managing Stress",
-        "comments": "ETW 5 -- done"
+        "value": "Managing Stress"
       },
       {
         "type": "declare_global_constant",
@@ -362,8 +363,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_money_short",
-        "value": "Family Budgets",
-        "comments": "ETW 6 -- might need reordering"
+        "value": "Family Budgets"
       },
       {
         "type": "declare_global_constant",
@@ -374,8 +374,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_rules_short",
-        "value": "Rules",
-        "comments": "ETW 7 -- done"
+        "value": "Rules"
       },
       {
         "type": "declare_global_constant",
@@ -386,8 +385,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_consequence_short",
-        "value": "Calm Consequences",
-        "comments": "ETW 8 -- done"
+        "value": "Calm Consequences"
       },
       {
         "type": "declare_global_constant",
@@ -398,8 +396,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_solve_short",
-        "value": "Problem Solving",
-        "comments": "ETW 9 -- done"
+        "value": "Problem Solving"
       },
       {
         "type": "declare_global_constant",
@@ -410,8 +407,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_safe_short",
-        "value": "Teen Safety",
-        "comments": "ETW 10 - need to discuss with Orli"
+        "value": "Teen Safety"
       },
       {
         "type": "declare_global_constant",
@@ -422,8 +418,7 @@
       {
         "type": "declare_global_constant",
         "name": "w_crisis_short",
-        "value": "Dealing with Crisis",
-        "comments": "ETW 11 - waiting for images"
+        "value": "Dealing with Crisis"
       },
       {
         "type": "declare_global_constant",

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -960,485 +960,6 @@
   },
   {
     "flow_type": "template",
-    "flow_name": "workshop_stepper",
-    "status": "released",
-    "db_ignore_events": true,
-    "rows": [
-      {
-        "name": "progress_bar_value",
-        "type": "set_variable"
-      },
-      {
-        "name": "progress_bar_num_items",
-        "type": "set_variable"
-      },
-      {
-        "name": "progress_bar",
-        "value": "@local.progress_bar_value",
-        "parameter_list": {
-          "num_items": "@local.progress_bar_num_items"
-        },
-        "type": "set_variable"
-      },
-      {
-        "type": "nav_group",
-        "name": "nav_template_list"
-      }
-    ],
-    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
-  },
-  {
-    "flow_type": "template",
-    "flow_name": "workshop_activity",
-    "status": "released",
-    "db_ignore_events": true,
-    "rows": [
-      {
-        "name": "activity_image_src",
-        "value": "src/assets/not-found-image.png",
-        "comments": "A workshop activity corresponds to a column in Figma. It typically consists of intro and content. It occasionally has an outro.",
-        "type": "set_variable"
-      },
-      {
-        "name": "activity_title",
-        "value": "Title of this activity",
-        "type": "set_variable"
-      },
-      {
-        "name": "include_outro",
-        "value": "false",
-        "type": "set_variable"
-      },
-      {
-        "name": "hide_intro",
-        "value": "false",
-        "type": "set_variable"
-      },
-      {
-        "name": "hide_content",
-        "value": "true",
-        "type": "set_variable"
-      },
-      {
-        "name": "hide_outro",
-        "value": "true",
-        "type": "set_variable"
-      },
-      {
-        "type": "display_theme",
-        "name": "display_theme",
-        "value": "passive_theme"
-      },
-      {
-        "type": "animated_section",
-        "name": "intro",
-        "value": "fade_in_out",
-        "hidden": "@local.hide_intro",
-        "rows": [
-          {
-            "type": "image",
-            "name": "intro_image_src",
-            "value": "@local.activity_image",
-            "parameter_list": {
-              "background_box": "true"
-            }
-          },
-          {
-            "type": "title",
-            "name": "intro_title",
-            "value": "@local.activity_title"
-          },
-          {
-            "type": "text",
-            "name": "intro_text"
-          },
-          {
-            "type": "template",
-            "name": "intro_nav_buttons",
-            "value": "nav_buttons",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_content",
-                  "false"
-                ],
-                "_raw": "completed | set_local:hide_content:false",
-                "_cleaned": "completed | set_local:hide_content:false"
-              },
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_intro",
-                  "true"
-                ],
-                "_raw": "completed | set_local:hide_intro:true",
-                "_cleaned": "completed | set_local:hide_intro:true"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "emit",
-                "args": [
-                  "uncompleted"
-                ],
-                "_raw": "uncompleted | emit:uncompleted",
-                "_cleaned": "uncompleted | emit:uncompleted"
-              }
-            ],
-            "comments": "completed | set_local:hide_content:false; completed | set_local:hide_intro:true; uncompleted | emit:uncompleted ",
-            "rows": [
-              {
-                "name": "button_completed",
-                "value": "Let's go!",
-                "type": "set_variable"
-              },
-              {
-                "name": "button_uncompleted",
-                "value": "Skip",
-                "hidden": "true",
-                "comments": "default: set_properties\nuse extend_properties to add to an existing list of properties",
-                "type": "set_variable"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "type": "animated_section",
-        "name": "content",
-        "hidden": "@local.hide_content",
-        "rows": [
-          {
-            "type": "display_group",
-            "name": "activity_banner",
-            "hidden": "true",
-            "rows": [
-              {
-                "type": "title",
-                "name": "banner_title",
-                "value": "@local.activity_title"
-              },
-              {
-                "type": "image",
-                "name": "banner_image_src",
-                "value": "@local.activity_image",
-                "parameter_list": {
-                  "background_box": "true"
-                }
-              }
-            ]
-          },
-          {
-            "type": "template",
-            "name": "content_box",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_content",
-                  "true"
-                ],
-                "_raw": "completed | set_local:hide_content:true",
-                "_cleaned": "completed | set_local:hide_content:true"
-              },
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_outro",
-                  "false"
-                ],
-                "_raw": "completed | set_local:hide_outro:false",
-                "_cleaned": "completed | set_local:hide_outro:false"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_intro",
-                  "false"
-                ],
-                "_raw": "uncompleted | set_local:hide_intro:false",
-                "_cleaned": "uncompleted | set_local:hide_intro:false"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_content",
-                  "true"
-                ],
-                "_raw": "uncompleted | set_local:hide_content:true",
-                "_cleaned": "uncompleted | set_local:hide_content:true"
-              }
-            ],
-            "hidden": "!@local.include_outro",
-            "comments": "Do this row when include_outro = TRUE\n!@local.include_outro",
-            "rows": []
-          },
-          {
-            "type": "template",
-            "name": "content_box",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "emit",
-                "args": [
-                  "completed"
-                ],
-                "_raw": "completed | emit:completed",
-                "_cleaned": "completed | emit:completed"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_intro",
-                  "false"
-                ],
-                "_raw": "uncompleted | set_local:hide_intro:false",
-                "_cleaned": "uncompleted | set_local:hide_intro:false"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_content",
-                  "true"
-                ],
-                "_raw": "uncompleted | set_local:hide_content:true",
-                "_cleaned": "uncompleted | set_local:hide_content:true"
-              }
-            ],
-            "hidden": "@local.include_outro",
-            "comments": "Do this row when include_outro = FALSE\n@local.include_outro",
-            "rows": []
-          }
-        ]
-      },
-      {
-        "type": "animated_section",
-        "name": "outro",
-        "hidden": "@local.hide_outro",
-        "rows": [
-          {
-            "type": "image",
-            "name": "outro_image_src",
-            "value": "@local.activity_image",
-            "parameter_list": {
-              "background_box": "true"
-            }
-          },
-          {
-            "type": "title",
-            "name": "outro_title",
-            "value": "@local.activity_title",
-            "hidden": "true"
-          },
-          {
-            "type": "text",
-            "name": "outro_text"
-          },
-          {
-            "type": "button",
-            "name": "outro_button",
-            "hidden": "true"
-          },
-          {
-            "type": "text",
-            "name": "outro_habit_text",
-            "parameter_list": {
-              "alert": "plh_images/icons/star_circle.svg"
-            }
-          },
-          {
-            "type": "template",
-            "name": "outro_nav_buttons",
-            "value": "nav_buttons",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "emit",
-                "args": [
-                  "completed"
-                ],
-                "_raw": "completed | emit:completed",
-                "_cleaned": "completed | emit:completed"
-              }
-            ],
-            "rows": []
-          }
-        ]
-      }
-    ],
-    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
-  },
-  {
-    "flow_type": "template",
-    "flow_name": "nav_buttons",
-    "status": "released",
-    "db_ignore_events": true,
-    "rows": [
-      {
-        "type": "display_group",
-        "rows": [
-          {
-            "type": "button",
-            "name": "button_info",
-            "value": "@global.ideas_button",
-            "hidden": "true",
-            "parameter_list": {
-              "colour": "secondary"
-            }
-          },
-          {
-            "type": "button",
-            "name": "button_completed",
-            "value": "Done!",
-            "action_list": [
-              {
-                "trigger": "click",
-                "action_id": "emit",
-                "args": [
-                  "completed"
-                ],
-                "_raw": "click | emit:completed",
-                "_cleaned": "click | emit:completed"
-              }
-            ]
-          },
-          {
-            "type": "button",
-            "name": "button_uncompleted",
-            "value": "Back",
-            "action_list": [
-              {
-                "trigger": "click",
-                "action_id": "emit",
-                "args": [
-                  "uncompleted"
-                ],
-                "_raw": "click | emit:uncompleted",
-                "_cleaned": "click | emit:uncompleted"
-              }
-            ],
-            "hidden": "true"
-          }
-        ]
-      }
-    ],
-    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
-  },
-  {
-    "flow_type": "template",
-    "flow_name": "pair",
-    "status": "released",
-    "db_ignore_events": true,
-    "rows": [
-      {
-        "name": "hide_animated_section_1",
-        "value": "false",
-        "type": "set_variable"
-      },
-      {
-        "name": "hide_animated_section_2",
-        "value": "true",
-        "type": "set_variable"
-      },
-      {
-        "type": "animated_section",
-        "name": "animated_section_1",
-        "hidden": "@local.hide_animated_section_1",
-        "rows": [
-          {
-            "type": "template",
-            "name": "box_1",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_animated_section_1",
-                  "true"
-                ],
-                "_raw": "completed | set_local:hide_animated_section_1:true",
-                "_cleaned": "completed | set_local:hide_animated_section_1:true"
-              },
-              {
-                "trigger": "completed",
-                "action_id": "set_local",
-                "args": [
-                  "hide_animated_section_2",
-                  "false"
-                ],
-                "_raw": "completed | set_local:hide_animated_section_2:false",
-                "_cleaned": "completed | set_local:hide_animated_section_2:false"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "emit",
-                "args": [
-                  "uncompleted"
-                ],
-                "_raw": "uncompleted | emit:uncompleted",
-                "_cleaned": "uncompleted | emit:uncompleted"
-              }
-            ],
-            "rows": []
-          }
-        ]
-      },
-      {
-        "type": "animated_section",
-        "name": "animated_section_2",
-        "hidden": "@local.hide_animated_section_2",
-        "rows": [
-          {
-            "type": "template",
-            "name": "box_2",
-            "action_list": [
-              {
-                "trigger": "completed",
-                "action_id": "emit",
-                "args": [
-                  "completed"
-                ],
-                "_raw": "completed | emit:completed",
-                "_cleaned": "completed | emit:completed"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_animated_section_1",
-                  "false"
-                ],
-                "_raw": "uncompleted | set_local:hide_animated_section_1:false",
-                "_cleaned": "uncompleted | set_local:hide_animated_section_1:false"
-              },
-              {
-                "trigger": "uncompleted",
-                "action_id": "set_local",
-                "args": [
-                  "hide_animated_section_2",
-                  "true"
-                ],
-                "_raw": "uncompleted  | set_local:hide_animated_section_2:true",
-                "_cleaned": "uncompleted  | set_local:hide_animated_section_2:true"
-              }
-            ],
-            "rows": []
-          }
-        ]
-      }
-    ],
-    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
-  },
-  {
-    "flow_type": "template",
     "flow_name": "box_video",
     "status": "released",
     "rows": [
@@ -1784,6 +1305,481 @@
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshop_boxes.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "workshop_stepper",
+    "status": "released",
+    "rows": [
+      {
+        "name": "progress_bar_value",
+        "type": "set_variable"
+      },
+      {
+        "name": "progress_bar_num_items",
+        "type": "set_variable"
+      },
+      {
+        "name": "progress_bar",
+        "value": "@local.progress_bar_value",
+        "parameter_list": {
+          "num_items": "@local.progress_bar_num_items"
+        },
+        "type": "set_variable"
+      },
+      {
+        "type": "nav_group",
+        "name": "nav_template_list"
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "workshop_activity",
+    "status": "released",
+    "rows": [
+      {
+        "name": "activity_image_src",
+        "value": "src/assets/not-found-image.png",
+        "comments": "A workshop activity corresponds to a column in Figma. It typically consists of intro and content. It occasionally has an outro.",
+        "type": "set_variable"
+      },
+      {
+        "name": "activity_title",
+        "value": "Title of this activity",
+        "type": "set_variable"
+      },
+      {
+        "name": "include_outro",
+        "value": "false",
+        "type": "set_variable"
+      },
+      {
+        "name": "hide_intro",
+        "value": "false",
+        "type": "set_variable"
+      },
+      {
+        "name": "hide_content",
+        "value": "true",
+        "type": "set_variable"
+      },
+      {
+        "name": "hide_outro",
+        "value": "true",
+        "type": "set_variable"
+      },
+      {
+        "type": "display_theme",
+        "name": "display_theme",
+        "value": "passive_theme"
+      },
+      {
+        "type": "animated_section",
+        "name": "intro",
+        "value": "fade_in_out",
+        "hidden": "@local.hide_intro",
+        "rows": [
+          {
+            "type": "image",
+            "name": "intro_image_src",
+            "value": "@local.activity_image",
+            "parameter_list": {
+              "background_box": "true"
+            }
+          },
+          {
+            "type": "title",
+            "name": "intro_title",
+            "value": "@local.activity_title"
+          },
+          {
+            "type": "text",
+            "name": "intro_text"
+          },
+          {
+            "type": "template",
+            "name": "intro_nav_buttons",
+            "value": "nav_buttons",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_content",
+                  "false"
+                ],
+                "_raw": "completed | set_local:hide_content:false",
+                "_cleaned": "completed | set_local:hide_content:false"
+              },
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_intro",
+                  "true"
+                ],
+                "_raw": "completed | set_local:hide_intro:true",
+                "_cleaned": "completed | set_local:hide_intro:true"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "emit",
+                "args": [
+                  "uncompleted"
+                ],
+                "_raw": "uncompleted | emit:uncompleted",
+                "_cleaned": "uncompleted | emit:uncompleted"
+              }
+            ],
+            "comments": "completed | set_local:hide_content:false; completed | set_local:hide_intro:true; uncompleted | emit:uncompleted ",
+            "rows": [
+              {
+                "name": "button_completed",
+                "value": "Let's go!",
+                "type": "set_variable"
+              },
+              {
+                "name": "button_uncompleted",
+                "value": "Skip",
+                "hidden": "true",
+                "comments": "default: set_properties\nuse extend_properties to add to an existing list of properties",
+                "type": "set_variable"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "animated_section",
+        "name": "content",
+        "hidden": "@local.hide_content",
+        "rows": [
+          {
+            "type": "display_group",
+            "name": "activity_banner",
+            "hidden": "true",
+            "rows": [
+              {
+                "type": "title",
+                "name": "banner_title",
+                "value": "@local.activity_title"
+              },
+              {
+                "type": "image",
+                "name": "banner_image_src",
+                "value": "@local.activity_image",
+                "parameter_list": {
+                  "background_box": "true"
+                }
+              }
+            ]
+          },
+          {
+            "type": "template",
+            "name": "content_box",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_content",
+                  "true"
+                ],
+                "_raw": "completed | set_local:hide_content:true",
+                "_cleaned": "completed | set_local:hide_content:true"
+              },
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_outro",
+                  "false"
+                ],
+                "_raw": "completed | set_local:hide_outro:false",
+                "_cleaned": "completed | set_local:hide_outro:false"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_intro",
+                  "false"
+                ],
+                "_raw": "uncompleted | set_local:hide_intro:false",
+                "_cleaned": "uncompleted | set_local:hide_intro:false"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_content",
+                  "true"
+                ],
+                "_raw": "uncompleted | set_local:hide_content:true",
+                "_cleaned": "uncompleted | set_local:hide_content:true"
+              }
+            ],
+            "hidden": "!@local.include_outro",
+            "comments": "Do this row when include_outro = TRUE\n!@local.include_outro",
+            "rows": []
+          },
+          {
+            "type": "template",
+            "name": "content_box",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "emit",
+                "args": [
+                  "completed"
+                ],
+                "_raw": "completed | emit:completed",
+                "_cleaned": "completed | emit:completed"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_intro",
+                  "false"
+                ],
+                "_raw": "uncompleted | set_local:hide_intro:false",
+                "_cleaned": "uncompleted | set_local:hide_intro:false"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_content",
+                  "true"
+                ],
+                "_raw": "uncompleted | set_local:hide_content:true",
+                "_cleaned": "uncompleted | set_local:hide_content:true"
+              }
+            ],
+            "hidden": "@local.include_outro",
+            "comments": "Do this row when include_outro = FALSE\n@local.include_outro",
+            "rows": []
+          }
+        ]
+      },
+      {
+        "type": "animated_section",
+        "name": "outro",
+        "hidden": "@local.hide_outro",
+        "rows": [
+          {
+            "type": "image",
+            "name": "outro_image_src",
+            "value": "@local.activity_image",
+            "parameter_list": {
+              "background_box": "true"
+            }
+          },
+          {
+            "type": "title",
+            "name": "outro_title",
+            "value": "@local.activity_title",
+            "hidden": "true"
+          },
+          {
+            "type": "text",
+            "name": "outro_text"
+          },
+          {
+            "type": "button",
+            "name": "outro_button",
+            "hidden": "true"
+          },
+          {
+            "type": "text",
+            "name": "outro_habit_text",
+            "parameter_list": {
+              "alert": "plh_images/icons/star_circle.svg"
+            }
+          },
+          {
+            "type": "template",
+            "name": "outro_nav_buttons",
+            "value": "nav_buttons",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "emit",
+                "args": [
+                  "completed"
+                ],
+                "_raw": "completed | emit:completed",
+                "_cleaned": "completed | emit:completed"
+              }
+            ],
+            "rows": []
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "nav_buttons",
+    "status": "released",
+    "rows": [
+      {
+        "type": "display_group",
+        "rows": [
+          {
+            "type": "button",
+            "name": "button_info",
+            "value": "@global.ideas_button",
+            "hidden": "true",
+            "parameter_list": {
+              "colour": "secondary"
+            }
+          },
+          {
+            "type": "button",
+            "name": "button_completed",
+            "value": "Done!",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "emit",
+                "args": [
+                  "completed"
+                ],
+                "_raw": "click | emit:completed",
+                "_cleaned": "click | emit:completed"
+              }
+            ]
+          },
+          {
+            "type": "button",
+            "name": "button_uncompleted",
+            "value": "Back",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "emit",
+                "args": [
+                  "uncompleted"
+                ],
+                "_raw": "click | emit:uncompleted",
+                "_cleaned": "click | emit:uncompleted"
+              }
+            ],
+            "hidden": "true"
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "pair",
+    "status": "released",
+    "rows": [
+      {
+        "name": "hide_animated_section_1",
+        "value": "false",
+        "type": "set_variable"
+      },
+      {
+        "name": "hide_animated_section_2",
+        "value": "true",
+        "type": "set_variable"
+      },
+      {
+        "type": "animated_section",
+        "name": "animated_section_1",
+        "hidden": "@local.hide_animated_section_1",
+        "rows": [
+          {
+            "type": "template",
+            "name": "box_1",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_animated_section_1",
+                  "true"
+                ],
+                "_raw": "completed | set_local:hide_animated_section_1:true",
+                "_cleaned": "completed | set_local:hide_animated_section_1:true"
+              },
+              {
+                "trigger": "completed",
+                "action_id": "set_local",
+                "args": [
+                  "hide_animated_section_2",
+                  "false"
+                ],
+                "_raw": "completed | set_local:hide_animated_section_2:false",
+                "_cleaned": "completed | set_local:hide_animated_section_2:false"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "emit",
+                "args": [
+                  "uncompleted"
+                ],
+                "_raw": "uncompleted | emit:uncompleted",
+                "_cleaned": "uncompleted | emit:uncompleted"
+              }
+            ],
+            "rows": []
+          }
+        ]
+      },
+      {
+        "type": "animated_section",
+        "name": "animated_section_2",
+        "hidden": "@local.hide_animated_section_2",
+        "rows": [
+          {
+            "type": "template",
+            "name": "box_2",
+            "action_list": [
+              {
+                "trigger": "completed",
+                "action_id": "emit",
+                "args": [
+                  "completed"
+                ],
+                "_raw": "completed | emit:completed",
+                "_cleaned": "completed | emit:completed"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_animated_section_1",
+                  "false"
+                ],
+                "_raw": "uncompleted | set_local:hide_animated_section_1:false",
+                "_cleaned": "uncompleted | set_local:hide_animated_section_1:false"
+              },
+              {
+                "trigger": "uncompleted",
+                "action_id": "set_local",
+                "args": [
+                  "hide_animated_section_2",
+                  "true"
+                ],
+                "_raw": "uncompleted  | set_local:hide_animated_section_2:true",
+                "_cleaned": "uncompleted  | set_local:hide_animated_section_2:true"
+              }
+            ],
+            "rows": []
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/core_templates/core_templates_workshops.xlsx"
   },
   {
     "flow_type": "template",
@@ -2159,7 +2155,7 @@
                       {
                         "type": "set_variable",
                         "name": "audio_title",
-                        "value": "Hear Sbo's story"
+                        "value": "Hear Sbo's message"
                       }
                     ]
                   }
@@ -3845,6 +3841,23 @@
   },
   {
     "flow_type": "template",
+    "flow_name": "suggestions",
+    "status": "released",
+    "rows": [
+      {
+        "type": "text",
+        "name": "description_text",
+        "value": "Ideas from other families:"
+      },
+      {
+        "type": "text",
+        "name": "list_text"
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/mode_templates/talk_together.xlsx"
+  },
+  {
+    "flow_type": "template",
     "flow_name": "welcome_individual",
     "status": "released",
     "rows": [
@@ -4232,6 +4245,49 @@
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/mode_templates/welcome.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "debug_go_to_nest_top",
+    "status": "released",
+    "rows": [
+      {
+        "type": "text",
+        "name": "text",
+        "value": "This text is followed by the template debug_go_to_nest_bottom"
+      },
+      {
+        "type": "template",
+        "name": "name_debug_go_to_nest_bottom",
+        "value": "debug_go_to_nest_bottom",
+        "rows": []
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/debug_templates/debug_go_to_nested.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "debug_go_to_nest_bottom",
+    "status": "released",
+    "rows": [
+      {
+        "type": "button",
+        "name": "button",
+        "value": "Go to example_emit and come back",
+        "action_list": [
+          {
+            "trigger": "click",
+            "action_id": "go_to",
+            "args": [
+              "example_emit"
+            ],
+            "_raw": "click | go_to:example_emit",
+            "_cleaned": "click | go_to:example_emit"
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/debug_templates/debug_go_to_nested.xlsx"
   },
   {
     "flow_type": "template",
@@ -4871,12 +4927,20 @@
       {
         "type": "text",
         "name": "text",
-        "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ",
+        "parameter_list": {
+          "style": "standart primary",
+          "text_align": "center"
+        }
       },
       {
         "type": "text",
         "name": "text_2",
-        "value": "This is the first line in first 'paragraph'.\nThis is the second line in first 'paragraph'.\n\nThis is the second 'paragraph'."
+        "value": "This is the first line in first 'paragraph'.\nThis is the second line in first 'paragraph'.\n",
+        "parameter_list": {
+          "style": "small",
+          "text_align": "left"
+        }
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/debug_templates/debug_small_issues.xlsx"
@@ -5333,19 +5397,19 @@
         "type": "text",
         "name": "text_option_1",
         "value": "This is the text to show if option 1 is selected",
-        "hidden": "@local.option_buttons==\"name_var_1\""
+        "hidden": "\"@local.option_buttons\"==\"name_var_1\""
       },
       {
         "type": "text",
         "name": "text_option_2",
         "value": "This is the text to show if option 2 is selected",
-        "hidden": "@local.option_buttons==\"name_var_2\""
+        "hidden": "\"@local.option_buttons\"==\"name_var_2\""
       },
       {
         "type": "text",
         "name": "text_option_3",
         "value": "This is the text to show if option 3 is selected",
-        "hidden": "@local.option_buttons==\"name_var_3\""
+        "hidden": "\"@local.option_buttons\"==\"name_var_3\""
       },
       {
         "name": "output_fieldname",
@@ -6512,7 +6576,6 @@
       {
         "type": "text_box",
         "name": "text_box",
-        "action_list": [],
         "parameter_list": {
           "blank_display_text": "@local.blank_display_text",
           "help": "some help text"
@@ -7608,6 +7671,11 @@
               "margin-top: 15px",
               "max-width: 320px"
             ]
+          },
+          {
+            "type": "button",
+            "name": "bt_1",
+            "value": "Button"
           }
         ]
       },
@@ -8080,8 +8148,18 @@
                   },
                   {
                     "name": "button",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "pop_up",
+                        "args": [
+                          "w_1on1_talk_pop"
+                        ],
+                        "_raw": "click | pop_up:w_1on1_talk_pop",
+                        "_cleaned": "click | pop_up:w_1on1_talk_pop"
+                      }
+                    ],
                     "hidden": "false",
-                    "comments": "Ideas from other families:\n(-) Walking to the shops\n(-) Get water together \n(-) Doing a chore together \n(-) Prepare dinner \n(-) Eat breakfast/lunch/dinner \n(-) Have tea after school \n(-) Watch a T.V. show  \n(-) Review homework \n(-) Chat before bedtime \n(-) Play a game/sport ",
                     "type": "set_variable"
                   }
                 ]
@@ -8097,6 +8175,27 @@
                 "type": "set_variable"
               }
             ]
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_1on1.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "module": "1on1",
+    "flow_name": "w_1on1_talk_pop",
+    "status": "released",
+    "rows": [
+      {
+        "type": "template",
+        "name": "suggestions",
+        "value": "suggestions",
+        "rows": [
+          {
+            "name": "list_text",
+            "value": "(-) Walking to the shops\n(-) Get water together \n(-) Doing a chore together \n(-) Prepare dinner \n(-) Eat breakfast/lunch/dinner \n(-) Have tea after school \n(-) Watch a T.V. show  \n(-) Review homework \n(-) Chat before bedtime \n(-) Play a game/sport ",
+            "type": "set_variable"
           }
         ]
       }
@@ -8163,9 +8262,18 @@
                     "rows": [
                       {
                         "name": "button_info",
-                        "value": "Examples",
+                        "action_list": [
+                          {
+                            "trigger": "click",
+                            "action_id": "pop_up",
+                            "args": [
+                              "w_1on1_talk_pop"
+                            ],
+                            "_raw": "click | pop_up:w_1on1_talk_pop",
+                            "_cleaned": "click | pop_up:w_1on1_talk_pop"
+                          }
+                        ],
                         "hidden": "false",
-                        "comments": "Same list as in w_1on1_talk",
                         "type": "set_variable"
                       }
                     ]
@@ -8372,12 +8480,33 @@
                   {
                     "name": "button_1",
                     "value": "@global.ideas_button",
-                    "comments": "Same examples as in w_1on1_talk",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "pop_up",
+                        "args": [
+                          "w_1on1_talk_pop"
+                        ],
+                        "_raw": "click | pop_up:w_1on1_talk_pop",
+                        "_cleaned": "click | pop_up:w_1on1_talk_pop"
+                      }
+                    ],
                     "type": "set_variable"
                   },
                   {
                     "name": "button_2",
                     "value": "@global.essential_tools",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "go_to",
+                        "args": [
+                          "w_1on1_tools_activity"
+                        ],
+                        "_raw": "click | go_to:w_1on1_tools_activity",
+                        "_cleaned": "click | go_to:w_1on1_tools_activity"
+                      }
+                    ],
                     "hidden": "false",
                     "type": "set_variable"
                   },
@@ -8819,13 +8948,13 @@
                   },
                   {
                     "name": "intro_text",
-                    "value": "You have done it! You have built 11 important parenting skills - and you will see the difference!  \n\nLet’s celebrate you, and plan your future parenting support.",
+                    "value": "CONGRATULATIONS! You have done it! You have built 11 important parenting skills. \n\nThis is a huge achievement. It shows such care for your family. \n\nLet’s celebrate you, and plan your future parenting support.",
                     "hidden": "!@field.do_workshops_together",
                     "type": "set_variable"
                   },
                   {
                     "name": "intro_text",
-                    "value": "You have done it! You have built 11 important parenting skills - and you will see the difference!  \n\nLet’s celebrate you, and plan your future ParentApp support.",
+                    "value": "CONGRATULATIONS! You have done it! You have built 11 important parenting skills. \n\nThis is a huge achievement. It shows such care for your family. \n\nLet’s celebrate you, and plan your future ParentApp support.",
                     "hidden": "@field.do_workshops_together",
                     "type": "set_variable"
                   }
@@ -8871,17 +9000,44 @@
               },
               {
                 "name": "intro_text",
-                "value": "CONGRATULATIONS! You have successfully completed the course. This is a huge achievement. It shows such care for your family.",
+                "value": "You and your family have learnt so much. Let's think back and see what has changed.",
                 "type": "set_variable"
               },
               {
                 "type": "nested_properties",
                 "name": "content_box",
+                "value": "pair",
                 "rows": [
                   {
-                    "name": "text",
-                    "value": "Discuss what has changed over this time:\n\n(-) What has changed in your family?\n(-) What are you proud of that you have done?\n\nRemember to praise and encourage each other!",
-                    "type": "set_variable"
+                    "type": "nested_properties",
+                    "name": "box_1",
+                    "value": "box_audio",
+                    "rows": [
+                      {
+                        "type": "nested_properties",
+                        "name": "widget_audio",
+                        "rows": [
+                          {
+                            "name": "audio_title",
+                            "value": "Reflect with Sbo",
+                            "comments": "Users may need some time to reflect themselves before sharing:\n\n- Close eyes and relax\n- Recall family life before ParentApp\n- Summary of workshop topics\n- Reflect on key experiences (discussions, looking at comics, sharing experiences, practicing skills)\n- Reflect on changes in self & family\n- Consider how to continue to use new skills",
+                            "type": "set_variable"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "nested_properties",
+                    "name": "box_2",
+                    "value": "box_image",
+                    "rows": [
+                      {
+                        "name": "text",
+                        "value": "Discuss together:\n\n(-) What has changed in your family?\n(-) What are you proud of that you have done?\n\nRemember to praise and encourage each other!",
+                        "type": "set_variable"
+                      }
+                    ]
                   }
                 ]
               }
@@ -8992,23 +9148,52 @@
                       {
                         "type": "nested_properties",
                         "name": "box_2",
-                        "value": "box_image",
+                        "value": "pair",
                         "rows": [
                           {
-                            "name": "image_src",
-                            "value": "plh_images/workshops/celebrate/read/slide_3.svg",
-                            "type": "set_variable"
+                            "type": "nested_properties",
+                            "name": "box_1",
+                            "value": "box_image_more",
+                            "rows": [
+                              {
+                                "name": "image_src",
+                                "value": "plh_images/workshops/celebrate/read/slide_3.svg",
+                                "type": "set_variable"
+                              },
+                              {
+                                "name": "title",
+                                "value": "Idea 3",
+                                "hidden": "false",
+                                "type": "set_variable"
+                              },
+                              {
+                                "name": "text",
+                                "value": "Text each other every week to share what you’ve done well.",
+                                "type": "set_variable"
+                              }
+                            ]
                           },
                           {
-                            "name": "title",
-                            "value": "Idea 3",
-                            "hidden": "false",
-                            "type": "set_variable"
-                          },
-                          {
-                            "name": "text",
-                            "value": "Text each other every week to share what you’ve done well.",
-                            "type": "set_variable"
+                            "type": "nested_properties",
+                            "name": "box_2",
+                            "value": "box_image",
+                            "rows": [
+                              {
+                                "name": "image_src",
+                                "type": "set_variable"
+                              },
+                              {
+                                "name": "title",
+                                "value": "Idea 4",
+                                "hidden": "false",
+                                "type": "set_variable"
+                              },
+                              {
+                                "name": "text",
+                                "value": "Share @global.parent_app and help other families start their journey.",
+                                "type": "set_variable"
+                              }
+                            ]
                           }
                         ]
                       }
@@ -11218,7 +11403,7 @@
           },
           {
             "name": "top_text",
-            "value": "Our first response to crisis is anger because we are afraid. But this is when our teens really need us to breathe, listen and think.",
+            "value": "Crisis can make us feel angry or helpless. But this is when our teens really need us to breathe, listen and think.",
             "hidden": "false",
             "type": "set_variable"
           },
@@ -11384,18 +11569,18 @@
                     "rows": [
                       {
                         "name": "image_src",
-                        "value": "plh_images/workshops/crisis/learn/slide_1.svg",
+                        "value": "plh_images/workshops/crisis/learn/slide_5.svg",
                         "type": "set_variable"
                       },
                       {
                         "name": "title",
-                        "value": "Crisis 1: @global.w_crisis_teen_girl_1 gets pregnant",
+                        "value": "Crisis 1: @global.w_crisis_teen_boy_2 fights at school ",
                         "hidden": "false",
                         "type": "set_variable"
                       },
                       {
                         "name": "text",
-                        "value": "\"@global.w_crisis_male_caregiver_1, I’m so ashamed. I don’t know what to do\"\n\nHow could you respond to @global.w_crisis_teen_girl_1?",
+                        "value": "\"I’ve never done this before. And now they will expel me\"\n\nHow could you respond to @global.w_crisis_teen_boy_2? ",
                         "comments": "Last sentence needs different formatting.",
                         "type": "set_variable"
                       }
@@ -11413,18 +11598,18 @@
                         "rows": [
                           {
                             "name": "image_src",
-                            "value": "plh_images/workshops/crisis/learn/slide_2.svg",
+                            "value": "plh_images/workshops/crisis/learn/slide_1.svg",
                             "type": "set_variable"
                           },
                           {
                             "name": "title",
-                            "value": "Crisis 2: @global.w_crisis_teen_boy_2 makes a girl pregnant",
+                            "value": "Crisis 2: @global.w_crisis_teen_girl_1 gets pregnant",
                             "hidden": "false",
                             "type": "set_variable"
                           },
                           {
                             "name": "text",
-                            "value": "\"@global.w_crisis_male_caregiver_2, I don’t want to have a baby\"\n\nHow could you respond to @global.w_crisis_teen_boy_2?",
+                            "value": "\"@global.w_crisis_male_caregiver_1, I’m so ashamed. I don’t know what to do\"\n\nHow could you respond to @global.w_crisis_teen_girl_1?",
                             "type": "set_variable"
                           }
                         ]
@@ -11441,18 +11626,18 @@
                             "rows": [
                               {
                                 "name": "image_src",
-                                "value": "plh_images/workshops/crisis/learn/slide_3.svg",
+                                "value": "plh_images/workshops/crisis/learn/slide_2.svg",
                                 "type": "set_variable"
                               },
                               {
                                 "name": "title",
-                                "value": "Crisis 3: Someone in the family gets sick ",
+                                "value": "Crisis 3: @global.w_crisis_teen_boy_2 makes a girl pregnant",
                                 "hidden": "false",
                                 "type": "set_variable"
                               },
                               {
                                 "name": "text",
-                                "value": "\"The test said I have caught HIV. I’m scared I’m going to die\"\n\nHow could you respond in this situation? ",
+                                "value": "\"@global.w_crisis_male_caregiver_2, I don’t want to have a baby\"\n\nHow could you respond to @global.w_crisis_teen_boy_2?",
                                 "type": "set_variable"
                               }
                             ]
@@ -11469,18 +11654,18 @@
                                 "rows": [
                                   {
                                     "name": "image_src",
-                                    "value": "plh_images/workshops/crisis/learn/slide_4.svg",
+                                    "value": "plh_images/workshops/crisis/learn/slide_3.svg",
                                     "type": "set_variable"
                                   },
                                   {
                                     "name": "title",
-                                    "value": "Crisis 4: @global.w_crisis_teen_girl_1 is attacked by her boyfriend",
+                                    "value": "Crisis 4: Someone in the family gets sick ",
                                     "hidden": "false",
                                     "type": "set_variable"
                                   },
                                   {
                                     "name": "text",
-                                    "value": "\"I didn’t really want to, but I’m scared I’ll get pregnant or be ill. @global.w_crisis_female_caregiver, I’m so scared...\"\n\nHow could you respond to @global.w_crisis_teen_girl_1?",
+                                    "value": "\"The test said I have caught HIV. I’m scared I’m going to die\"\n\nHow could you respond in this situation? ",
                                     "type": "set_variable"
                                   }
                                 ]
@@ -11492,18 +11677,18 @@
                                 "rows": [
                                   {
                                     "name": "image_src",
-                                    "value": "plh_images/workshops/crisis/learn/slide_5.svg",
+                                    "value": "plh_images/workshops/crisis/learn/slide_4.svg",
                                     "type": "set_variable"
                                   },
                                   {
                                     "name": "title",
-                                    "value": "Crisis 5: @global.w_crisis_teen_boy_2 cheats at school ",
+                                    "value": "Crisis 5: @global.w_crisis_teen_girl_1 is pressured into sex by her boyfriend",
                                     "hidden": "false",
                                     "type": "set_variable"
                                   },
                                   {
                                     "name": "text",
-                                    "value": "\"I’ve never done this before. And now they will expel me\"\n\nHow could you respond to @global.w_crisis_teen_boy_2? ",
+                                    "value": "\"I didn’t really want to. Now I will get pregnant or be ill. @global.w_crisis_female_caregiver, I’m so scared...\"\n\nHow could you respond to @global.w_crisis_teen_girl_1?",
                                     "type": "set_variable"
                                   }
                                 ]
@@ -11626,8 +11811,9 @@
                 "rows": [
                   {
                     "name": "intro_text",
-                    "value": "You’ve completed this week’s workshop. \n\nNext week’s workshop will celebrate you all, and plan support for everyone going forward. \n\nWhy don’t you plan some party food together, and have some music ready if you like to dance!",
+                    "value": "You’ve completed this week’s workshop. \n\nNext week’s workshop will celebrate you all, and help you plan for the future. \n\nWhy don’t you plan some party food together, and have some music ready if you like to dance!",
                     "hidden": "!@field.do_workshops_together",
+                    "comments": "ETW to check ",
                     "type": "set_variable"
                   },
                   {
@@ -17376,15 +17562,6 @@
         "rows": [
           {
             "name": "nav_template_list",
-            "value": [
-              "w_self_care_welcome_individual",
-              "w_self_care_intro",
-              "w_self_care_recognise",
-              "w_self_care_reward",
-              "w_self_care_tools_activity",
-              "w_self_care_home_practice",
-              "w_self_care_ending"
-            ],
             "comments": "w_self_care_welcome_individual; w_self_care_intro; w_self_care_relax; w_self_care_recognise; w_self_care_reward;  w_self_care_tools_activity; w_self_care_survey_activity; w_self_care_home_practice; w_self_care_ending",
             "type": "set_variable"
           }
@@ -17631,8 +17808,18 @@
                     "rows": [
                       {
                         "name": "button_info",
+                        "action_list": [
+                          {
+                            "trigger": "click",
+                            "action_id": "pop_up",
+                            "args": [
+                              "w_self_care_recognise_pop"
+                            ],
+                            "_raw": "click | pop_up:w_self_care_recognise_pop",
+                            "_cleaned": "click | pop_up:w_self_care_recognise_pop"
+                          }
+                        ],
                         "hidden": "false",
-                        "comments": "Things to praise yourself for:\n(-) Showing love to my children \n(-) Getting up even though I felt tired \n(-) Smiling at someone \n(-) Making food to stay strong \n(-) Spending time with my children \n(-) Helping my children with schoolwork",
                         "type": "set_variable"
                       }
                     ]
@@ -17651,6 +17838,31 @@
                 "type": "set_variable"
               }
             ]
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_self_care.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "w_self_care_recognise_pop",
+    "status": "released",
+    "rows": [
+      {
+        "type": "template",
+        "name": "suggestions",
+        "value": "suggestions",
+        "rows": [
+          {
+            "name": "description_text",
+            "value": "Things to praise yourself for:",
+            "type": "set_variable"
+          },
+          {
+            "name": "list_text",
+            "value": "(-) Showing love to your children \n(-) Getting up even though you felt tired \n(-) Smiling at someone \n(-) Making food to stay strong \n(-) Spending time with your children \n(-) Helping your children with schoolwork",
+            "type": "set_variable"
           }
         ]
       }
@@ -17713,8 +17925,18 @@
                     "rows": [
                       {
                         "name": "button_info",
+                        "action_list": [
+                          {
+                            "trigger": "click",
+                            "action_id": "pop_up",
+                            "args": [
+                              "w_self_care_reward_pop"
+                            ],
+                            "_raw": "click | pop_up:w_self_care_reward_pop",
+                            "_cleaned": "click | pop_up:w_self_care_reward_pop"
+                          }
+                        ],
                         "hidden": "false",
-                        "comments": "(-) Have a hot drink \n(-) Call a friend or family \n(-) Have a relaxed bath \n(-) Read \n(-) Watch TV",
                         "type": "set_variable"
                       }
                     ]
@@ -17733,6 +17955,31 @@
                 "type": "set_variable"
               }
             ]
+          }
+        ]
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_self_care.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "w_self_care_reward_pop",
+    "status": "released",
+    "rows": [
+      {
+        "type": "template",
+        "name": "suggestions",
+        "value": "suggestions",
+        "rows": [
+          {
+            "name": "description_text",
+            "value": "Things you can do to reward yourself:",
+            "type": "set_variable"
+          },
+          {
+            "name": "list_text",
+            "value": "(-) Have a hot drink \n(-) Call a friend or family \n(-) Have a relaxed bath \n(-) Read \n(-) Watch TV",
+            "type": "set_variable"
           }
         ]
       }
@@ -17782,6 +18029,17 @@
               {
                 "name": "button_1",
                 "value": "Relax activity",
+                "action_list": [
+                  {
+                    "trigger": "click",
+                    "action_id": "go_to",
+                    "args": [
+                      "w_self_care_relax"
+                    ],
+                    "_raw": "click | go_to:w_self_care_relax",
+                    "_cleaned": "click | go_to:w_self_care_relax"
+                  }
+                ],
                 "hidden": "false",
                 "comments": "placeholder",
                 "type": "set_variable"
@@ -17805,6 +18063,17 @@
               {
                 "name": "button_1",
                 "value": "Recognise activity",
+                "action_list": [
+                  {
+                    "trigger": "click",
+                    "action_id": "go_to",
+                    "args": [
+                      "w_self_care_recognise"
+                    ],
+                    "_raw": "click | go_to:w_self_care_recognise",
+                    "_cleaned": "click | go_to:w_self_care_recognise"
+                  }
+                ],
                 "hidden": "false",
                 "comments": "placeholder",
                 "type": "set_variable"
@@ -17828,6 +18097,17 @@
               {
                 "name": "button_1",
                 "value": "Reward activity",
+                "action_list": [
+                  {
+                    "trigger": "click",
+                    "action_id": "go_to",
+                    "args": [
+                      "w_self_care_reward"
+                    ],
+                    "_raw": "click | go_to:w_self_care_reward",
+                    "_cleaned": "click | go_to:w_self_care_reward"
+                  }
+                ],
                 "hidden": "false",
                 "comments": "placeholder",
                 "type": "set_variable"
@@ -17915,6 +18195,17 @@
                   {
                     "name": "button_1",
                     "value": "Relax activity",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "go_to",
+                        "args": [
+                          "w_self_care_relax"
+                        ],
+                        "_raw": "click | go_to:w_self_care_relax",
+                        "_cleaned": "click | go_to:w_self_care_relax"
+                      }
+                    ],
                     "hidden": "false",
                     "comments": "placeholder",
                     "type": "set_variable"
@@ -17922,6 +18213,17 @@
                   {
                     "name": "button_2",
                     "value": "Recognise activity",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "go_to",
+                        "args": [
+                          "w_self_care_recognise"
+                        ],
+                        "_raw": "click | go_to:w_self_care_recognise",
+                        "_cleaned": "click | go_to:w_self_care_recognise"
+                      }
+                    ],
                     "hidden": "false",
                     "comments": "placeholder",
                     "type": "set_variable"
@@ -17929,6 +18231,17 @@
                   {
                     "name": "button_3",
                     "value": "Reward activity",
+                    "action_list": [
+                      {
+                        "trigger": "click",
+                        "action_id": "go_to",
+                        "args": [
+                          "w_self_care_reward"
+                        ],
+                        "_raw": "click | go_to:w_self_care_reward",
+                        "_cleaned": "click | go_to:w_self_care_reward"
+                      }
+                    ],
                     "hidden": "false",
                     "comments": "placeholder",
                     "type": "set_variable"


### PR DESCRIPTION
- Fix nested template goto
- content sync for testing
- Actually go back to root template.

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Fixes bug where a embedding a template that contains a goto, would not go back to the correct template after clicking the go back (emit completed or uncompleted) buttons.

Example of template that reproduces this bug: template/debug_go_to_nest_top

## Git Issues

_Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
