### PR TITLE
add suport for calc now and timestamp statements

### DIFF
--- a/src/app/shared/components/template/services/template-calc.service.ts
+++ b/src/app/shared/components/template/services/template-calc.service.ts
@@ -86,6 +86,17 @@ export class TemplateCalcService {
  * ```
  */
 const CALC_FUNCTIONS: IFunctionHashmap = {
+  /** Shortcut method to generate current datetime as Date object */
+  now: () => new Date(),
+
+  /**
+   * Same code used in app generateTimestamp method to generate a string representation
+   * of a given date (or current date if no input specified)
+   */
+  timestamp: (value?: string | Date) => {
+    const date = value ? new Date(value) : new Date();
+    return (window as any).date_fns.format(date, "yyyy-MM-dd'T'HH:mm:ss");
+  },
   /**
    * Pick a random item from a list
    * @param arr array of items to pick from


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

- Add `@calc(now())` function to generate current Date (wrapper around JS `new Date()`)
- Add `@calc(timestamp())` function to generate db-friendly string representation of date or time object (default current date)
- Examples added to [example_calc](https://docs.google.com/spreadsheets/d/15TccctjzepSPPv9xrLp46fhYldNN0wrho1zA5voTYcg/edit#gid=1595229908)

## Git Issues

Closes #

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/129746817-f2c0ae15-f281-476a-9ccb-ebf30a493bc1.png)

![image](https://user-images.githubusercontent.com/10515065/129746563-9c1d7c94-4f7f-4cca-9659-ff8fdc30f946.png)




