### PR TITLE
Allow bold / italics formatting in spreadsheet (without markdown)

### DIFF
--- a/scripts/src/plh-data-convert/index.ts
+++ b/scripts/src/plh-data-convert/index.ts
@@ -163,7 +163,7 @@ function convertXLSXSheetsToJson(xlsxFilePath: string) {
       if (
         html !== undefined &&
         typeof html === "string" &&
-        (html.indexOf("<b>") > -1 || html.indexOf("<em>") > -1)
+        (html.indexOf("<b>") > -1 || html.indexOf("<em>") > -1 || html.indexOf("<i>") > -1)
       ) {
         console.log("Formatting?", html);
         html = html.replace(/<span[^>]*>/g, "<span>"); // Remove span style

--- a/scripts/src/plh-data-convert/index.ts
+++ b/scripts/src/plh-data-convert/index.ts
@@ -157,6 +157,20 @@ function convertXLSXSheetsToJson(xlsxFilePath: string) {
   const workbook = xlsx.readFile(xlsxFilePath);
   const { Sheets } = workbook;
   Object.entries(Sheets).forEach(([sheet_name, worksheet]) => {
+    /* If bold or italics, include HTML in cell value */
+    Object.keys(worksheet).forEach((cellId) => {
+      let html = worksheet[cellId]?.h;
+      if (
+        html !== undefined &&
+        typeof html === "string" &&
+        (html.indexOf("<b>") > -1 || html.indexOf("<em>") > -1)
+      ) {
+        console.log("Formatting?", html);
+        html = html.replace(/<span[^>]*>/g, "<span>"); // Remove span style
+        worksheet[cellId].v = html;
+      }
+    });
+
     json[sheet_name] = xlsx.utils.sheet_to_json(worksheet);
   });
   return json;

--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -3,5 +3,5 @@
   [class]="style + ' ' + buttonAlign"
   [disabled]="disabled"
   (click)="triggerActions('click')"
-  ><span [class]="textAlign">{{ _row.value }}</span></ion-button
->
+  ><span *ngIf="innerHTML" [class]="textAlign" [innerHTML]="innerHTML"></span
+></ion-button>

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -1,4 +1,5 @@
 import { AfterContentInit, Component, ElementRef, OnInit, ViewChild } from "@angular/core";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { getStringParamFromTemplateRow, getBooleanParamFromTemplateRow } from "../../../../utils";
 import { TemplateBaseComponent } from "../base";
 
@@ -16,12 +17,14 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
   nestedStyle: boolean = false;
   nestedProperty: string;
   nestedStyleName = "nested_color";
-  constructor(private elRef: ElementRef) {
+  innerHTML: SafeHtml;
+  constructor(private elRef: ElementRef, private domSanitizer: DomSanitizer) {
     super();
   }
   @ViewChild("ionButton", { static: true }) btn: any;
   ngOnInit() {
     this.getParams();
+    this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(this._row.value);
   }
 
   getParams() {

--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.html
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.html
@@ -1,8 +1,6 @@
 <div class="box-wrapper">
   <div class="item" [class]="style">
-    <div class="text">
-      {{ _row.value }}
-    </div>
+    <div *ngIf="innerHTML" class="text" [innerHTML]="innerHTML"></div>
     <div class="icon" [class]="icon_position" *ngIf="icon_src">
       <img [src]="icon_result" alt="" />
     </div>

--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { ITemplateRowProps } from "../../models";
 import { getStringParamFromTemplateRow } from "../../../../utils";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 
 @Component({
   selector: "plh-dashed-box",
@@ -16,12 +17,14 @@ export class TmplDashedBoxComponent
   assetsPrefix = "/assets/plh_assets/";
   icon_result: string;
   icon_position: string;
-  constructor() {
+  innerHTML: SafeHtml;
+  constructor(private domSanitizer: DomSanitizer) {
     super();
   }
 
   ngOnInit() {
     this.getParams();
+    this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(this._row.value);
   }
 
   getParams() {

--- a/src/app/shared/components/template/components/title.ts
+++ b/src/app/shared/components/template/components/title.ts
@@ -2,12 +2,13 @@ import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "./base";
 import { ITemplateRowProps } from "../models";
 import { getStringParamFromTemplateRow } from "../../../utils";
+import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 
 @Component({
   selector: "plh-tmpl-title",
   template: `
     <div class="title-wrapper" [class]="textAlign">
-      <h1 [class]="style">{{ _row.value }}</h1>
+      <h1 *ngIf="innerHTML" [class]="style" [innerHTML]="innerHTML"></h1>
       <ion-icon
         *ngIf="help"
         name="help-circle-outline"
@@ -25,13 +26,15 @@ export class TmplTitleComponent extends TemplateBaseComponent implements ITempla
   tooltipPosition: string;
   textAlign: string;
   style: string | null;
+  innerHTML: SafeHtml;
 
-  constructor() {
+  constructor(private domSanitizer: DomSanitizer) {
     super();
   }
 
   ngOnInit() {
     this.getParams();
+    this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(this._row.value);
   }
 
   getParams() {

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -23705,5 +23705,33 @@
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_solve.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "feature_formatting",
+    "status": "released",
+    "rows": [
+      {
+        "type": "title",
+        "name": "title1",
+        "value": "<span>This is a title where part of it is </span><span><i>italics</i></span>"
+      },
+      {
+        "type": "text",
+        "name": "text1",
+        "value": "<span>This is text where part is </span><span><b>bold </b></span><span>part is in </span><span><i>italics</i></span><span><b><i> </b></i></span><span>and part is </span><span><b><i>both bold and italics (emphasised) </b></i></span>"
+      },
+      {
+        "type": "dashed_box",
+        "name": "box1",
+        "value": "<span>This is a dashed box where some of the text is </span><span><b>bold</b></span><span> and </span><span><i>italics</i></span>"
+      },
+      {
+        "type": "button",
+        "name": "button1",
+        "value": "<span>Some of this button is </span><span><b>bold. </b></span><span><i>WOAH!</i></span>"
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/feature_templates/feature_template_components.xlsx"
   }
 ]

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -24710,5 +24710,33 @@
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_stress.xlsx"
+  },
+  {
+    "flow_type": "template",
+    "flow_name": "feature_formatting",
+    "status": "released",
+    "rows": [
+      {
+        "type": "title",
+        "name": "title1",
+        "value": "<span>This is a title where part of it is </span><span><i>italics</i></span>"
+      },
+      {
+        "type": "text",
+        "name": "text1",
+        "value": "<span>This is text where part is </span><span><b>bold </b></span><span>part is in </span><span><i>italics</i></span><span><b><i> </b></i></span><span>and part is </span><span><b><i>both bold and italics (emphasised) </b></i></span>"
+      },
+      {
+        "type": "dashed_box",
+        "name": "box1",
+        "value": "<span>This is a dashed box where some of the text is </span><span><b>bold</b></span><span> and </span><span><i>italics</i></span>"
+      },
+      {
+        "type": "button",
+        "name": "button1",
+        "value": "<span>Some of this button is </span><span><b>bold. </b></span><span><i>WOAH!</i></span>"
+      }
+    ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/feature_templates/feature_template_components.xlsx"
   }
 ]

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -24707,8 +24707,8 @@
             ]
           }
         ]
-        "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_stress.xlsx"
       }
     ],
+    "_xlsxPath": "plh_sheets_beta/plh_templating/top_templates/workshop_templates/workshop_stress.xlsx"
   }
 ]


### PR DESCRIPTION
- Support bold or italics from excel
- Support formatting in more components

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Uses the formatting in the XLSX file itself (as opposed to markdown typed in) which is then converted to HTML and then shown to the user in the following components
- Text
- Title
- Dashed Box
- Button_

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
