### PR TITLE
Support full-stops at end of dynamic variables

### DIFF
--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -244,6 +244,7 @@ export class TemplateVariablesService {
     if (dynamicNested) {
       return this.evaluatePLHString(dynamicNested, context);
     }
+    evaluated = this.applyDynamicTextModifiers(evaluated, evaluators);
     return evaluated;
   }
 
@@ -334,6 +335,33 @@ export class TemplateVariablesService {
         parsedValue = "";
     }
     return { parsedValue, parseSuccess };
+  }
+
+  /**
+   * Text may have additonal modifiers included with evalutors to be applied
+   * after parsing (e.g. adding full-stop at end of text)
+   */
+  private applyDynamicTextModifiers(
+    text: string,
+    evaluators: FlowTypes.TemplateRowDynamicEvaluator[]
+  ) {
+    for (const evaluator of evaluators) {
+      if (evaluator.modifiers) {
+        const modifiers = Object.keys(
+          evaluator.modifiers
+        ) as (keyof FlowTypes.TemplateRowDynamicEvaluator["modifiers"])[];
+        modifiers.forEach((modifier) => {
+          switch (modifier) {
+            case "end_period":
+              if (!text.endsWith(".")) text = `${text}.`;
+              break;
+            default:
+              break;
+          }
+        });
+      }
+    }
+    return text;
   }
 }
 

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -244,7 +244,6 @@ export class TemplateVariablesService {
     if (dynamicNested) {
       return this.evaluatePLHString(dynamicNested, context);
     }
-    evaluated = this.applyDynamicTextModifiers(evaluated, evaluators);
     return evaluated;
   }
 
@@ -336,35 +335,7 @@ export class TemplateVariablesService {
     }
     return { parsedValue, parseSuccess };
   }
-
-  /**
-   * Text may have additonal modifiers included with evalutors to be applied
-   * after parsing (e.g. adding full-stop at end of text)
-   */
-  private applyDynamicTextModifiers(
-    text: string,
-    evaluators: FlowTypes.TemplateRowDynamicEvaluator[]
-  ) {
-    for (const evaluator of evaluators) {
-      if (evaluator.modifiers) {
-        const modifiers = Object.keys(
-          evaluator.modifiers
-        ) as (keyof FlowTypes.TemplateRowDynamicEvaluator["modifiers"])[];
-        modifiers.forEach((modifier) => {
-          switch (modifier) {
-            case "end_period":
-              if (!text.endsWith(".")) text = `${text}.`;
-              break;
-            default:
-              break;
-          }
-        });
-      }
-    }
-    return text;
-  }
 }
-
 function _arrayToObject(arr: any[]) {
   const obj = {};
   arr.forEach((el, i) => (obj[i] = el));

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -397,8 +397,7 @@ export namespace FlowTypes {
     | "icon_banner"
     | "dashed_box"
     | "lottie_animation"
-    | "parent_point_box"
-    | "help_icon";
+    | "parent_point_box";
 
   export interface TemplateRow {
     type: TemplateRowType;

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -397,7 +397,8 @@ export namespace FlowTypes {
     | "icon_banner"
     | "dashed_box"
     | "lottie_animation"
-    | "parent_point_box";
+    | "parent_point_box"
+    | "help_icon";
 
   export interface TemplateRow {
     type: TemplateRowType;
@@ -435,6 +436,10 @@ export namespace FlowTypes {
     // i.e. @data.campaign_list | evaluate_conditions | first (or similar)
     type: "local" | "field" | "fields" | "global" | "data" | "campaign" | "calc";
     fieldName: string;
+    /** additional text modifiers to be applied after parsing */
+    modifiers?: {
+      end_period?: true;
+    };
     // computed properties
     parsedValue?: any;
     parsedExpression?: string;

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -435,10 +435,6 @@ export namespace FlowTypes {
     // i.e. @data.campaign_list | evaluate_conditions | first (or similar)
     type: "local" | "field" | "fields" | "global" | "data" | "campaign" | "calc";
     fieldName: string;
-    /** additional text modifiers to be applied after parsing */
-    modifiers?: {
-      end_period?: true;
-    };
     // computed properties
     parsedValue?: any;
     parsedExpression?: string;

--- a/src/app/shared/utils/variables.utils.ts
+++ b/src/app/shared/utils/variables.utils.ts
@@ -69,10 +69,8 @@ export function extractDynamicEvaluators(
     const regex1 = /!?@([a-z]+)\.([0-9a-z_]+)([0-9a-z_.]*)/gi;
     allMatches = _matchAll(regex1, fullExpression).map((m) => {
       let [matchedExpression, type, fieldName] = m as any[];
-      let evaluator: FlowTypes.TemplateRowDynamicEvaluator;
       if (matchedExpression.endsWith(".")) matchedExpression = matchedExpression.slice(0, -1);
-      evaluator = { fullExpression, matchedExpression, type, fieldName };
-      return evaluator;
+      return { fullExpression, matchedExpression, type, fieldName };
     });
     // provide a separate regex for @eval statements as they don't use dot notation
     // i.e @calc(some JS expression) as opposed to @calc.(some expression)
@@ -81,9 +79,7 @@ export function extractDynamicEvaluators(
       ...allMatches,
       ..._matchAll(regex2, fullExpression).map((m) => {
         const [matchedExpression, type, fieldName] = m as any[];
-        let evaluator: FlowTypes.TemplateRowDynamicEvaluator;
-        evaluator = { fullExpression, matchedExpression, type, fieldName };
-        return evaluator;
+        return { fullExpression, matchedExpression, type, fieldName };
       }),
     ];
     // expect the number of match statements to match the total number of @ characters (replace all non-@)

--- a/src/app/shared/utils/variables.utils.ts
+++ b/src/app/shared/utils/variables.utils.ts
@@ -68,8 +68,9 @@ export function extractDynamicEvaluators(
   if (typeof fullExpression === "string") {
     const regex1 = /!?@([a-z]+)\.([0-9a-z_]+)([0-9a-z_.]*)/gi;
     allMatches = _matchAll(regex1, fullExpression).map((m) => {
-      const [matchedExpression, type, fieldName] = m as any[];
+      let [matchedExpression, type, fieldName] = m as any[];
       let evaluator: FlowTypes.TemplateRowDynamicEvaluator;
+      if (matchedExpression.endsWith(".")) matchedExpression = matchedExpression.slice(0, -1);
       evaluator = { fullExpression, matchedExpression, type, fieldName };
       return evaluator;
     });
@@ -97,30 +98,9 @@ export function extractDynamicEvaluators(
     }
   }
   if (allMatches.length > 0) {
-    allMatches = processMatchModifiers(allMatches);
     return allMatches;
   }
   return null;
-}
-
-/**
- * Process match text for minor housekeeping/tidying before returning
- * expression and any modifiers for parsing.
- */
-function processMatchModifiers(matches: FlowTypes.TemplateRowDynamicEvaluator[]) {
-  return matches.map((match, i) => {
-    const isLastMatch = i === matches.length - 1;
-    if (isLastMatch) {
-      // if expression ends with a period this cannot be distinguished easily from
-      // nested properties (e.g. @local.some_value.@some_nested vs @local.some_value.)
-      // extract and save as future modifier
-      if (match.matchedExpression.endsWith(".")) {
-        match.matchedExpression = match.matchedExpression.slice(0, -1);
-        match.modifiers = { end_period: true };
-      }
-    }
-    return match;
-  });
 }
 
 /**

--- a/src/app/shared/utils/variables.utils.ts
+++ b/src/app/shared/utils/variables.utils.ts
@@ -69,6 +69,7 @@ export function extractDynamicEvaluators(
     const regex1 = /!?@([a-z]+)\.([0-9a-z_]+)([0-9a-z_.]*)/gi;
     allMatches = _matchAll(regex1, fullExpression).map((m) => {
       let [matchedExpression, type, fieldName] = m as any[];
+      // if expression ends in period expect this is intended as a text full-stop (not nested property)
       if (matchedExpression.endsWith(".")) matchedExpression = matchedExpression.slice(0, -1);
       return { fullExpression, matchedExpression, type, fieldName };
     });


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Add method to parser to check for dynamic expressions ending in full stops, and treat as a string full-stop instead of trying to access nested property

## TODO
- As the fix is to interpret the dynamic expressions slightly differently, any content authored as a workaround should ideally be updated (change spaces before full-stops). Although could add short term _hack_ to automatically replace ```(space).``` in sentences if useful. Otherwise should be good to merge

## Git Issues

_Closes #_

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/122655557-07753f00-d108-11eb-9aa0-6734ecd365ef.png)
