### PR TITLE
WiP - Action list value updates

### DIFF
--- a/src/app/shared/components/common/components/combo-box-modal/combo-box-modal.component.ts
+++ b/src/app/shared/components/common/components/combo-box-modal/combo-box-modal.component.ts
@@ -22,7 +22,6 @@ interface AnswerBody {
 export class ComboBoxModalComponent implements OnInit {
   @Input() row: FlowTypes.TemplateRow;
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: any };
   @Input() selectedValue: string;
   @Input() customAnswerSelected: boolean;
   @Input() style: string;

--- a/src/app/shared/components/template/components/audio/audio.component.ts
+++ b/src/app/shared/components/template/components/audio/audio.component.ts
@@ -20,7 +20,6 @@ export class TmplAudioComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit, OnDestroy {
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: any };
   @ViewChild("range", { static: false }) range: IonRange;
   src: string | null;
   titleAudio: string | null;

--- a/src/app/shared/components/template/components/base.ts
+++ b/src/app/shared/components/template/components/base.ts
@@ -13,7 +13,7 @@ import { TemplateContainerComponent } from "../template-container.component";
  * Other components can either extend this one, or implement ITemplateRowProps
  * in their own way.
  * Note, if extending the base component access to data is provided by the declared properties,
- * e.g. `_row`, `_localVariables`
+ * e.g. `_row`
  */
 export class TemplateBaseComponent implements ITemplateRowProps {
   _row: FlowTypes.TemplateRow;
@@ -41,6 +41,7 @@ export class TemplateBaseComponent implements ITemplateRowProps {
 
   /** Update the current value of the row by setting a local variable that matches */
   setValue(value: any) {
+    console.log("setting value", value);
     const action: FlowTypes.TemplateRowAction = {
       action_id: "set_local",
       args: [this._row._nested_name, value],

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -22,7 +22,6 @@ export class TmplComboBoxComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit, OnDestroy {
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: any };
   placeholder: string;
   prioritisePlaceholder: boolean;
   style: string;
@@ -78,7 +77,6 @@ export class TmplComboBoxComponent
       componentProps: {
         row: this._row,
         template: this.template,
-        localVariables: this.localVariables,
         selectedValue: this.customAnswerSelected ? this.text : this._row.value,
         customAnswerSelected: this.customAnswerSelected,
         style: this.style,

--- a/src/app/shared/components/template/components/debugger.ts
+++ b/src/app/shared/components/template/components/debugger.ts
@@ -23,10 +23,6 @@ import { TemplateBaseComponent } from "./base";
             <td>{{ _row[key] | json }}</td>
           </tr>
         </div>
-        <!-- <tr *ngIf="_row._dynamicFields">
-          <td>@local</td>
-          <td>{{ parent.localVariables | json }}</td>
-        </tr> -->
       </table>
       <ion-button fill="clear" size="small" (click)="logDebugInfo()">(log full details)</ion-button>
     </div>
@@ -84,7 +80,6 @@ export class TemplateDebuggerComponent extends TemplateBaseComponent {
     console.group(this._row.type, this._row.name);
     console.log("row", this._row);
     console.log("parent rows", mapToJson(this.parent.templateRowMap));
-    console.log("local overrides", this.parent.localVariables);
     console.log("fields", fields);
     console.log("globals", this.templateService.globals);
     console.log("parent", this.parent);

--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -24,7 +24,6 @@ export class TmplParentPointBoxComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit {
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: any };
   @ViewChild("star", { static: false }) star: ElementRef;
   @ViewChild("celebretionAnim", { static: false }) celebretionAnim: ElementRef;
   @ViewChild("item", { static: false }) item: ElementRef;

--- a/src/app/shared/components/template/components/slider/slider.component.ts
+++ b/src/app/shared/components/template/components/slider/slider.component.ts
@@ -19,7 +19,6 @@ export class TmplSliderComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit {
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: string };
   @ViewChild("slider") slider: NouisliderComponent;
   help: string | null;
   no_value_text: string = "no_value";

--- a/src/app/shared/components/template/components/slider/slider.component.ts
+++ b/src/app/shared/components/template/components/slider/slider.component.ts
@@ -28,12 +28,13 @@ export class TmplSliderComponent
   disabled: boolean = false;
   title: string | null;
   step: number = 1;
-  sliderValue: number | null = 0;
   min_value_label: string | null;
   max_value_label: string | null;
   listNumbers: Array<number> = [];
   no_value: boolean = false;
   labels_count: number | null = 8;
+  /** Track the previous value when toggling NA on/off */
+  previousValue: number;
 
   // Note - not all config options are actually supported by ng2-nouislider (need to dig into code to see what is)
   sliderConfig: Options = {
@@ -66,7 +67,6 @@ export class TmplSliderComponent
     this.step = getNumberParamFromTemplateRow(this._row, "step", this.step);
     this.min_value_label = getStringParamFromTemplateRow(this._row, "min_value_label", null);
     this.max_value_label = getStringParamFromTemplateRow(this._row, "max_value_label", null);
-    this.sliderValue = this._row.value > this.maxValue ? undefined : this._row.value;
     this.labels_count = getNumberParamFromTemplateRow(this._row, "labels_count", 8);
     this.no_value_text = getStringParamFromTemplateRow(this._row, "no_value_text", "no_value");
     this.updateConfigParams();
@@ -75,9 +75,10 @@ export class TmplSliderComponent
 
   async toggleNACheckbox() {
     if (this._row.value === "no_value") {
-      // if restoring functionality assume the value reverts to last known or undefined
-      await this.changeValue(this.sliderValue);
+      // if restoring functionality assume the value reverts to last known (if a number)
+      await this.changeValue(typeof this.previousValue === "number" ? this.previousValue : 0);
     } else {
+      this.previousValue = this._row.value;
       // if removing functionality specify the value as no_value
       await this.changeValue("no_value");
     }
@@ -92,7 +93,7 @@ export class TmplSliderComponent
     this.sliderConfig.range.min = this.minValue;
     this.sliderConfig.range.max = this.maxValue;
     this.sliderConfig.step = this.step;
-    this.sliderConfig.start = this.sliderValue || 0;
+    this.sliderConfig.start = Number(this._row.value) || 0;
     this.sliderConfig.pips.values = this.labels_count;
   }
 }

--- a/src/app/shared/components/template/components/timer/timer.component.ts
+++ b/src/app/shared/components/template/components/timer/timer.component.ts
@@ -23,7 +23,6 @@ export class TmplTimerComponent extends TemplateBaseComponent implements ITempla
     this._row = value;
   }
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: any };
   @ViewChild("min", { static: false }) minInput: ElementRef;
   @ViewChild("sec", { static: false }) secInput: ElementRef;
   state: TimerState;

--- a/src/app/shared/components/template/components/video.ts
+++ b/src/app/shared/components/template/components/video.ts
@@ -50,5 +50,4 @@ export class TmplVideoComponent extends TemplateBaseComponent implements OnInit 
     }
   }
   @Input() template: FlowTypes.Template;
-  @Input() localVariables: { [name: string]: string };
 }

--- a/src/app/shared/components/template/models/index.ts
+++ b/src/app/shared/components/template/models/index.ts
@@ -19,7 +19,6 @@ export interface ITemplateContainerProps {
 /**
  * Properties passed to a template row instance
  * @param row specific data used in component rendering
- * @param localVariables compiled list of variables used across all template rows
  * @param parent reference to parent template container
  */
 export interface ITemplateRowProps {

--- a/src/app/shared/components/template/services/template-action.service.ts
+++ b/src/app/shared/components/template/services/template-action.service.ts
@@ -80,6 +80,13 @@ export class TemplateActionService {
   }
   private async processAction(action: FlowTypes.TemplateRowAction) {
     let { action_id, args } = action;
+    args = args.map((arg) => {
+      // HACK - update any self referenced values (see note from template.parser method)
+      if (arg === "this.value") {
+        arg = this.container.templateRowMap.get(action._triggeredBy?._nested_name)?.value;
+      }
+      return arg;
+    });
     let [key, value] = args;
 
     switch (action_id) {
@@ -190,7 +197,6 @@ export class TemplateActionService {
       }
       rowEntry.value = value;
       this.container.templateRowService.templateRowMap.set(rowEntry._nested_name, rowEntry);
-      this.container.localVariables[rowEntry._nested_name] = rowEntry;
     } else {
       // TODO
       console.warn("Setting local variable which does not exist", { key, value }, "TODO");

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -40,11 +40,6 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   @Input() row?: FlowTypes.TemplateRow;
   children: { [name: string]: TemplateContainerComponent } = {};
 
-  /** Local variables track specific updates that have been made via set_local in this template
-   *  The are used to help restore correct state if reprocessing rows after parent-triggered render
-   * (note, we can't use templateRowMap for this as duplicate named rows would override each other during init) */
-  localVariables: any = {};
-
   template: FlowTypes.Template;
 
   /** */


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
As action lists are parsed and kept static, the values they refer to are always one step behind changes (if referring to self value in a row). Add workaround so that in cases where a row (e.g. `slider`) has an action (e.g. `set_field: some_field: @slider.value`), the self-reference is identified and populated when triggering the action (after the local reference updated)

## TODO
- Create example sheet for testing (e.g. workshop_setup qs)
- Check for any issues
- (optional) remove additional authoring added to duplicate set fields in nav buttons

## Git Issues

_Closes #_

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
