### PR TITLE
Add support for item loops within templates

### DIFF
--- a/packages/plh-data/model/flowTypes.ts
+++ b/packages/plh-data/model/flowTypes.ts
@@ -436,7 +436,8 @@ export namespace FlowTypes {
     | "lottie_animation"
     | "parent_point_box"
     | "debug_toggle"
-    | "items";
+    | "items"
+    | "group";
 
   export interface TemplateRow extends Row_with_translations {
     type: TemplateRowType;

--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -45,6 +45,7 @@ import { TmplParentPointBoxComponent } from "./points-item/points-item.component
 import { TmplLottieAnimation } from "./lottie-animation";
 import { TmplIconComponent } from "./icon";
 import { PLHDebugToggleComponent } from "../../debug-toggle";
+import { TmplGroupComponent } from "./layout/group";
 
 /** All components should be exported as a single array for easy module import */
 export const TEMPLATE_COMPONENTS = [
@@ -87,6 +88,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplDashedBoxComponent,
   TmplParentPointBoxComponent,
   TmplLottieAnimation,
+  TmplGroupComponent,
 ];
 
 /***************************************************************************************
@@ -147,4 +149,5 @@ export const TEMPLATE_COMPONENT_MAPPING: Record<
   lottie_animation: TmplLottieAnimation,
   debug_toggle: PLHDebugToggleComponent as any,
   items: null,
+  group: TmplGroupComponent,
 };

--- a/src/app/shared/components/template/components/layout/group.ts
+++ b/src/app/shared/components/template/components/layout/group.ts
@@ -1,0 +1,22 @@
+import { Component } from "@angular/core";
+import { TemplateLayoutComponent } from "./layout";
+
+@Component({
+  selector: "plh-tmpl-group",
+  template: `
+    <plh-template-component
+      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      [row]="childRow"
+      [parent]="parent"
+    ></plh-template-component>
+  `,
+  styleUrls: ["../tmpl-components-common.scss"],
+  styles: [
+    `
+      :host {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class TmplGroupComponent extends TemplateLayoutComponent {}

--- a/src/app/shared/components/template/utils/template-utils.ts
+++ b/src/app/shared/components/template/utils/template-utils.ts
@@ -135,3 +135,18 @@ export function getImageAssetPath(value: string) {
   }
   return transformed;
 }
+
+/**
+ * Take an object and return an array via the object.values method.
+ * Provide additional check in case already is array (return array), or is not an object
+ * (return empty array)
+ */
+export function objectToArray(obj: any) {
+  if (Array.isArray(obj)) return obj;
+  if (obj) {
+    if (typeof obj === "object") {
+      return Object.values(obj);
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add support for a `begin_items`  and `end_items` template block that can be used to iterate over items and provide dynamic methods to work with them

## Git Issues

Closes #

## Screenshots/Videos

[example_items sheet](https://docs.google.com/spreadsheets/d/1n82prWaYx-HWKW0ibxv-sO_Vuw9WxvuNLRJ_jI_WXtk/edit#gid=1082016302)

![image](https://user-images.githubusercontent.com/10515065/129291249-767eba72-c7a0-4a85-b360-3e037c8500ad.png)


Corresponding data_list
![image](https://user-images.githubusercontent.com/10515065/129291079-cc19f5bc-7cb5-4a76-a7c9-2cdf23fdf575.png)

Example output
![image](https://user-images.githubusercontent.com/10515065/129291211-33e376d8-dd8a-407f-b519-c6762274a597.png)


