### PR TITLE
change null to "" if the parameter for left_icon_src is left empty

### DIFF
--- a/src/app/shared/components/template/components/tile-component/tile-component.component.ts
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.ts
@@ -40,7 +40,7 @@ export class TmplTileComponent extends TemplateBaseComponent implements ITemplat
     this.first_line_text = getStringParamFromTemplateRow(this._row, "first_line_text", null);
     this.second_line_text = getStringParamFromTemplateRow(this._row, "second_line_text", null);
     this.icon_src = getStringParamFromTemplateRow(this._row, "icon_src", null);
-    this.left_icon_src = getStringParamFromTemplateRow(this._row, "left_icon_src", null);
+    this.left_icon_src = getStringParamFromTemplateRow(this._row, "left_icon_src", "");
     this.value = this._row.value;
     this.windowWidth = window.innerWidth;
     this.style = `


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Change the value for a left_icon_src parameter in the tile_component to "" from null. This is required as if it is null then the `*ngIf="left_icon_src"` in the file \parenting-app-ui\src\app\shared\components\template\components\tile-component\tile-component.component.html evaluates as true if the parameter is null. The consequence of having null is that for tiles that don't have the parameter left_icon_src the icon is not found as the location is "null" and it displays a default value if it exists in the authoring or a broken image if there is no default value. One example is the quickstart round icons in the home screen as shown below.

## Screenshots/Videos
Screenshot of quickstart buttons going back to default values if null:
<img src="https://user-images.githubusercontent.com/46322225/124601418-b54e5080-de5f-11eb-8472-1c268a932e97.png" width="300px"></img>
Screenshot of quickstart buttons going back to default values if "":
<img src="https://user-images.githubusercontent.com/46322225/124601603-f21a4780-de5f-11eb-8915-53cacd317385.png" width="300px"></img>
