### PR TITLE
Condition stops nested property assignment

### DIFF
--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -226,6 +226,11 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   ): ILocalVariables {
     templateRows.forEach((r) => {
       let { name, value, rows, type } = r;
+      if (r.condition) {
+        if (!this.filterRowOnCondition(r, localvariables)) {
+          return;
+        }
+      }
       // TODO - set_variable / set_nested_properties should have consistent naming
       // set_variable is actually setting the _value field, so should be called accordingly
       if (type === "set_variable" || type === "set_local" || type === "nested_properties") {


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Makes sure that condition column prevents a nested property from being set when the condition value returns false.

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
