### PR TITLE
Feat/template startup

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<ion-app *ngIf="skipTutorial">
+<ion-app *ngIf="skipTutorial && initComplete">
   <ion-menu #menu side="start" menuId="main-side-menu" contentId="main-content">
     <ion-header>
       <ion-toolbar color="primary">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ import { TemplateService } from "./shared/components/template/services/template.
 import { CampaignService } from "./feature/campaign/campaign.service";
 import { ServerService } from "./shared/services/server/server.service";
 import { DataEvaluationService } from "./shared/services/data/data-evaluation.service";
+import { TemplateProcessService } from "./shared/components/template/services/template-process.service";
 
 @Component({
   selector: "app-root",
@@ -26,6 +27,7 @@ export class AppComponent {
   APP_VERSION = environment.version;
   ENV_NAME = environment.envName;
   skipTutorial: boolean;
+  public initComplete = false;
   constructor(
     private platform: Platform,
     private menuController: MenuController,
@@ -37,6 +39,7 @@ export class AppComponent {
     private surveyService: SurveyService,
     private tourService: TourService,
     private templateService: TemplateService,
+    private templateProcessService: TemplateProcessService,
     private appEventService: AppEventService,
     private campaignService: CampaignService,
     private dataEvaluationService: DataEvaluationService,
@@ -85,6 +88,9 @@ export class AppComponent {
     await this.appEventService.init();
     await this.serverService.init();
     await this.dataEvaluationService.refreshDBCache();
+    await this.templateService.init();
+    await this.templateProcessService.init();
+    this.initComplete = true;
   }
 
   clickOnMenuItem(id: string) {

--- a/src/app/shared/components/template/services/template-action.service.ts
+++ b/src/app/shared/components/template/services/template-action.service.ts
@@ -3,6 +3,7 @@ import { takeWhile } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
 import { TemplateContainerComponent } from "../template-container.component";
 import { SettingsService } from "src/app/pages/settings/settings.service";
+import { TemplateProcessService } from "./template-process.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -134,6 +135,20 @@ export class TemplateActionService {
           this.actionsQueue.push({ ...a, _triggeredBy: action._triggeredBy })
         );
         return;
+      case "process_template":
+        // HACK - create an embedded template processor service instance to process template programatically
+        const templateToProcess = this.container.templateService.getTemplateByName(args[0]);
+        const processor = new TemplateProcessService(
+          this.container.templateService,
+          this.container.templateVariables,
+          this.container.templateTranslateService,
+          this.container.tourService,
+          this.container.router,
+          this.container.route,
+          this.container.templateNavService,
+          this.container.settingsService
+        );
+        return processor.processTemplateWithoutRender(templateToProcess);
       case "emit":
         const [emit_value, emit_from] = args;
         let container: TemplateContainerComponent = this.container;

--- a/src/app/shared/components/template/services/template-calc.service.ts
+++ b/src/app/shared/components/template/services/template-calc.service.ts
@@ -8,14 +8,20 @@ import { DataEvaluationService } from "src/app/shared/services/data/data-evaluat
 @Injectable({ providedIn: "root" })
 export class TemplateCalcService {
   /** list of all variables accessible directly within calculations */
-  public calcContext: ICalcContext;
+  private calcContext: ICalcContext;
 
   constructor(
     private serverService: ServerService,
     private dataEvaluationService: DataEvaluationService
-  ) {
-    this.calcContext = this.generateCalcContext();
-    this.addWindowCalcFunctions();
+  ) {}
+
+  /** Provide calc context, initialising only once */
+  public getCalcContext() {
+    if (!this.calcContext) {
+      this.addWindowCalcFunctions();
+      this.calcContext = this.generateCalcContext();
+    }
+    return this.calcContext;
   }
 
   /**

--- a/src/app/shared/components/template/services/template-process.service.ts
+++ b/src/app/shared/components/template/services/template-process.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { FlowTypes } from "packages/plh-data/model";
+import { SettingsService } from "src/app/pages/settings/settings.service";
+import { TEMPLATE } from "src/app/shared/services/data/data.service";
+import { TourService } from "src/app/shared/services/tour/tour.service";
+import { TemplateContainerComponent } from "../template-container.component";
+import { TemplateNavService } from "./template-nav.service";
+import { TemplateTranslateService } from "./template-translate.service";
+import { TemplateVariablesService } from "./template-variables.service";
+import { TemplateService } from "./template.service";
+
+/**
+ * The template process service is a slightly hacky wrapper around the template container component so that
+ * we can process templates programatically (i.e. without rendering a template component)
+ *
+ * TODO - Ideally all core processing lobic should move into the template process service and the container
+ * component extending it (instead of vice-versa)
+ */
+@Injectable({ providedIn: "root" })
+export class TemplateProcessService {
+  container: TemplateContainerComponent;
+  constructor(
+    templateService: TemplateService,
+    templateVariables: TemplateVariablesService,
+    templateTranslateService: TemplateTranslateService,
+    tourService: TourService,
+    router: Router,
+    route: ActivatedRoute,
+    // elRef: ElementRef,
+    templateNavService: TemplateNavService,
+    // cdr: ChangeDetectorRef,
+    settingsService: SettingsService
+  ) {
+    // Create mock template container component
+    console.log("hello template process service");
+    this.container = new TemplateContainerComponent(
+      templateService,
+      templateVariables,
+      templateTranslateService,
+      tourService,
+      router,
+      route,
+      null as any,
+      templateNavService,
+      null as any,
+      settingsService
+    );
+  }
+
+  public async init() {
+    await this.initialiseStartupTemplates();
+  }
+
+  public async processTemplateWithoutRender(template: FlowTypes.Template) {
+    console.log("[Template Process]", template.flow_name);
+    // this.container.name = this.container.name || this.templatename;
+    // this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];
+    this.container.template = template;
+    // reset any existing templateRowMap data
+    this.container.templateRowService.templateRowMap = {};
+    // process the template as if it were rendered
+    // TODO - should filter out template rows to only include those used programatically (e.g. set_variable, set_field etc.)
+    await this.container.templateRowService.processContainerTemplateRows();
+  }
+
+  private async initialiseStartupTemplates() {
+    const startupTemplates = TEMPLATE.filter((t) => t.process_on_start).sort(
+      (a, b) => a.process_on_start - b.process_on_start
+    );
+    for (const template of startupTemplates) {
+      // create a deep clone of the object to prevent accidental reference changes
+      // assign a name (in case top-level template) and store breadcrumb path for nested
+      // (NOTE - would no longer be required if reading in json objects instead of ts import)
+      const templateCopy = JSON.parse(JSON.stringify(template));
+      await this.processTemplateWithoutRender(templateCopy);
+    }
+  }
+}

--- a/src/app/shared/components/template/services/template-row.service.ts
+++ b/src/app/shared/components/template/services/template-row.service.ts
@@ -38,7 +38,7 @@ export class TemplateRowService {
    * On template init combine any inherited row overrides with template rows,
    * process dynamic variables and filter conditions
    */
-  public async processInitialTemplateRows() {
+  public async processContainerTemplateRows() {
     const { name, template, row } = this.container;
     log_group("[Rows Init]", name, row?.value || "");
     const overrides = this.getParentOverridesHashmap(row?.rows, name);
@@ -258,7 +258,7 @@ export class TemplateRowService {
     if (!isNestedTemplate) {
       switch (type) {
         case "set_field":
-          console.warn("[W] Setting fields from template is not advised", row);
+          // console.warn("[W] Setting fields from template is not advised", row);
           await this.container.templateService.setField(name, value);
           return;
         // ensure set_variables are recorded via their name (instead of default nested name)

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -132,7 +132,7 @@ export class TemplateVariablesService {
     const fullExpression = evaluators[0].fullExpression;
     log_group(fullExpression);
     // create a base context of variables and functions that will be available when evaluating javascript
-    let calcContext = this.templateCalcService.calcContext;
+    let calcContext = this.templateCalcService.getCalcContext();
 
     // evaluate each dynamic expression and store to the 'this' context that will be used to evaluate
     // at the end. E.g. this.fields = { some_value: 4 }. Update the context and full expression


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Note 1
Type definition updates to support feature already merged with #945 to support testing

## Note 2
The implementation is somewhat hacky, as currently the logic that processes and renders templates is coupled tightly with the template display component itself (because traditionally we would process templates in the order that they're rendered on the page, allowing deep nesting and more complex use cases).

So for now, to allow programmatic rendering we essentially create a dummy display component which is never rendered, and use that to process the logic. In the future we ideally would want to refactor to separate all the processing logic out from the display component, and call from either a display component or programatically.

## Description
Add support to programmatically parse template rows, so that all logic is processed (including set_variable, set_field etc.) statements, but no rows rendered. Templates can either be processed via `process_template` action, or automatically on app start via `process_on_start` content_list column

- Create [example_startup sheets](https://docs.google.com/spreadsheets/d/1ww3DZBygZH9iT_tIfyrV_-DrML6zaA9UKHF1M8DQifc/edit#gid=1745157248)
- Add support for `process_on_start` content_list column
- Add support for `process_template` action 

## Git Issues

Closes #

## Screenshots/Videos

_Startup Processing_
![image](https://user-images.githubusercontent.com/10515065/129635807-51b9e0b7-2677-4568-8ecc-f6013c321069.png)

_Triggered Processing_
![image](https://user-images.githubusercontent.com/10515065/129635724-9b30c103-542c-4ff4-977f-9e4d10d23592.png)

Example field initialised from startup.
Fields set in startup_1 have been overwritten by higher-priority fields set in startup_2 (see individual sheets for code)

![image](https://user-images.githubusercontent.com/10515065/129635932-b301157a-77b2-49c1-a020-0aeabafedada.png)

