### PR TITLE
Add support for double go_to by removing child emits

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -121,9 +121,6 @@ export class TemplateNavService {
       const navExitAction = actions.find(
         (a) => a.action_id === "emit" && ["completed", "uncompleted"].includes(a.args[0])
       );
-      if (navExitAction) {
-        this.location.back();
-      }
       /**
        * 2021-04-12 CC - Previous attempt at navigating back with different query params
        * Temporariliy deprecated, pending future implementation
@@ -140,6 +137,10 @@ export class TemplateNavService {
       //   replaceUrl: true,
       //   queryParamsHandling: "merge",
       // });
+      /** Current implementation simply navigates back */
+      if (navExitAction) {
+        this.location.back();
+      }
     }
   }
 

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -1,3 +1,4 @@
+import { Location } from "@angular/common";
 import { Injectable } from "@angular/core";
 import { ModalController } from "@ionic/angular";
 import { FlowTypes } from "scripts/types";
@@ -18,7 +19,7 @@ const log = SHOW_DEBUG_LOGS ? console.log : () => null;
  * ...
  */
 export class TemplateNavService {
-  constructor(private modalCtrl: ModalController) {}
+  constructor(private modalCtrl: ModalController, private location: Location) {}
 
   public async handleQueryParamChange(
     params: INavQueryParams,
@@ -120,18 +121,25 @@ export class TemplateNavService {
       const navExitAction = actions.find(
         (a) => a.action_id === "emit" && ["completed", "uncompleted"].includes(a.args[0])
       );
-      const nav_child_emit = navExitAction?.args?.[0] || null;
-      const nav_child = nav_child_emit ? container.name : null;
-      const queryParams: INavQueryParams = { nav_child_emit, nav_child, nav_parent: null };
-      // if we have navigated from a popup we need to return to the popup parent template
-      // otherwise return to the template of the element that initiated the navigation
-      const navTargetTemplate = popup_parent || nav_parent;
-      router.navigate(["../", navTargetTemplate], {
-        relativeTo: route,
-        queryParams,
-        replaceUrl: true,
-        queryParamsHandling: "merge",
-      });
+      if (navExitAction) {
+        this.location.back();
+      }
+      /**
+       * 2021-04-12 CC - Previous attempt at navigating back with different query params
+       * Temporariliy deprecated, pending future implementation
+       */
+      // const nav_child_emit = navExitAction?.args?.[0] || null;
+      // const nav_child = nav_child_emit ? container.name : null;
+      // const queryParams: INavQueryParams = { nav_child_emit, nav_child, nav_parent: null };
+      // // if we have navigated from a popup we need to return to the popup parent template
+      // // otherwise return to the template of the element that initiated the navigation
+      // const navTargetTemplate = popup_parent || nav_parent;
+      // router.navigate(["../", navTargetTemplate], {
+      //   relativeTo: route,
+      //   queryParams,
+      //   replaceUrl: true,
+      //   queryParamsHandling: "merge",
+      // });
     }
   }
 

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -121,6 +121,7 @@ export class TemplateNavService {
       const navExitAction = actions.find(
         (a) => a.action_id === "emit" && ["completed", "uncompleted"].includes(a.args[0])
       );
+
       /**
        * 2021-04-12 CC - Previous attempt at navigating back with different query params
        * Temporariliy deprecated, pending future implementation
@@ -137,6 +138,7 @@ export class TemplateNavService {
       //   replaceUrl: true,
       //   queryParamsHandling: "merge",
       // });
+
       /** Current implementation simply navigates back */
       if (navExitAction) {
         this.location.back();


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Previously go_to statements attempted to change previous urls on completion to also pass back information, but this system did not work well for cases where we had multiple nav actions.

This PR simplifies behaviour, using standard back methods on complete/uncomplete actions and not trying to update history

## Git Issues

_Closes #_

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/114398885-39ae7180-9b98-11eb-8c5c-0bcdd2112b5f.mp4
