### PR TITLE
Temporary solution to issue 25 in QA Feedback spreadsheet. Creates a …

### DIFF
--- a/src/app/shared/components/template/components/radio-group/radio-group.component.html
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.html
@@ -14,7 +14,7 @@
             [value]="item.name"
             [checked]="el.value === value"
             (click)="setValue(el.value)"
-            [name]="_row.name"
+            [name]="groupName"
           />
           {{ item.text }}
         </label>
@@ -39,7 +39,7 @@
             [value]="item.name"
             [checked]="el.value === value"
             (click)="setValue(el.value)"
-            [name]="_row.name"
+            [name]="groupName"
           />
           {{ item.text }}
         </label>
@@ -61,7 +61,7 @@
             [value]="item.name"
             [checked]="el.value === value"
             (click)="setValue(el.value)"
-            [name]="_row.name"
+            [name]="groupName"
           />
           <span> {{ item.text }} </span>
         </label>

--- a/src/app/shared/components/template/components/radio-group/radio-group.component.ts
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.ts
@@ -36,6 +36,7 @@ export class TmplRadioGroupComponent
   radioBtnList: any;
   valuesFromBtnList;
   arrayOfBtn: Array<IButton>;
+  groupName: string;
   radioButtonType: string | null;
   options_per_row: number = 2;
   baseSrcAssets = "/assets/plh_assets/";
@@ -87,6 +88,13 @@ export class TmplRadioGroupComponent
       this.createArrayBtnElement();
     }
     this.getFlexWidth();
+    // Temporary fix to give appropriate group names to radiobutton
+    // was previously _row.name
+    // but this is incorrect because of template nesting meaning these names are
+    // not unique on a page
+    // not sure what the correct implementation should be. It could be the
+    // full name with template stack, a counter on the row name or a unique random id
+    this.groupName = Math.random().toString();
   }
 
   createArrayBtnElement() {


### PR DESCRIPTION
…group name for buttons randomly.

PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

PR  temporarily fixes issue #25 in QA spreadsheet.  It gives appropriate group names to radiobutton. It was previously _row.name but this is incorrect because of template nesting meaning these names are not unique on a page not sure what the correct implementation should be. It could be the full name with template stack, a counter on the row name or a unique random id
