### PR TITLE
display group types

### DIFF
--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -10,6 +10,7 @@ import { AnimatedSectionComponent } from "./layout/animated_section";
 import { AccordionSectionComponent } from "./layout/accordion_section";
 import { TmplAdvancedDashedBoxComponent } from "./layout/advanced-dashed-box/advanced-dashed-box.component";
 import { AnimatedSectionGroupComponent } from "./layout/animated_section_group";
+import { FormComponent } from "./layout/form";
 import { WorkshopsComponent } from "./layout/workshops_accordion";
 import { NavGroupComponent } from "./layout/nav_group";
 import { TmplAudioComponent } from "./audio/audio.component";
@@ -60,6 +61,7 @@ export const TEMPLATE_COMPONENTS = [
   AnimatedSectionComponent,
   AccordionSectionComponent,
   TmplAdvancedDashedBoxComponent,
+  FormComponent,
   TmplTimerComponent,
   TmplSliderComponent,
   TmplNumberComponent,
@@ -96,6 +98,7 @@ export const TEMPLATE_COMPONENT_MAPPING: Record<
   workshops_accordion: WorkshopsComponent,
   accordion_section: AccordionSectionComponent,
   advanced_dashed_box: TmplAdvancedDashedBoxComponent,
+  form: FormComponent,
   animated_section: AnimatedSectionComponent,
   display_group: TmplDisplayGroupComponent,
   audio: TmplAudioComponent,

--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
@@ -1,10 +1,13 @@
 <div class="box-wrapper">
   <div class="item margin-t-regular" [class]="style">
-    <div *ngIf="innerHTML" class="text" [innerHTML]="innerHTML"></div>
     <div class="icon" [class]="icon_position" *ngIf="icon_src">
       <img [src]="icon_result" alt="" />
     </div>
-    <plh-template-component *ngFor="let childRow of _row.rows" [row]="childRow" [parent]="parent">
+    <plh-template-component
+      *ngFor="let childRow of templateRow.rows"
+      [row]="childRow"
+      [parent]="parent"
+    >
     </plh-template-component>
   </div>
 </div>

--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.ts
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from "@angular/core";
-import { SafeHtml, DomSanitizer } from "@angular/platform-browser";
+import { Component, Input, OnInit } from "@angular/core";
+import { FlowTypes } from "scripts/types";
 import { getStringParamFromTemplateRow } from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../../base";
 
@@ -9,27 +9,30 @@ import { TemplateBaseComponent } from "../../base";
   styleUrls: ["./advanced-dashed-box.component.scss"],
 })
 export class TmplAdvancedDashedBoxComponent extends TemplateBaseComponent implements OnInit {
+  @Input() templateRow: FlowTypes.TemplateRow;
   style: string;
   icon_src: string | null;
   assetsPrefix = "/assets/plh_assets/";
   icon_result: string;
   icon_position: string;
-  innerHTML: SafeHtml;
 
-  constructor(private domSanitizer: DomSanitizer) {
+  constructor() {
     super();
   }
 
   ngOnInit() {
     this.getParams();
-    this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(this._row.value);
   }
 
   getParams() {
-    this.icon_src = getStringParamFromTemplateRow(this._row, "icon_src", "");
-    this.style = getStringParamFromTemplateRow(this._row, "style", "default");
+    this.icon_src = getStringParamFromTemplateRow(this.templateRow, "icon_src", "");
+    this.style = getStringParamFromTemplateRow(this.templateRow, "style", "default");
     this.icon_result = this.getPathImg();
-    this.icon_position = getStringParamFromTemplateRow(this._row, "icon_position", "top-left");
+    this.icon_position = getStringParamFromTemplateRow(
+      this.templateRow,
+      "icon_position",
+      "top-left"
+    );
   }
 
   getPathImg(): string {

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -10,12 +10,17 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
     [class]="style"
     [style.marginBottom.px]="offset"
   >
-    <div [style.marginBottom.px]="-offset" class="offset">
-      <plh-template-component
-        *ngFor="let childRow of _row.rows"
-        [row]="childRow"
-        [parent]="parent"
-      ></plh-template-component>
+    <div [style.marginBottom.px]="-offset" class="offset" [ngSwitch]="type">
+      <ng-container *ngSwitchCase="'default'">
+        <plh-template-component
+          *ngFor="let childRow of _row.rows"
+          [row]="childRow"
+          [parent]="parent"
+        ></plh-template-component>
+      </ng-container>
+      <ng-container *ngSwitchCase="'dashed_box'">
+        <plh-advanced-dashed-box [templateRow]="_row" [parent]="parent"></plh-advanced-dashed-box>
+      </ng-container>
     </div>
   </div>`,
   styleUrls: ["../tmpl-components-common.scss"],
@@ -53,6 +58,7 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
   style: string | null;
   offset: number = 0;
   bgColor: string;
+  type: string;
 
   constructor(private elRef: ElementRef) {
     super();
@@ -73,6 +79,7 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
   getParams() {
     this.style = getStringParamFromTemplateRow(this._row, "style", null);
     this.offset = getNumberParamFromTemplateRow(this._row, "offset", 0);
+    this.type = getStringParamFromTemplateRow(this._row, "type", "default");
   }
 
   setBackground() {

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -18,9 +18,12 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
           [parent]="parent"
         ></plh-template-component>
       </ng-container>
-      <ng-container *ngSwitchCase="'dashed_box'">
-        <plh-advanced-dashed-box [templateRow]="_row" [parent]="parent"></plh-advanced-dashed-box>
-      </ng-container>
+      <plh-advanced-dashed-box
+        *ngSwitchCase="'dashed_box'"
+        [templateRow]="_row"
+        [parent]="parent"
+      ></plh-advanced-dashed-box>
+      <plh-tmpl-form *ngSwitchCase="'form'" [templateRow]="_row" [parent]="parent"></plh-tmpl-form>
     </div>
   </div>`,
   styleUrls: ["../tmpl-components-common.scss"],

--- a/src/app/shared/components/template/components/layout/form.ts
+++ b/src/app/shared/components/template/components/layout/form.ts
@@ -1,0 +1,85 @@
+import { Component, Input, OnInit, ViewChild, ViewChildren } from "@angular/core";
+import { TemplateBaseComponent } from "../base";
+import { Plugins } from "@capacitor/core";
+import { FlowTypes } from "scripts/types";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
+
+const { Device } = Plugins;
+
+@Component({
+  selector: "plh-tmpl-form",
+  template: ` <div>
+    <plh-template-component
+      *ngFor="let childRow of templateRow.rows"
+      [row]="childRow"
+      [parent]="parent"
+    >
+    </plh-template-component>
+    <ion-button (click)="submit()">{{ button_text }}</ion-button>
+  </div>`,
+  styles: [
+    `
+      ion-button {
+        font-size: 25px;
+        font-family: Roboto, sans-serif;
+        font-weight: 500;
+        color: var(--ion-color-primary-contrast);
+        text-transform: none;
+        white-space: pre-line;
+        min-height: 71px;
+        padding: var(--regular-margin) var(--regular-padding) 0;
+        --border-radius: 15px;
+        --box-shadow: var(--ion-btn-dark-box-shadow);
+        min-width: 100%;
+        --background: var(--ion-btn-primary);
+      }
+    `,
+  ],
+})
+export class FormComponent extends TemplateBaseComponent implements OnInit {
+  @Input() templateRow: FlowTypes.TemplateRow;
+  private deviceInfo;
+  private form = {};
+  private isAllowedDeviceInfo: boolean;
+  public button_text: string;
+
+  constructor() {
+    super();
+    this.deviceInfo = Device.getInfo();
+  }
+
+  ngOnInit() {
+    this.getParams();
+  }
+
+  public submit(): void {
+    this.fillInForm();
+    console.log(this.form, this.isAllowedDeviceInfo);
+  }
+
+  private getParams(): void {
+    this.button_text = getStringParamFromTemplateRow(this.templateRow, "button_text", "Submit");
+    this.isAllowedDeviceInfo = getBooleanParamFromTemplateRow(
+      this.templateRow,
+      "get_device_info",
+      false
+    );
+  }
+
+  private fillInForm(): void {
+    this.templateRow.rows.forEach((r) => {
+      if (
+        r.value &&
+        (r.type === "text_box" || r.type === "simple_checkbox" || r.type === "text_area")
+      ) {
+        this.form[r.name] = r.value;
+      }
+    });
+    if (this.isAllowedDeviceInfo) {
+      this.form["device_info"] = this.deviceInfo["__zone_symbol__value"];
+    }
+  }
+}

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -350,6 +350,7 @@ export namespace FlowTypes {
     | "accordion_section"
     | "advanced_dashed_box"
     | "workshops_accordion"
+    | "form"
     | "toggle_bar"
     | "animated_section_group"
     | "display_group"

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -37062,7 +37062,7 @@
       {
         "type": "radio_group",
         "name": "radio_group_text",
-        "value": "nothing selected",
+        "value": "name_var_2",
         "parameter_list": {
           "answer_list": "@local.answer_list_4"
         },
@@ -37109,7 +37109,7 @@
       {
         "type": "radio_group",
         "name": "radio_group_image_1",
-        "value": "nothing selected",
+        "value": "happy",
         "parameter_list": {
           "answer_list": "@local.answer_list_5"
         },
@@ -37180,12 +37180,12 @@
       },
       {
         "type": "radio_group",
-        "name": "radio_group_image_1",
-        "value": "nothing selected",
+        "name": "radio_group_image_3",
+        "value": "happiest",
         "parameter_list": {
           "answer_list": "@local.answer_list_5"
         },
-        "_nested_name": "radio_group_image_1",
+        "_nested_name": "radio_group_image_3",
         "_dynamicFields": {
           "parameter_list": {
             "answer_list": [
@@ -37218,11 +37218,11 @@
       },
       {
         "type": "radio_group",
-        "name": "radio_group_two_options_1",
+        "name": "radio_group_two_options_3",
         "parameter_list": {
           "answer_list": "@local.answer_list_2"
         },
-        "_nested_name": "radio_group_two_options_1",
+        "_nested_name": "radio_group_two_options_3",
         "_dynamicFields": {
           "parameter_list": {
             "answer_list": [
@@ -37249,12 +37249,12 @@
       },
       {
         "type": "radio_group",
-        "name": "radio_group_two_options_2",
+        "name": "radio_group_two_options_4",
         "parameter_list": {
           "answer_list": "@local.answer_list_2",
           "options_per_row": "2"
         },
-        "_nested_name": "radio_group_two_options_2",
+        "_nested_name": "radio_group_two_options_4",
         "_dynamicFields": {
           "parameter_list": {
             "answer_list": [
@@ -37281,12 +37281,12 @@
       },
       {
         "type": "radio_group",
-        "name": "radio_group_image_2",
+        "name": "radio_group_image_4",
         "parameter_list": {
           "answer_list": "@local.answer_list_7",
           "options_per_row": "2"
         },
-        "_nested_name": "radio_group_image_2",
+        "_nested_name": "radio_group_image_4",
         "_dynamicFields": {
           "parameter_list": {
             "answer_list": [
@@ -37313,11 +37313,11 @@
       },
       {
         "type": "radio_group",
-        "name": "radio_group_image_2",
+        "name": "radio_group_image_5",
         "parameter_list": {
           "answer_list": "@local.answer_list_7"
         },
-        "_nested_name": "radio_group_image_2",
+        "_nested_name": "radio_group_image_5",
         "_dynamicFields": {
           "parameter_list": {
             "answer_list": [
@@ -37731,6 +37731,152 @@
           }
         ],
         "_nested_name": "dg_example_7"
+      },
+      {
+        "type": "display_group",
+        "name": "dg_example_dashed_box",
+        "parameter_list": {
+          "type": "dashed_box"
+        },
+        "rows": [
+          {
+            "type": "subtitle",
+            "value": "Subtitle",
+            "name": "subtitle",
+            "_nested_name": "dg_example_dashed_box.subtitle"
+          },
+          {
+            "type": "parent_point_box",
+            "name": "points_example_1",
+            "value": 3,
+            "parameter_list": {
+              "lottie_src": "lottie_animations/parent_centre.json",
+              "text": "text two"
+            },
+            "_nested_name": "dg_example_dashed_box.points_example_1"
+          },
+          {
+            "type": "button",
+            "name": "btn_example",
+            "value": "Continue",
+            "parameter_list": {
+              "style": "blue"
+            },
+            "_nested_name": "dg_example_dashed_box.btn_example"
+          }
+        ],
+        "_nested_name": "dg_example_dashed_box"
+      },
+      {
+        "type": "display_group",
+        "name": "dg_example_form",
+        "parameter_list": {
+          "type": "form"
+        },
+        "rows": [
+          {
+            "type": "text_box",
+            "name": "user_name",
+            "parameter_list": {
+              "help": "some help text",
+              "placeholder": "Add your name"
+            },
+            "_nested_name": "dg_example_form.user_name"
+          },
+          {
+            "type": "text_box",
+            "name": "user_phone",
+            "parameter_list": {
+              "help": "some help text",
+              "placeholder": "Add your phone number"
+            },
+            "_nested_name": "dg_example_form.user_phone"
+          },
+          {
+            "type": "simple_checkbox",
+            "name": "checkbox_1",
+            "value": false,
+            "action_list": [
+              {
+                "trigger": "changed",
+                "action_id": "set_field",
+                "args": [
+                  "demo_changed_field_checkbox",
+                  "@local.checkbox_1"
+                ],
+                "_raw": "changed | set_field:demo_changed_field_checkbox:@local.checkbox_1",
+                "_cleaned": "changed | set_field:demo_changed_field_checkbox:@local.checkbox_1"
+              }
+            ],
+            "parameter_list": {
+              "label_text": "Example answer?"
+            },
+            "_nested_name": "dg_example_form.checkbox_1",
+            "_dynamicFields": {
+              "action_list": {
+                "0": {
+                  "args": {
+                    "1": [
+                      {
+                        "fullExpression": "@local.checkbox_1",
+                        "matchedExpression": "@local.checkbox_1",
+                        "type": "local",
+                        "fieldName": "checkbox_1"
+                      }
+                    ]
+                  },
+                  "_raw": [
+                    {
+                      "fullExpression": "changed | set_field:demo_changed_field_checkbox:@local.checkbox_1",
+                      "matchedExpression": "@local.checkbox_1",
+                      "type": "local",
+                      "fieldName": "checkbox_1"
+                    }
+                  ],
+                  "_cleaned": [
+                    {
+                      "fullExpression": "changed | set_field:demo_changed_field_checkbox:@local.checkbox_1",
+                      "matchedExpression": "@local.checkbox_1",
+                      "type": "local",
+                      "fieldName": "checkbox_1"
+                    }
+                  ]
+                }
+              }
+            },
+            "_dynamicDependencies": {
+              "@local.checkbox_1": [
+                "action_list.0.args.1",
+                "action_list.0._raw",
+                "action_list.0._cleaned"
+              ]
+            }
+          },
+          {
+            "type": "simple_checkbox",
+            "name": "checkbox_2",
+            "value": true,
+            "parameter_list": {
+              "label_text": "Example answer?"
+            },
+            "_nested_name": "dg_example_form.checkbox_2"
+          },
+          {
+            "type": "title",
+            "value": "Some text here",
+            "name": "title",
+            "_nested_name": "dg_example_form.title"
+          },
+          {
+            "type": "text_area",
+            "name": "text_area",
+            "parameter_list": {
+              "placeholder": "example placeholder"
+            },
+            "_nested_name": "dg_example_form.text_area"
+          }
+        ],
+        "_nested_name": "dg_example_form"
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/feature_templates/feature_template_components.xlsx"
@@ -40356,54 +40502,255 @@
   },
   {
     "flow_type": "template",
-    "flow_name": "feature_advanced_dashed_box",
+    "flow_name": "feature_toggle_bar ",
     "status": "released",
     "rows": [
       {
-        "type": "advanced_dashed_box",
-        "value": "Every time you do a relax, mark your star in ParentPoints to track your success. ",
-        "parameter_list": {
-          "icon_src": "plh_images/icons/star_circle.svg",
-          "icon_position": "top-left"
-        },
-        "rows": [
+        "type": "toggle_bar",
+        "name": "toggle_1",
+        "value": false,
+        "action_list": [
           {
-            "type": "button",
-            "name": "btn_example_1",
-            "value": "some text as an example ",
-            "_nested_name": "advanced_dashed_box.btn_example_1"
+            "trigger": "changed",
+            "action_id": "set_field",
+            "args": [
+              "changed_field_toggle",
+              "@local.toggle_1"
+            ],
+            "_raw": "changed | set_field:changed_field_toggle:@local.toggle_1",
+            "_cleaned": "changed | set_field:changed_field_toggle:@local.toggle_1"
           }
         ],
-        "name": "advanced_dashed_box",
-        "_nested_name": "advanced_dashed_box"
+        "parameter_list": {
+          "label": "some text",
+          "position": "right",
+          "true_text": "some text for true value",
+          "false_text": "text for false"
+        },
+        "_nested_name": "toggle_1",
+        "_dynamicFields": {
+          "action_list": {
+            "0": {
+              "args": {
+                "1": [
+                  {
+                    "fullExpression": "@local.toggle_1",
+                    "matchedExpression": "@local.toggle_1",
+                    "type": "local",
+                    "fieldName": "toggle_1"
+                  }
+                ]
+              },
+              "_raw": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ],
+              "_cleaned": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ]
+            }
+          }
+        },
+        "_dynamicDependencies": {
+          "@local.toggle_1": [
+            "action_list.0.args.1",
+            "action_list.0._raw",
+            "action_list.0._cleaned"
+          ]
+        }
       },
       {
-        "type": "advanced_dashed_box",
-        "value": "Every time you do a relax, mark your star in ParentPoints to track your success. ",
-        "parameter_list": {
-          "icon_src": "plh_images/icons/star_circle.svg",
-          "icon_position": "top-left"
-        },
-        "rows": [
+        "type": "toggle_bar",
+        "name": "toggle_2",
+        "value": false,
+        "action_list": [
           {
-            "type": "subtitle",
-            "value": "Subtitle",
-            "name": "subtitle",
-            "_nested_name": "advanced_dashed_box.subtitle"
-          },
-          {
-            "type": "parent_point_box",
-            "name": "points_example_1",
-            "value": 3,
-            "parameter_list": {
-              "lottie_src": "lottie_animations/parent_centre.json",
-              "text": "text two"
-            },
-            "_nested_name": "advanced_dashed_box.points_example_1"
+            "trigger": "changed",
+            "action_id": "set_field",
+            "args": [
+              "changed_field_toggle",
+              "@local.toggle_1"
+            ],
+            "_raw": "changed | set_field:changed_field_toggle:@local.toggle_1",
+            "_cleaned": "changed | set_field:changed_field_toggle:@local.toggle_1"
           }
         ],
-        "name": "advanced_dashed_box",
-        "_nested_name": "advanced_dashed_box"
+        "parameter_list": {
+          "label": "some text",
+          "position": "center",
+          "true_text": "some text for true value"
+        },
+        "_nested_name": "toggle_2",
+        "_dynamicFields": {
+          "action_list": {
+            "0": {
+              "args": {
+                "1": [
+                  {
+                    "fullExpression": "@local.toggle_1",
+                    "matchedExpression": "@local.toggle_1",
+                    "type": "local",
+                    "fieldName": "toggle_1"
+                  }
+                ]
+              },
+              "_raw": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ],
+              "_cleaned": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ]
+            }
+          }
+        },
+        "_dynamicDependencies": {
+          "@local.toggle_1": [
+            "action_list.0.args.1",
+            "action_list.0._raw",
+            "action_list.0._cleaned"
+          ]
+        }
+      },
+      {
+        "type": "toggle_bar",
+        "name": "toggle_3",
+        "value": false,
+        "action_list": [
+          {
+            "trigger": "changed",
+            "action_id": "set_field",
+            "args": [
+              "changed_field_toggle",
+              "@local.toggle_1"
+            ],
+            "_raw": "changed | set_field:changed_field_toggle:@local.toggle_1",
+            "_cleaned": "changed | set_field:changed_field_toggle:@local.toggle_1"
+          }
+        ],
+        "parameter_list": {
+          "label": "some text",
+          "false_text": "false text"
+        },
+        "_nested_name": "toggle_3",
+        "_dynamicFields": {
+          "action_list": {
+            "0": {
+              "args": {
+                "1": [
+                  {
+                    "fullExpression": "@local.toggle_1",
+                    "matchedExpression": "@local.toggle_1",
+                    "type": "local",
+                    "fieldName": "toggle_1"
+                  }
+                ]
+              },
+              "_raw": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ],
+              "_cleaned": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ]
+            }
+          }
+        },
+        "_dynamicDependencies": {
+          "@local.toggle_1": [
+            "action_list.0.args.1",
+            "action_list.0._raw",
+            "action_list.0._cleaned"
+          ]
+        }
+      },
+      {
+        "type": "toggle_bar",
+        "name": "toggle_4",
+        "value": true,
+        "action_list": [
+          {
+            "trigger": "changed",
+            "action_id": "set_field",
+            "args": [
+              "changed_field_toggle",
+              "@local.toggle_1"
+            ],
+            "_raw": "changed | set_field:changed_field_toggle:@local.toggle_1",
+            "_cleaned": "changed | set_field:changed_field_toggle:@local.toggle_1"
+          }
+        ],
+        "parameter_list": {
+          "label": "some text",
+          "false_text": "false text"
+        },
+        "_nested_name": "toggle_4",
+        "_dynamicFields": {
+          "action_list": {
+            "0": {
+              "args": {
+                "1": [
+                  {
+                    "fullExpression": "@local.toggle_1",
+                    "matchedExpression": "@local.toggle_1",
+                    "type": "local",
+                    "fieldName": "toggle_1"
+                  }
+                ]
+              },
+              "_raw": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ],
+              "_cleaned": [
+                {
+                  "fullExpression": "changed | set_field:changed_field_toggle:@local.toggle_1",
+                  "matchedExpression": "@local.toggle_1",
+                  "type": "local",
+                  "fieldName": "toggle_1"
+                }
+              ]
+            }
+          }
+        },
+        "_dynamicDependencies": {
+          "@local.toggle_1": [
+            "action_list.0.args.1",
+            "action_list.0._raw",
+            "action_list.0._cleaned"
+          ]
+        }
       }
     ],
     "_xlsxPath": "plh_sheets_beta/plh_templating/quality_assurance/feature_templates/feature_template_components.xlsx"
@@ -51530,11 +51877,39 @@
       {
         "name": "answer_list_1",
         "value": [
-          "name:false | text: On my own | image:plh_images/workshops/options/individual.svg | image_selected:plh_images/workshops/options/individual.svg",
-          "name:true | text:In my group | image:plh_images/workshops/options/together.svg | image_selected:plh_images/workshops/options/together.svg"
+          "name:false | text: @global.individual | image:plh_images/workshops/options/individual.svg | image_selected:plh_images/workshops/options/individual.svg",
+          "name:true | text: @global.together | image:plh_images/workshops/options/together.svg | image_selected:plh_images/workshops/options/together.svg"
         ],
         "type": "set_variable",
-        "_nested_name": "answer_list_1"
+        "_nested_name": "answer_list_1",
+        "_dynamicFields": {
+          "value": {
+            "0": [
+              {
+                "fullExpression": "name:false | text: @global.individual | image:plh_images/workshops/options/individual.svg | image_selected:plh_images/workshops/options/individual.svg",
+                "matchedExpression": "@global.individual",
+                "type": "global",
+                "fieldName": "individual"
+              }
+            ],
+            "1": [
+              {
+                "fullExpression": "name:true | text: @global.together | image:plh_images/workshops/options/together.svg | image_selected:plh_images/workshops/options/together.svg",
+                "matchedExpression": "@global.together",
+                "type": "global",
+                "fieldName": "together"
+              }
+            ]
+          }
+        },
+        "_dynamicDependencies": {
+          "@global.individual": [
+            "value.0"
+          ],
+          "@global.together": [
+            "value.1"
+          ]
+        }
       },
       {
         "type": "radio_group",

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -37759,9 +37759,6 @@
             "type": "button",
             "name": "btn_example",
             "value": "Continue",
-            "parameter_list": {
-              "style": "blue"
-            },
             "_nested_name": "dg_example_dashed_box.btn_example"
           }
         ],
@@ -37771,7 +37768,9 @@
         "type": "display_group",
         "name": "dg_example_form",
         "parameter_list": {
-          "type": "form"
+          "type": "form",
+          "get_device_info": "true",
+          "button_text": "Send"
         },
         "rows": [
           {


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
 - added possibility to use the form component and advanced_dashed_box through the display group by adding a type to it. 
 -  types (form | dashed_box)
 [feature_display_group](https://docs.google.com/spreadsheets/d/1ARbNRGDer5vj9qSpRMZFrMkYifGkH3TLtDVp72YbaqU/edit#gid=1231713195)

_What this PR does_

## Git Issues

_Closes #_

## Screenshots/Videos
<img width="656" alt="Снимок экрана 2021-05-24 в 20 01 17" src="https://user-images.githubusercontent.com/81557818/119345658-c25a1a80-bccb-11eb-801c-277c63fe3f3a.png">

_If useful, provide screenshot or capture to highlight main changes_
