### PR TITLE
add start_tour action

### DIFF
--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { takeUntil, takeWhile } from "rxjs/operators";
 import { BehaviorSubject, Subject } from "scripts/node_modules/rxjs";
 import { TEMPLATE } from "../../services/data/data.service";
+import { TourService } from "../../services/tour/tour.service";
 import { mapToJson } from "../../utils";
 import { FlowTypes, ITemplateContainerProps } from "./models";
 import { TemplateNavService } from "./services/template-nav.service";
@@ -64,6 +65,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   constructor(
     private templateService: TemplateService,
     private templateVariables: TemplateVariablesService,
+    private tourService: TourService,
     public router: Router,
     public route: ActivatedRoute,
     public elRef: ElementRef,
@@ -166,6 +168,8 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
         return this.templateService.setField(key, value);
       case "set_theme":
         return this.templateService.setTheme(this.template, "set_theme", action.args);
+      case "start_tour":
+        return this.tourService.startTour(key);
       case "emit":
         const [emit_value, emit_from] = args;
         let container: TemplateContainerComponent = this;

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -450,7 +450,8 @@ export namespace FlowTypes {
       | "audio_play"
       | "style"
       | "close_pop_up"
-      | "set_theme";
+      | "set_theme"
+      | "start_tour";
     args: string[];
     /** field populated for tracking the component that triggered the action */
     _triggeredBy?: TemplateRow;

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -1,6 +1,24 @@
 /* eslint-disable */
   import { FlowTypes } from "src/app/shared/model/flowTypes";
   export const template: FlowTypes.Template[] = [
+    {"flow_type": "template",
+    "flow_name": "example_tour_action",
+    "status": "released",
+    "rows": [{
+      "name":"start_tour_button",
+      "type":"button",
+      _nested_name:"start_tour_button",
+      "value":"Start Tour",
+      "action_list":[
+         {
+          "trigger": "click",
+          "action_id": "start_tour",
+          "args": [
+            "intro_tour"
+          ],
+        },
+      ]
+    }]},
   {
     "flow_type": "template",
     "flow_name": "box_tools",


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add a `start_tour` action type that can be used to demo a tour
- Add an example template (hardcoded into templates, not authored in excel so just temporary), as below:
```
{"flow_type": "template",
    "flow_name": "example_tour_action",
    "status": "released",
    "rows": [{
      "name":"start_tour_button",
      "type":"button",
      _nested_name:"start_tour_button",
      "value":"Start Tour",
      "action_list":[
         {
          "trigger": "click",
          "action_id": "start_tour",
          "args": [
            "intro_tour"
          ],
        },
      ]
    }]}
```

## Git Issues

_Closes #_

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/118107175-5b3c8c00-b3d6-11eb-8699-0a8fbc167fa7.mp4
