### PR TITLE
Update nav_group.ts

### DIFF
--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -156,9 +156,10 @@ export class NavGroupComponent extends TemplateLayoutComponent {
       );
       const previousPercentDone = Number.parseInt(this.templateService.getField(progressField));
       let percentDone = currentPercentDone;
-      if (previousPercentDone && previousPercentDone != NaN) {
-        percentDone = Math.max(currentPercentDone, previousPercentDone);
-      }
+      // if (previousPercentDone && previousPercentDone != NaN) {
+      //
+      //   percentDone = Math.max(currentPercentDone, previousPercentDone);
+      // }
       await this.parent.handleActions(
         [
           {


### PR DESCRIPTION
Commenting out code that returns a max value between the current percentage of stepper and the previous current percentage of the stepper. Issue 905

PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

This PR deals with the [git issue](https://github.com/IDEMSInternational/parenting-app-ui/issues/905). Upon returning to the previous stages of the stepper, the stepper remains on the current step.

### Scenario 1:
We have a stepper with 6 slides. We head to slider 3 from slider 2.
The currentPercentDone will be 50 and previousPercentDone will be 33. And bypassing value in this function, percentDone will be 50.
Stepper will successfully move to Slider 3.

### Scenario 2:
We have a stepper with 6 slides. We want to head toward slider 1 from slider 3.
The currentPercentDone will be 16 and previousPercentDone will be 50. And bypassing value in this function, percentDone will be still 50.
Stepper will remain to Slider 3 instead of moving to Slider 1.

### Scenario 3:
We have a stepper with 6 slides. We want to head toward slider 1 from slider 3.
The currentPercentDone will be 16 and previousPercentDone will be 50. And bypassing value in this function, percentDone will be still 50.
Stepper will remain to Slider 3 instead of moving to Slider 1. Furthermore, if we exit a stepper by tapping/clicking the back button that heads to the home page and returns back to that stepper once again, it is still on slider 3.

## Git Issues

https://github.com/IDEMSInternational/parenting-app-ui/issues/905
All three scenarios listed above are catered.

