### PR TITLE
add transparent style to radio group

### DIFF
--- a/src/app/shared/components/template/components/radio-group/radio-group.component.scss
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.scss
@@ -86,12 +86,12 @@ $primary-radio-border-rd: calc(15px * var(--scale-factor));
       }
       .transparent {
         .standard-label {
-          border: 2px solid transparent;
+          border: 2px solid transparent !important;
           box-shadow: none;
         }
         .checked {
           transition: 0.3s linear;
-          border: var(--ion-border-standard);
+          border: var(--ion-border-standard) !important;
           box-shadow: var(--ion-default-box-shadow);
         }
       }

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -14613,6 +14613,24 @@
           "name:name_var_3| image:/plh_images/icons/heart.svg"
         ],
         "type": "set_variable"
+      },
+      {
+        "type": "radio_group",
+        "name": "radio_group_square_ex2",
+        "parameter_list": {
+          "answer_list": "@local.answer3_list",
+          "options_per_row": "3",
+          "style": "transparent"
+        }
+      },
+      {
+        "name": "answer3_list",
+        "value": [
+          "name:name_var_1 | image:/plh_images/icons/heart.svg",
+          "name:name_var_2| image:/plh_images/icons/heart.svg",
+          "name:name_var_3| image:/plh_images/icons/heart.svg"
+        ],
+        "type": "set_variable"
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/feature_templates/feature_template_components.xlsx"


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
transparent style for radio group
[Spreadsheet](https://docs.google.com/spreadsheets/d/1ARbNRGDer5vj9qSpRMZFrMkYifGkH3TLtDVp72YbaqU/edit#gid=1335725621)

_What this PR does_

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
<img width="618" alt="Снимок экрана 2021-04-23 в 19 41 01" src="https://user-images.githubusercontent.com/81557818/115867817-263fb800-a46e-11eb-88a7-fdf66a075bd1.png">
