### PR TITLE
Created the go_to_url action and set it to open a url in a new window…

### DIFF
--- a/src/app/shared/components/template/services/template-action.service.ts
+++ b/src/app/shared/components/template/services/template-action.service.ts
@@ -91,6 +91,8 @@ export class TemplateActionService {
         return this.container.templateService.setGlobal(key, value);
       case "go_to":
         return this.container.templateNavService.handleNavAction(action, this.container);
+      case "go_to_url":
+        return window.open(args[1], "_blank");
       case "pop_up":
         return this.container.templateNavService.handlePopupAction(action, this.container);
       case "set_field":

--- a/src/app/shared/model/flowTypes.ts
+++ b/src/app/shared/model/flowTypes.ts
@@ -466,6 +466,7 @@ export namespace FlowTypes {
       | "changed"
       // note - to keep target nav within component stack go_to is actually just a special case of pop_up
       | "go_to"
+      | "go_to_url"
       | "pop_up"
       | "audio_end"
       | "audio_play"

--- a/src/data/template.ts
+++ b/src/data/template.ts
@@ -6179,6 +6179,18 @@
     "status": "released",
     "rows": [
       {
+        "name": "tile_1_text",
+        "value": "WHO Website",
+        "type": "set_variable",
+        "_nested_name": "tile_1_text"
+      },
+      {
+        "name": "tile_2_text",
+        "value": "UNICEF Website",
+        "type": "set_variable",
+        "_nested_name": "tile_2_text"
+      },
+      {
         "type": "title",
         "name": "title",
         "value": "@data.parent_centre.covid.title",
@@ -6209,18 +6221,138 @@
         "_nested_name": "text_1"
       },
       {
-        "type": "text",
-        "name": "text_2",
-        "value": "https://www.who.int/emergencies/diseases/novel-coronavirus-2019",
-        "exclude_from_translation": true,
-        "_nested_name": "text_2"
+        "type": "display_group",
+        "rows": [
+          {
+            "type": "tile_component",
+            "name": "tile_1",
+            "value": "tile_1",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "go_to_url",
+                "args": [
+                  "https",
+                  "//www.who.int/emergencies/diseases/novel-coronavirus-2019"
+                ],
+                "_raw": "click | go_to_url:https://www.who.int/emergencies/diseases/novel-coronavirus-2019",
+                "_cleaned": "click | go_to_url:https://www.who.int/emergencies/diseases/novel-coronavirus-2019"
+              }
+            ],
+            "exclude_from_translation": true,
+            "parameter_list": {
+              "first_line_text": "@local.tile_1_text",
+              "left_icon_src": "globe-outline",
+              "style": "button_tile",
+              "icon_src": "chevron-forward-outline"
+            },
+            "_nested_name": "display_group.tile_1",
+            "_dynamicFields": {
+              "parameter_list": {
+                "first_line_text": [
+                  {
+                    "fullExpression": "@local.tile_1_text",
+                    "matchedExpression": "@local.tile_1_text",
+                    "type": "local",
+                    "fieldName": "tile_1_text"
+                  }
+                ]
+              }
+            },
+            "_dynamicDependencies": {
+              "@local.tile_1_text": [
+                "parameter_list.first_line_text"
+              ]
+            }
+          },
+          {
+            "type": "help_icon",
+            "name": "help_1",
+            "value": "help_1",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "pop_up",
+                "args": [
+                  "parent_centre_covid_who_pop_up"
+                ],
+                "_raw": "click | pop_up:parent_centre_covid_who_pop_up",
+                "_cleaned": "click | pop_up:parent_centre_covid_who_pop_up"
+              }
+            ],
+            "exclude_from_translation": true,
+            "_nested_name": "display_group.help_1"
+          }
+        ],
+        "name": "display_group",
+        "_nested_name": "display_group"
       },
       {
-        "type": "text",
-        "name": "text_3",
-        "value": "https://www.unicef.org/coronavirus/covid-19",
-        "exclude_from_translation": true,
-        "_nested_name": "text_3"
+        "type": "display_group",
+        "rows": [
+          {
+            "type": "tile_component",
+            "name": "tile_2",
+            "value": "tile_2",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "go_to_url",
+                "args": [
+                  "https",
+                  "//www.unicef.org/coronavirus/covid-19"
+                ],
+                "_raw": "click | go_to_url:https://www.unicef.org/coronavirus/covid-19",
+                "_cleaned": "click | go_to_url:https://www.unicef.org/coronavirus/covid-19"
+              }
+            ],
+            "exclude_from_translation": true,
+            "parameter_list": {
+              "first_line_text": "@local.tile_2_text",
+              "left_icon_src": "globe-outline",
+              "style": "button_tile",
+              "icon_src": "chevron-forward-outline"
+            },
+            "_nested_name": "display_group.tile_2",
+            "_dynamicFields": {
+              "parameter_list": {
+                "first_line_text": [
+                  {
+                    "fullExpression": "@local.tile_2_text",
+                    "matchedExpression": "@local.tile_2_text",
+                    "type": "local",
+                    "fieldName": "tile_2_text"
+                  }
+                ]
+              }
+            },
+            "_dynamicDependencies": {
+              "@local.tile_2_text": [
+                "parameter_list.first_line_text"
+              ]
+            }
+          },
+          {
+            "type": "help_icon",
+            "name": "help_2",
+            "value": "help_2",
+            "action_list": [
+              {
+                "trigger": "click",
+                "action_id": "pop_up",
+                "args": [
+                  "parent_centre_covid_uni_pop_up"
+                ],
+                "_raw": "click | pop_up:parent_centre_covid_uni_pop_up",
+                "_cleaned": "click | pop_up:parent_centre_covid_uni_pop_up"
+              }
+            ],
+            "exclude_from_translation": true,
+            "_nested_name": "display_group.help_2"
+          }
+        ],
+        "name": "display_group",
+        "_nested_name": "display_group"
       },
       {
         "type": "dashed_box",


### PR DESCRIPTION
…. URL should start with http or https.

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

Create action go_to_url to open an external link through a button. The argument (url) should start with http or https.
Updated the template [parent-centre_covid](https://docs.google.com/spreadsheets/d/1G0vehNt2KV8cDpyiqa1YT2rl2wQllKNA2w0246sHrdQ/edit#gid=1097835814) to demo the behaviour in the buttons to WHO and UNICEF websites.
