### PR TITLE
Fix popup height

### DIFF
--- a/src/app/shared/components/template/components/layout/popup.ts
+++ b/src/app/shared/components/template/components/layout/popup.ts
@@ -28,17 +28,17 @@ import { TemplateContainerComponent } from "../../template-container.component";
         align-items: center;
       }
       .popup-backdrop {
-        height: 100%;
+        height: calc(100vh - 40px);
         width: 100%;
+        margin-top: 40px;
       }
       .popup-content {
         width: 80%;
-        height: calc(100vh - 140px);
+        max-height: calc(100vh - 140px);
         background: white;
         border: 2px solid black;
         border-radius: 40px;
         padding: 20px;
-        margin-top: 40px;
       }
       .close-button {
         margin-left: auto;


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Instead of always being all, only be as tall as popup content.

Also corrects centering of popup
