### PR TITLE
fix deep merge dynamic refs

### DIFF
--- a/src/app/shared/components/template/mocks/template-merge.mock.ts
+++ b/src/app/shared/components/template/mocks/template-merge.mock.ts
@@ -136,7 +136,7 @@ export class TestClass {
         return mergeNestedTemplates(override as any, originalRow) as any;
       }
       // merge and remove dynamic references
-      // TODO - also remove _dynamicFields references
+      // TODO - also remove _dynamicDependencies references
       else {
         Object.keys(mergeFields).forEach((field) => {
           overriddenRow[field] = override[field];
@@ -199,7 +199,18 @@ function mergeNestedTemplateRows(
     const primaryRow = primaryHashmap[secondaryRow.name];
     let mergedRow = { ...secondaryRow };
     if (primaryRow) {
-      mergedRow = { ...secondaryRow, ...primaryRow };
+      // merge and remove dynamic references
+      // TODO - also remove _dynamicDependencies references
+      // TODO - merge with processRowOverrideMethod
+      Object.keys(primaryRow).forEach((field) => {
+        mergedRow[field] = primaryRow[field];
+        if (mergedRow._dynamicFields && mergedRow._dynamicFields.hasOwnProperty(field)) {
+          delete mergedRow._dynamicFields[field];
+          if (Object.keys(mergedRow._dynamicFields).length === 0) {
+            delete mergedRow._dynamicFields;
+          }
+        }
+      });
     }
     if (mergedRow.rows) {
       mergedRow.rows = mergeNestedTemplateRows(primaryRow?.rows, secondaryRow.rows);

--- a/src/app/shared/components/template/mocks/template-merge.mock.ts
+++ b/src/app/shared/components/template/mocks/template-merge.mock.ts
@@ -199,12 +199,13 @@ function mergeNestedTemplateRows(
     const primaryRow = primaryHashmap[secondaryRow.name];
     let mergedRow = { ...secondaryRow };
     if (primaryRow) {
-      // merge and remove dynamic references
+      // merge
+      mergedRow = { ...secondaryRow, ...primaryRow };
+      // remove overriden dynamic references
       // TODO - also remove _dynamicDependencies references
       // TODO - merge with processRowOverrideMethod
       Object.keys(primaryRow).forEach((field) => {
-        mergedRow[field] = primaryRow[field];
-        if (mergedRow._dynamicFields && mergedRow._dynamicFields.hasOwnProperty(field)) {
+        if (mergedRow._dynamicFields?.[field]) {
           delete mergedRow._dynamicFields[field];
           if (Object.keys(mergedRow._dynamicFields).length === 0) {
             delete mergedRow._dynamicFields;

--- a/src/app/shared/components/template/utils/template-utils.ts
+++ b/src/app/shared/components/template/utils/template-utils.ts
@@ -33,7 +33,18 @@ function mergeNestedTemplateRows(
     const primaryRow = primaryHashmap[secondaryRow.name];
     let mergedRow = { ...secondaryRow };
     if (primaryRow) {
-      mergedRow = { ...secondaryRow, ...primaryRow };
+      // merge and remove dynamic references
+      // TODO - also remove _dynamicDependencies references
+      // TODO - merge with processRowOverrideMethod
+      Object.keys(primaryRow).forEach((field) => {
+        mergedRow[field] = primaryRow[field];
+        if (mergedRow._dynamicFields && mergedRow._dynamicFields.hasOwnProperty(field)) {
+          delete mergedRow._dynamicFields[field];
+          if (Object.keys(mergedRow._dynamicFields).length === 0) {
+            delete mergedRow._dynamicFields;
+          }
+        }
+      });
     }
     if (mergedRow.rows) {
       mergedRow.rows = mergeNestedTemplateRows(primaryRow?.rows, secondaryRow.rows);

--- a/src/app/shared/components/template/utils/template-utils.ts
+++ b/src/app/shared/components/template/utils/template-utils.ts
@@ -33,12 +33,13 @@ function mergeNestedTemplateRows(
     const primaryRow = primaryHashmap[secondaryRow.name];
     let mergedRow = { ...secondaryRow };
     if (primaryRow) {
-      // merge and remove dynamic references
+      // merge
+      mergedRow = { ...secondaryRow, ...primaryRow };
+      // remove overriden dynamic references
       // TODO - also remove _dynamicDependencies references
       // TODO - merge with processRowOverrideMethod
       Object.keys(primaryRow).forEach((field) => {
-        mergedRow[field] = primaryRow[field];
-        if (mergedRow._dynamicFields && mergedRow._dynamicFields.hasOwnProperty(field)) {
+        if (mergedRow._dynamicFields?.[field]) {
           delete mergedRow._dynamicFields[field];
           if (Object.keys(mergedRow._dynamicFields).length === 0) {
             delete mergedRow._dynamicFields;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fix templating script issue where deep nested merge was not removing dynamic references after merge (and so the value would revert to dynamic value), as seen in `debug_data_bottom` issue

## Git Issues

_Closes #_

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/10515065/118161724-d4a89e80-b417-11eb-8b20-3d9a14eab63c.png)
