### PR TITLE
Remove duplicate nav re-renders

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -46,8 +46,11 @@ export class TemplateNavService {
     // TODO - merge with hacks folder on merge
     if (!popup_child && !popup_parent && container.template) {
       // TODO - this could also be handled by having a default nav_resume action that emits force_rerender
-      await container.forceRerender(false);
-      // trigger any actions defined for the nav_resume trigger
+      // force rerender on top-most template only
+      if (!parent) {
+        await container.forceRerender(false);
+      }
+      // trigger any actions defined for the nav_resume trigger on all templates
       await container.templateActionService.handleActions([
         { action_id: "emit", args: ["nav_resume"], trigger: "nav_resume" },
       ]);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Minor fix so that the automatic template reprocessing that happens after nav actions (e.g. popup close, back press) is only triggered from the top-most template (by default the action searches for the top-most template anyways and re-renders all templates, so this prevents duplicate rerendering)

This can be seen in the logs when navigating back to the weekly workshops page

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
