### PR TITLE
add sidemenu template

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,10 +11,12 @@
       </ion-toolbar>
     </ion-header>
     <ion-content>
-      <ion-list style="height: 100%; display: flex; flex-direction: column" (click)="menu.close()">
+      <plh-template-container
+        class="main-layout-padding"
+        templatename="app_menu"
+      ></plh-template-container>
+      <!-- <ion-list style="height: 100%; display: flex; flex-direction: column" (click)="menu.close()">
         <ion-item routerLink="/">Home</ion-item>
-        <!-- <ion-item>Progress</ion-item> -->
-        <!-- <ion-item routerLink="family">My Family</ion-item> -->
         <ion-item routerLink="about">About PLH App</ion-item>
         <ion-item routerLink="settings">Settings</ion-item>
         <ion-item routerLink="template">Template</ion-item>
@@ -24,15 +26,13 @@
         <div style="flex: 1"></div>
         <ion-item routerLink="privacy">Privacy Policy</ion-item>
         <ion-item routerLink="app-terms">App Terms</ion-item>
-      </ion-list>
+      </ion-list> -->
     </ion-content>
   </ion-menu>
-  <!-- Sit global header above main content view -->
   <div style="display: flex; flex-direction: column; height: 100%">
     <plh-main-header></plh-main-header>
     <div class="route-container">
       <ion-router-outlet id="main-content"></ion-router-outlet>
     </div>
-    <!-- <plh-main-tabs></plh-main-tabs> -->
   </div>
 </ion-app>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,6 @@
         <ion-title>ParentApp</ion-title>
 
         <div class="app-version" slot="end">
-          <plh-debug-toggle></plh-debug-toggle>
           <span>{{ APP_VERSION }} ({{ ENV_NAME }})</span>
         </div>
       </ion-toolbar>
@@ -14,19 +13,8 @@
       <plh-template-container
         class="main-layout-padding"
         templatename="app_menu"
+        (click)="menu.close()"
       ></plh-template-container>
-      <!-- <ion-list style="height: 100%; display: flex; flex-direction: column" (click)="menu.close()">
-        <ion-item routerLink="/">Home</ion-item>
-        <ion-item routerLink="about">About PLH App</ion-item>
-        <ion-item routerLink="settings">Settings</ion-item>
-        <ion-item routerLink="template">Template</ion-item>
-        <ion-item routerLink="tour">Tour</ion-item>
-        <ion-item routerLink="template/message_navigation">In-week messages</ion-item>
-        <ion-item routerLink="campaigns">Campaigns</ion-item>
-        <div style="flex: 1"></div>
-        <ion-item routerLink="privacy">Privacy Policy</ion-item>
-        <ion-item routerLink="app-terms">App Terms</ion-item>
-      </ion-list> -->
     </ion-content>
   </ion-menu>
   <div style="display: flex; flex-direction: column; height: 100%">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -30,6 +30,7 @@ import player from "lottie-web";
 import { MatomoModule } from "ngx-matomo";
 import { TourComponent } from "./feature/tour/tour.component";
 import { httpInterceptorProviders } from "./shared/services/server/interceptors";
+import { TemplateComponentsModule } from "./shared/components/template/template.module";
 
 // Note we need a separate function as it's required
 // by the AOT compiler.
@@ -55,6 +56,7 @@ export function lottiePlayerFactory() {
     ...introModules,
     SurveyModule,
     LottieModule.forRoot({ player: lottiePlayerFactory, useCache: true }),
+    TemplateComponentsModule,
     // TODO - use env (handle undefined case)
     // TODO - handle breaking versions ng 10/11/12 matomo rc1,2
     // MatomoModule.forRoot({

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -68,7 +68,9 @@ export class TemplateNavService {
     const [templatename] = action.args;
     const nav_parent_triggered_by = action._triggeredBy.name;
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
-    return container.router.navigate(["template", templatename], {
+    // handle direct page or template navigation
+    const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
+    return container.router.navigate(navTarget, {
       queryParams,
       queryParamsHandling: "merge",
     });


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Builds from #922 (merged to avoid type issues)

- Replace sidemenu with `app_menu` template
- Update `go_to` action to support direct navigation when previxed with a `/` (e.g. `/campaigns`)

## Git Issues

Closes #920

## Screenshots/Videos
https://user-images.githubusercontent.com/10515065/127236547-c2b71cf9-d1ce-4fe7-8045-4d5bb22b749b.mp4
