### PR TITLE
feat: default center styles for components

### DIFF
--- a/src/app/shared/components/template/components/audio/audio.component.scss
+++ b/src/app/shared/components/template/components/audio/audio.component.scss
@@ -9,6 +9,7 @@
   display: flex;
   position: relative;
   flex-direction: column;
+  margin: var(--regular-padding);
   .top-row {
     display: flex;
     justify-content: space-between;

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -1,3 +1,6 @@
+:host {
+  width: 100%;
+}
 ion-button {
   font-size: 25px;
   font-family: Roboto, sans-serif;
@@ -5,16 +8,21 @@ ion-button {
   color: #fff;
   text-transform: none;
   white-space: pre-line;
-  padding: 5px 0;
+  padding: var(--regular-padding);
   min-height: 70px;
-  max-width: calc(100% - 4px);
   min-width: 59px;
+  height: auto;
   --border-radius: 15px;
   --box-shadow: var(--ion-btn-dark-box-shadow);
   display: flex;
   width: fit-content;
   margin: 0 auto;
 }
+
+ion-button::part(native) {
+  height: auto;
+}
+
 ion-button:disabled,
 ion-button[disabled] {
   filter: brightness(55%);

--- a/src/app/shared/components/template/components/image.ts
+++ b/src/app/shared/components/template/components/image.ts
@@ -12,6 +12,13 @@ import { getStringParamFromTemplateRow } from "../../../utils";
     </div>
   `,
   styleUrls: ["./tmpl-components-common.scss"],
+  styles: [
+    `
+      :host {
+        width: 100%;
+      }
+    `,
+  ],
 })
 export class TmplImageComponent extends TemplateBaseComponent implements OnInit {
   assetsPrefix = "/assets/plh_assets/";

--- a/src/app/shared/components/template/components/layout/animated_section.ts
+++ b/src/app/shared/components/template/components/layout/animated_section.ts
@@ -10,5 +10,12 @@ import { TemplateBaseComponent } from "../base";
       [parent]="parent"
     ></plh-template-component>
   </div>`,
+  styles: [
+    `
+      :host {
+        width: 100%;
+      }
+    `,
+  ],
 })
 export class AnimatedSectionComponent extends TemplateBaseComponent {}

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -22,6 +22,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
   styles: [
     `
       :host {
+        width: 100%;
         border-radius: 20px;
       }
     `,

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -28,6 +28,9 @@ import { TemplateLayoutComponent } from "./layout";
   </div>`,
   styles: [
     `
+      :host {
+        width: 100%;
+      }
       .slide {
         width: 95vw;
       }
@@ -42,12 +45,14 @@ import { TemplateLayoutComponent } from "./layout";
       .nav-progress {
         display: flex;
         flex-direction: row;
-        justify-content: center;
+        justify-content: space-evenly;
+        gap: 5px;
+        padding: 10px;
       }
 
       .nav-progress-part {
         height: 5px;
-        flex-grow: 1;
+        flex: 1;
         background-color: var(--ion-primary-color, #0d3f60);
         margin: 10px;
         max-width: 40px;

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -54,7 +54,6 @@ import { TemplateLayoutComponent } from "./layout";
         height: 5px;
         flex: 1;
         background-color: var(--ion-primary-color, #0d3f60);
-        margin: 10px;
         max-width: 40px;
       }
 

--- a/src/app/shared/components/template/components/text-box/text-box.component.scss
+++ b/src/app/shared/components/template/components/text-box/text-box.component.scss
@@ -1,5 +1,5 @@
 .wrapper {
-  padding: 20px 0;
+  padding: 20px 5px;
   .text-box-input {
     background: #fff;
     border: 2px solid #096b8b;

--- a/src/app/shared/components/template/components/timer/timer.component.html
+++ b/src/app/shared/components/template/components/timer/timer.component.html
@@ -1,23 +1,38 @@
-<div class="round-container round-container-br-15">
+<div class="round-container wrapper-audio round-container-br-15">
   <div class="timer-row">
-    <h2 class="timer-title" >{{title}}</h2>
-  <ion-icon *ngIf="help" name="help-circle-outline" class="timer-help" [pTooltip]="help" tooltipPosition="right" tooltipEvent="click"></ion-icon>
+    <h2 class="timer-title">{{ title }}</h2>
+    <ion-icon
+      *ngIf="help"
+      name="help-circle-outline"
+      class="timer-help"
+      [pTooltip]="help"
+      tooltipPosition="right"
+      tooltipEvent="click"
+    ></ion-icon>
   </div>
   <div class="timer-content">
     <ion-button class="add-min" (click)="clickLeftButton()">
-      <img [src]="!timerStarted ? '/assets/icon/timer/play.svg' : '/assets/icon/timer/pause.svg'" alt="">
+      <img
+        [src]="!timerStarted ? '/assets/icon/timer/play.svg' : '/assets/icon/timer/pause.svg'"
+        alt=""
+      />
     </ion-button>
     <div class="timer-counter round-container round-container-br-15" (click)="openPicker()">
       <div #min>
-        {{minutes}}
+        {{ minutes }}
       </div>
       <div>:</div>
       <div #sec>
-        {{seconds}}
+        {{ seconds }}
       </div>
     </div>
-    <ion-button class="add-min"  (click)="clickRightButton()">
-      <img class="right-icon" [class.left-icon]="timerStarted" [src]="timerStarted ? '/assets/icon/timer/add-time.svg' : '/assets/icon/timer/repeat.svg'" alt="">
+    <ion-button class="add-min" (click)="clickRightButton()">
+      <img
+        class="right-icon"
+        [class.left-icon]="timerStarted"
+        [src]="timerStarted ? '/assets/icon/timer/add-time.svg' : '/assets/icon/timer/repeat.svg'"
+        alt=""
+      />
     </ion-button>
   </div>
 </div>

--- a/src/app/shared/components/template/components/timer/timer.component.scss
+++ b/src/app/shared/components/template/components/timer/timer.component.scss
@@ -1,56 +1,59 @@
 :host {
-    width: 363px;
-    min-height: 183px;
-    margin-top: 10px;
-    margin-bottom: 10px;
+  width: 363px;
+  min-height: 183px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 .timer-counter {
-    width: 200px;
-    height: 73px;
-    margin: 0 7px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    div{
-        font-weight: bold;
-        font-size: 40px;
-        color: #0D3F60;
-    }
+  width: 200px;
+  height: 73px;
+  margin: 0 7px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  div {
+    font-weight: bold;
+    font-size: 40px;
+    color: #0d3f60;
+  }
+}
+.wrapper-audio {
+  margin: var(--large-padding);
+  width: auto;
 }
 .timer-content {
-    display: flex;
-    margin-bottom: 22px;
-    justify-content: center;
+  display: flex;
+  margin-bottom: 22px;
+  justify-content: center;
 }
 .timer-title {
-   margin-left: 8px;
-    max-width: 298px;
-}   
+  margin-left: 8px;
+  max-width: 298px;
+}
 
 .timer-help {
-    margin-top: 15px;
-    margin-left: 10px;
-    color: #0D3F60;
-    height: 32px;
-    width: 32px;
+  margin-top: 15px;
+  margin-left: 10px;
+  color: #0d3f60;
+  height: 32px;
+  width: 32px;
 }
 
 .timer-row {
-    display: flex;
+  display: flex;
 }
-.add-min{
-    width: 64px;
-    height: 64px;
-    --background: #00A0CC;
-    --background-size: cover;
-    --border-radius: 50%;
-    --padding:0;
-    .right-icon{
-        max-width: none;
-        top: 0;
-    }
-    .left-icon{
-        margin-top: 8px;
-    }
+.add-min {
+  width: 64px;
+  height: 64px;
+  --background: #00a0cc;
+  --background-size: cover;
+  --border-radius: 50%;
+  --padding: 0;
+  .right-icon {
+    max-width: none;
+    top: 0;
+  }
+  .left-icon {
+    margin-top: 8px;
+  }
 }
-

--- a/src/app/shared/components/template/components/tmpl-components-common.scss
+++ b/src/app/shared/components/template/components/tmpl-components-common.scss
@@ -5,6 +5,9 @@
 .hidden {
   display: none;
 }
+:host .display-group .offset :nth-child(1n) {
+  width: 100%;
+}
 
 .display-group {
   display: flex;
@@ -16,40 +19,41 @@
     align-items: inherit;
     justify-content: inherit;
     flex-direction: inherit;
+    width: inherit;
   }
 }
 .tool_1 {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #f89b2d;
   border-radius: 20px;
 }
 .tool_2 {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #ff7a00;
   border-radius: 20px;
 }
 .tool_3 {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #0f8ab2;
   border-radius: 20px;
 }
 .tool_4 {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #096b8b;
   border-radius: 20px;
 }
 .tool_5 {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #0d3f60;
   border-radius: 20px;
 }
 .white_box {
-  padding: 0 15px;
+  padding: 15px;
   flex-direction: column;
   background: #fff;
   border: 2px solid #0d3f60;
@@ -57,20 +61,21 @@
 }
 
 .plh-tmpl-comp {
-  display: flex;
-  flex-direction: column;
+  display: inherit;
+  flex-direction: inherit;
   width: 100%;
-  justify-content: center;
+  justify-content: inherit;
+  align-items: inherit;
   .animated_section {
     display: flex;
   }
 }
 
 .tmpl-image-container {
-  width: calc(100% - 20px);
+  width: 100%;
   display: flex;
   justify-content: center;
-  margin: 10px;
+  padding: 10px;
 }
 
 .tmpl-video-container {
@@ -121,6 +126,7 @@ p {
 .title-wrapper {
   display: flex;
   align-items: center;
+  padding: var(--regular-padding);
   h1 {
     font-size: 25px;
     margin: 0;
@@ -154,6 +160,7 @@ p {
 .subtitle-wrapper {
   display: flex;
   align-items: center;
+  padding: var(--regular-padding);
   h2 {
     font-size: 20px;
     line-height: 22px;
@@ -236,4 +243,19 @@ p {
 }
 .whiteText {
   color: #fff;
+}
+:host {
+  plh-template-container {
+    width: 100%;
+  }
+}
+
+.plh-tmpl-comp[data-hidden="true"] {
+  display: none;
+}
+.plh-tmpl-comp[data-debug="true"] {
+  display: block;
+  border: 1px solid #c7c7c7;
+  padding: 2px;
+  margin: 2px;
 }

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -9,6 +9,8 @@ import {
   OnInit,
   ElementRef,
   AfterContentInit,
+  ViewEncapsulation,
+  HostBinding,
 } from "@angular/core";
 import { TEMPLATE_COMPONENT_MAPPING } from "./components";
 import { FlowTypes, ITemplateRowProps } from "./models";
@@ -51,6 +53,14 @@ export class TmplCompHostDirective {
     </div>
   `,
   styleUrls: ["./components/tmpl-components-common.scss", "./template-container.component.scss"],
+  encapsulation: ViewEncapsulation.None,
+  styles: [
+    `
+      :host :nth-child(1n) {
+        width: 100%;
+      }
+    `,
+  ],
 })
 export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRowProps {
   /**
@@ -60,6 +70,13 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   @Input() row: FlowTypes.TemplateRow;
   /** reference to parent template container */
   @Input() parent: TemplateContainerComponent;
+
+  @HostBinding("attr.data-hidden") get getAttrHidden() {
+    return this.row && this.row.hidden;
+  }
+  @HostBinding("attr.data-debug-hidden") get getAttrDat() {
+    return this.parent && this.parent.debugMode;
+  }
 
   styles: { [name: string]: any } = {};
 
@@ -83,7 +100,9 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
     // Depending on row type, either prepare instantiation of a nested template or a display component
     switch (row.type) {
       case "template":
-        return this.renderTemplateComponent(TemplateContainerComponent);
+        return this.row.hidden === "true"
+          ? null
+          : this.renderTemplateComponent(TemplateContainerComponent);
       default:
         const displayComponent = TEMPLATE_COMPONENT_MAPPING[row.type];
         if (displayComponent) {

--- a/src/app/shared/components/template/template-container.component.scss
+++ b/src/app/shared/components/template/template-container.component.scss
@@ -2,8 +2,12 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
+  width: 100%;
 }
-
+plh-template-container {
+  width: 100%;
+}
 .template-container {
   width: 100%;
   height: 100%;

--- a/src/global.scss
+++ b/src/global.scss
@@ -30,32 +30,40 @@
 @import "./theme/typography";
 @import "./theme/tooltip";
 .slide-up-modal {
-    .modal-wrapper {
-        max-width: 80%;
-        min-height: 200px;
-        height: auto;
-        display: flex;
-        margin: 40px;
-        border-radius: 40px;
-        box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.4);
-        animation-name: slide-up;
-        animation-iteration-count: 1;
-        animation-duration: 0.4s;
-        position: relative;
-        transform: rotate(-60deg);
-    }
+  .modal-wrapper {
+    max-width: 80%;
+    min-height: 200px;
+    height: auto;
+    display: flex;
+    margin: 40px;
+    border-radius: 40px;
+    box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.4);
+    animation-name: slide-up;
+    animation-iteration-count: 1;
+    animation-duration: 0.4s;
+    position: relative;
+    transform: rotate(-60deg);
+  }
 
-    @keyframes slide-up {
-        from {
-            transform: rotate(-60deg);
-            bottom: -600px;
-        }
-        to {
-            transform: rotate(0deg);
-            bottom: 0px;
-        }
+  @keyframes slide-up {
+    from {
+      transform: rotate(-60deg);
+      bottom: -600px;
     }
+    to {
+      transform: rotate(0deg);
+      bottom: 0px;
+    }
+  }
+}
+plh-template-component[data-hidden="true"] {
+  display: none;
+}
+plh-template-component[data-debug-hidden="true"] {
+  display: block;
+}
+.no_padding {
+  padding: 0 !important;
 }
 @import "~@angular/material/prebuilt-themes/indigo-pink.css";
 @import "~nouislider/distribute/nouislider.min.css";
-

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -66,6 +66,9 @@ $border-radius-standard: 15px;
     var(--ion-gradient-secondary-end) 100%
   );
 
+  --regular-padding: 5px;
+  --large-padding: 10px;
+
   --ion-banner-secondary: linear-gradient(
     179.77deg,
     hsl(48, 100%, 71%) 34.6%,


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Update styles in tmpl-components-common.scss and tmpl-containter.scss for default center position.
Update padding in image, title, subtitle, timer, audio components.
Add default variables paddings:  --regular-padding(5px), --large-padding (5px);
Fixed ion-button height.
_What this PR does_

## Git Issues
#482 
_Closes #_

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/78734738/114372016-c56cd180-9b89-11eb-8d38-056013958759.png)
![image](https://user-images.githubusercontent.com/78734738/114372063-d1589380-9b89-11eb-9f15-30abc46171e6.png)

_If useful, provide screenshot or capture to highlight main changes_
