### PR TITLE
Added the condition column to the js evaluation and fixed a bug with …

### DIFF
--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -6068,12 +6068,17 @@
     "rows": [
       {
         "name": "var_1",
-        "value": "val_1",
+        "value": "\"val_1\"",
         "type": "set_variable"
       },
       {
         "name": "var_2",
         "value": "true",
+        "type": "set_variable"
+      },
+      {
+        "name": "var_3",
+        "value": 5,
         "type": "set_variable"
       },
       {
@@ -6084,7 +6089,7 @@
           {
             "name": "text",
             "value": "The condition is not satisfied",
-            "hidden": "1>0",
+            "condition": "@local.var_1==\"val_2\"",
             "type": "set_variable"
           },
           {
@@ -6103,13 +6108,13 @@
           {
             "name": "text",
             "value": "The condition is satisfied",
-            "condition": "@local.var_1==\"val_1\"",
+            "condition": "@local.var_3<9",
             "type": "set_variable"
           },
           {
             "name": "text",
             "value": "The condition is not satisfied",
-            "condition": "@local.var_1==\"val_2\"",
+            "condition": "@local.var_3>9",
             "type": "set_variable"
           }
         ]


### PR DESCRIPTION
…nesting variables for conditional evaluation

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

PR adds js evaluation to the hidden column and fixes a problem with nested variables within the js conditional evaluation. See example condition spreadsheet, template [example_condition_top_1](https://docs.google.com/spreadsheets/d/1ZhrwgryqYKtj-HQvl7rYNgR07EGZKBcAwsSABGVb_sk/edit#gid=1694318910&range=A1): outcome should be four lines of text saying 'The condition is satisfied'.