### PR TITLE
Update display_group.ts making same height of  images.

### DIFF
--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -48,16 +48,20 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
         flex: 1 0 45%;
       }
       .two_columns_images .offset {
-        flex-wrap: wrap;
-        padding: 10px 0;
+        /*flex-wrap: wrap;*/
+        /*padding: 10px 0;*/
+
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-auto-rows: 2fr;
       }
       .two_columns_images > .offset > :nth-child(1n) {
-        flex: 1 0 45%;
+        /*flex: 1 0 45%;*/
       }
       .two_columns_images > .offset plh-template-component {
         padding: 0 20px;
         max-width: 10rem;
-        max-height: 9rem;
+        max-height: 10rem;
       }
       .two_columns .offset {
         flex-wrap: wrap;


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

This PR covers the issue related to the height of images. This is the continuation of the [issue 
](https://github.com/IDEMSInternational/parenting-app-ui/pull/873). Now it is catered and the height of all the images will be the same.
## Git Issues

closes #876

## Screenshots/Videos

![876_1](https://user-images.githubusercontent.com/45070594/130564673-92feaa1f-0b85-40a0-b87f-cc867826e9d4.png)
![876_2](https://user-images.githubusercontent.com/45070594/130564682-1399baf3-72d4-4e61-a593-c2705ffc5767.png)

