### PR TITLE
Fix/nested rendering

### DIFF
--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -48,4 +48,6 @@ export class TemplateBaseComponent implements ITemplateRowProps {
     };
     return this.parent.handleActions([action], this._row);
   }
+
+  trackByRow = (index: number, row: FlowTypes.TemplateRow) => this.parent.trackByRow(index, row);
 }

--- a/src/app/shared/components/template/components/layout/accordion_section.ts
+++ b/src/app/shared/components/template/components/layout/accordion_section.ts
@@ -41,7 +41,7 @@ import { TemplateBaseComponent } from "../base";
       <h2 (click)="toggleOpen()">{{ title }}</h2>
       <plh-template-component
         style="z-index: 2"
-        *ngFor="let childRow of _row.rows"
+        *ngFor="let childRow of _row.rows; trackBy: trackByRow"
         [row]="childRow"
         [parent]="parent"
       >

--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
@@ -4,7 +4,7 @@
       <img [src]="icon_result" alt="" />
     </div>
     <plh-template-component
-      *ngFor="let childRow of _row.rows"
+      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
       style="width: 100%"

--- a/src/app/shared/components/template/components/layout/animated_section.ts
+++ b/src/app/shared/components/template/components/layout/animated_section.ts
@@ -5,7 +5,7 @@ import { TemplateLayoutComponent } from "./layout";
   selector: "plh-tmpl-animated-section",
   template: `<div class="animated-section">
     <plh-template-component
-      *ngFor="let childRow of _row.rows"
+      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
     ></plh-template-component>

--- a/src/app/shared/components/template/components/layout/animated_section_group.ts
+++ b/src/app/shared/components/template/components/layout/animated_section_group.ts
@@ -5,7 +5,7 @@ import { TemplateBaseComponent } from "../base";
   selector: "plh-tmpl-animated-section-group",
   template: `<div class="animated-section-group">
     <plh-template-component
-      *ngFor="let childRow of _row.rows"
+      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
     ></plh-template-component>

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostBinding, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, HostBinding, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "../../../../utils";
 
@@ -13,7 +13,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
     <div [style.marginBottom.px]="-offset" class="offset" [ngSwitch]="type">
       <ng-container *ngSwitchCase="'default'">
         <plh-template-component
-          *ngFor="let childRow of _row.rows"
+          *ngFor="let childRow of _row.rows; trackBy: trackByRow"
           [row]="childRow"
           [parent]="parent"
         ></plh-template-component>

--- a/src/app/shared/components/template/components/layout/form.ts
+++ b/src/app/shared/components/template/components/layout/form.ts
@@ -12,7 +12,11 @@ const { Device } = Plugins;
 @Component({
   selector: "plh-tmpl-form",
   template: ` <div>
-    <plh-template-component *ngFor="let childRow of _row.rows" [row]="childRow" [parent]="parent">
+    <plh-template-component
+      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      [row]="childRow"
+      [parent]="parent"
+    >
     </plh-template-component>
     <ion-button (click)="submit()">{{ button_text }}</ion-button>
   </div>`,

--- a/src/app/shared/components/template/components/layout/layout.ts
+++ b/src/app/shared/components/template/components/layout/layout.ts
@@ -19,7 +19,7 @@ import { TemplateContainerComponent } from "../../template-container.component";
  *
  * @example template (rendering child rows with reference to this parent container)
  * ```
- *  <plh-template-component *ngFor="let childRow of _row.rows" [row]="childRow" [parent]="parent"></plh-template-component>
+ *  <plh-template-component *ngFor="let childRow of _row.rows; trackBy: trackByRow" [row]="childRow" [parent]="parent"></plh-template-component>
  * ```
  */
 export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
@@ -74,6 +74,9 @@ export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
   public interceptTemplateContainerAction(action: FlowTypes.TemplateRowAction) {
     return true;
   }
+
+  public trackByRow = (index: number, row: FlowTypes.TemplateRow) =>
+    this.parent.trackByRow(index, row);
 
   private addParentActionsFilter() {
     this.parent.templateActionService.handleActionsInterceptor = async (actions) => {

--- a/src/app/shared/components/template/components/slider/slider.component.html
+++ b/src/app/shared/components/template/components/slider/slider.component.html
@@ -17,7 +17,6 @@
       [class.hide-handle]="_row.value === 'no_value' || _row.value === undefined"
       [config]="sliderConfig"
       [style.width.%]="100"
-      [(ngModel)]="sliderValue"
     ></nouislider>
     <div class="checkbox-block" (click)="toggleNACheckbox()">
       <ion-checkbox

--- a/src/app/shared/components/template/services/template-row.service.ts
+++ b/src/app/shared/components/template/services/template-row.service.ts
@@ -83,6 +83,9 @@ export class TemplateRowService {
    */
   private extractOverrideFields(row: FlowTypes.TemplateRow) {
     const { _nested_name, _dynamicFields, _dynamicDependencies, type, ...overrideFields } = row;
+    if (overrideFields.rows) {
+      overrideFields.rows = overrideFields.rows.map((r) => this.extractOverrideFields(r));
+    }
     return overrideFields as FlowTypes.TemplateRow;
   }
 

--- a/src/app/shared/components/template/services/template-row.service.ts
+++ b/src/app/shared/components/template/services/template-row.service.ts
@@ -153,12 +153,12 @@ export class TemplateRowService {
     }
     this.container.template.rows = processedRows;
     // filtering can have impure results for deeply nested objects (e.g. changing original rows),
-    // so force new object first
+    // so force new object first (e.g. debug_combo_box_in_dg)
+    // NOTE - avoid any additional cdr detectChanges after (new object would always force full re-render)
     const renderedRows = this.filterConditionalTemplateRows(
       JSON.parse(JSON.stringify(processedRows))
     );
     this.renderedRows = renderedRows;
-    this.container.cdr.detectChanges();
     log("[Rows Processed]", logName, { rows, processedRows, renderedRows });
     return processedRows;
   }

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -17,6 +17,12 @@ import { TEMPLATE_COMPONENT_MAPPING } from "./components";
 import { FlowTypes, ITemplateRowProps } from "./models";
 import { TemplateContainerComponent } from "./template-container.component";
 
+/** Logging Toggle - rewrite default functions to enable or disable inline logs */
+let SHOW_DEBUG_LOGS = false;
+let log = SHOW_DEBUG_LOGS ? console.log : () => null;
+let log_group = SHOW_DEBUG_LOGS ? console.group : () => null;
+let log_groupEnd = SHOW_DEBUG_LOGS ? console.groupEnd : () => null;
+
 /*********************************************************************
  *  Directive used as part of loading dynamic flow component elemnt
  *********************************************************************/
@@ -79,7 +85,10 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   @Input() set row(row: FlowTypes.TemplateRow) {
     this._row = row;
     if (this.componentRef) {
+      log("[Component Update]", row.name, row);
       this.componentRef.instance.row = row;
+    } else {
+      log("[Component Create]", row.name, row);
     }
   }
 

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -120,8 +120,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
       if (full) {
         console.log("[Force Reload]", this.name);
         // ensure angular destroys previous row components before rendering new
-        this.templateRowService.renderedRows = [];
-        this.cdr.detectChanges();
         await this.renderTemplate();
       } else {
         await this.templateRowService.processRowUpdates();

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -169,25 +169,15 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
       const template = JSON.parse(JSON.stringify(foundTemplate));
       this.name = this.name || this.templatename;
       this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];
-
       this.template = template;
-
-      // If the template has previously been rendered but forced to re-initialise from parent
-      // try to restore previous state (WiP - TODO / Re-evaluate CC 2021-04-21)
-      const cachedRender = this.parent?.children?.[this.name];
-
       log_group("[Template Render Start]", this.name);
-
       await this.templateRowService.processInitialTemplateRows();
-      this.template.rows = this.templateRowService.processedRows;
-
       log("[Template] Rendered", this.name, {
         template,
         ctxt: { ...this },
         renderedRows: { ...this.templateRowService.renderedRows },
         rowMap: mapToJson(this.templateRowService.templateRowMap),
       });
-
       // if a parent exists also provide parent reference to this as a child
       if (this.parent) {
         this.parent.children[this.name] = this;
@@ -204,13 +194,15 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   /**
    * When using ngFor loop track by to ensure updates correctly propagated on change
    *
+   * NOTE - if the rendered row contains a component that also renders child rows
+   * this method should be applied in the child ngFor statement also
    */
   public trackByRow(index: number, row: FlowTypes.TemplateRow) {
-    let value = row.value;
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      value = row.value.id;
-    }
-    return `${row._nested_name}:${value}`;
+    // let value = row.value;
+    // if (value && typeof value === "object" && !Array.isArray(value)) {
+    //   value = row.value.id;
+    // }
+    return `${row._nested_name}`;
   }
 
   /** Query params are used to track state across navigation events */


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Update 2021-06-07
Hopefully now should be in much better shape, new updates include:

- Merged #830 to this branch for fixing child templates with same name as parent
- Merged #831 to remove duplicate re-renders following nav actions
- Updated change detection strategies to prevent excessive rerendering seen following #827 updates
- Improve additional change detection methods for nav events (fixes popup issue seen in `relax` templates)
- Improve change detection methods at component level (fixes immediate issue seen with `tools pages`)
- Fix slider bindings (fixes `debug_slider_with_template`)

## Description

- Add trackby methods to all display components to help rendering updates
- Change core row update methods to detect more changes
- Fix condition filter not being tracked for nested objects

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
