### PR TITLE
Fix intro.js to support Angular navigation

### DIFF
--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -16,8 +16,6 @@ import { TEMPLATE_COMPONENT_MAPPING } from "./components";
 import { FlowTypes, ITemplateRowProps } from "./models";
 import { TemplateContainerComponent } from "./template-container.component";
 
-export const NAME_CLASS_PREFIX = "tc-name-";
-
 /*********************************************************************
  *  Directive used as part of loading dynamic flow component elemnt
  *********************************************************************/
@@ -44,10 +42,11 @@ export class TmplCompHostDirective {
   selector: "plh-template-component",
   template: `
     <div
-      class="plh-tmpl-comp {{ rowNameClass }}"
+      class="plh-tmpl-comp"
       [attr.data-hidden]="row.hidden"
       [attr.data-debug]="parent.debugMode"
       [ngClass]="{ disabled: row.disabled }"
+      [attr.data-rowname]="row.name"
     >
       <!-- Template Debugger -->
       <plh-template-debugger
@@ -87,8 +86,6 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
 
   styles: { [name: string]: any } = {};
 
-  rowNameClass: string;
-
   @ViewChild(TmplCompHostDirective, { static: true }) tmplComponentHost: TmplCompHostDirective;
 
   constructor(
@@ -105,8 +102,6 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   }
 
   private renderRow(row: FlowTypes.TemplateRow) {
-    this.rowNameClass = NAME_CLASS_PREFIX + row.name;
-
     // console.log(`[${this.row.name}]`, "render row");
     // Depending on row type, either prepare instantiation of a nested template or a display component
     switch (row.type) {

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -16,6 +16,8 @@ import { TEMPLATE_COMPONENT_MAPPING } from "./components";
 import { FlowTypes, ITemplateRowProps } from "./models";
 import { TemplateContainerComponent } from "./template-container.component";
 
+export const NAME_CLASS_PREFIX = "tc-name-";
+
 /*********************************************************************
  *  Directive used as part of loading dynamic flow component elemnt
  *********************************************************************/
@@ -42,7 +44,7 @@ export class TmplCompHostDirective {
   selector: "plh-template-component",
   template: `
     <div
-      class="plh-tmpl-comp"
+      class="plh-tmpl-comp {{ rowNameClass }}"
       [attr.data-hidden]="row.hidden"
       [attr.data-debug]="parent.debugMode"
       [ngClass]="{ disabled: row.disabled }"
@@ -85,6 +87,8 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
 
   styles: { [name: string]: any } = {};
 
+  rowNameClass: string;
+
   @ViewChild(TmplCompHostDirective, { static: true }) tmplComponentHost: TmplCompHostDirective;
 
   constructor(
@@ -101,6 +105,8 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   }
 
   private renderRow(row: FlowTypes.TemplateRow) {
+    this.rowNameClass = NAME_CLASS_PREFIX + row.name;
+
     // console.log(`[${this.row.name}]`, "render row");
     // Depending on row type, either prepare instantiation of a nested template or a display component
     switch (row.type) {

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -318,6 +318,7 @@ export namespace FlowTypes {
     type: "step";
     message_text?: string;
     title?: string;
+    template_component_name?: string;
     element?: string;
     route?: string;
   }

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
 
 import introJs from "intro.js";
-import { NAME_CLASS_PREFIX } from "../../components/template/template-component";
 import { TOUR } from "../data/data.service";
 
 @Injectable({
@@ -27,7 +26,7 @@ export class TourService {
         steps: matchingTour.rows.map((row) => {
           let elementSelector = row.element;
           if (row.template_component_name && row.template_component_name.trim().length > 0) {
-            elementSelector = "." + NAME_CLASS_PREFIX + row.template_component_name;
+            elementSelector = `[data-rowname="${row.template_component_name}"]`;
           }
           return {
             intro: row.message_text,

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
 
 import introJs from "intro.js";
+import { NAME_CLASS_PREFIX } from "../../components/template/template-component";
 import { TOUR } from "../data/data.service";
 
 @Injectable({
@@ -23,23 +24,45 @@ export class TourService {
 
     if (matchingTour && matchingTour.rows && matchingTour.rows.length > 0) {
       this.introJS.setOptions({
-        steps: matchingTour.rows.map((row) => ({
-          intro: row.message_text,
-          title: row.title,
-          element: row.element,
-        })),
+        steps: matchingTour.rows.map((row) => {
+          let elementSelector = row.element;
+          return {
+            intro: row.message_text,
+            title: row.title,
+            element: elementSelector,
+            elementSelector: elementSelector,
+          } as any;
+        }),
         hidePrev: true,
-      });
-      this.introJS.onafterchange(() => {
-        setTimeout(() => this.introJS.refresh(), this.waitForRoutingDelay);
       });
       this.introJS.onbeforechange((elem) => {
         this.introJS.currentStep();
         const stepNumber = this.introJS.currentStep();
         const currentRow = matchingTour.rows[stepNumber];
+
+        /* If route changes then navigate, then after delay, actually change intro.js step */
         if (currentRow.route) {
-          this.router.navigateByUrl(currentRow.route);
+          const currentPath = this.router.url.replace(/^\//g, "");
+          const stepPath = currentRow.route.replace(/^\//g, "");
+          if (currentPath !== stepPath) {
+            this.router.navigateByUrl(currentRow.route).then(() => {
+              setTimeout(() => {
+                // Workaround to make sure element highlights work on new route
+                this.revaluateIntroElements();
+                setTimeout(() => {
+                  this.introJS.goToStepNumber(stepNumber + 1);
+                }, this.waitForRoutingDelay / 2);
+              }, this.waitForRoutingDelay / 2);
+            });
+            return false;
+          }
         }
+      });
+      this.introJS.onafterchange((elem) => {
+        this.introJS.refresh();
+        setTimeout(() => {
+          this.introJS.refresh();
+        }, this.waitForRoutingDelay);
       });
       const startRoute = matchingTour.rows[0].route ? matchingTour.rows[0].route : "module_list";
       await this.router.navigateByUrl(startRoute);
@@ -47,5 +70,19 @@ export class TourService {
         this.introJS.start();
       }, this.waitForRoutingDelay);
     }
+  }
+
+  revaluateIntroElements() {
+    // Workaround from here:
+    // https://github.com/usablica/intro.js/issues/717#issuecomment-646445169
+    this.introJS["_options"].steps.forEach((step, key) => {
+      if (step.elementSelector) {
+        const el = document.querySelector(step.elementSelector);
+        if (el !== null) {
+          this.introJS["_introItems"][key].element = el;
+        }
+        this.introJS["_introItems"][key].position = step.position ? step.position : "bottom";
+      }
+    });
   }
 }

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -67,7 +67,7 @@ export class TourService {
           this.introJS.refresh();
         }, this.waitForRoutingDelay);
       });
-      const startRoute = matchingTour.rows[0].route ? matchingTour.rows[0].route : "module_list";
+      const startRoute = matchingTour.rows[0].route ? matchingTour.rows[0].route : "/";
       await this.router.navigateByUrl(startRoute);
       setTimeout(() => {
         this.introJS.start();

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -26,6 +26,9 @@ export class TourService {
       this.introJS.setOptions({
         steps: matchingTour.rows.map((row) => {
           let elementSelector = row.element;
+          if (row.template_component_name && row.template_component_name.trim().length > 0) {
+            elementSelector = "." + NAME_CLASS_PREFIX + row.template_component_name;
+          }
           return {
             intro: row.message_text,
             title: row.title,

--- a/src/data/tour.ts
+++ b/src/data/tour.ts
@@ -59,7 +59,7 @@
         "type": "step",
         "title": "Start a workshop",
         "message_text": "Click here to continue your last workshop",
-        "element": "#main-content > plh-template-testing > ion-content > plh-template-container > div > plh-template-component:nth-child(2)",
+        "template_component_name": "workshop_button_0",
         "route": "template/workshop_buttons_temp"
       },
       {


### PR DESCRIPTION
- Workaround for intro.js to support ng routes
- Tour can highlight template comp by name

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Workaround to deal with the fact that intro.js does not support single page applications.

When changing step, don't actually change step until navigation is done, then use workaround to select elements that are only just shown on page.

Also adds support for highlighting elements in a tour by their name in a template page.
_

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
