### PR TITLE
Non-display items's Space Correction

### DIFF
--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -12,11 +12,13 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
   >
     <div [style.marginBottom.px]="-offset" class="offset" [ngSwitch]="type">
       <ng-container *ngSwitchCase="'default'">
-        <plh-template-component
-          *ngFor="let childRow of _row.rows; trackBy: trackByRow"
-          [row]="childRow"
-          [parent]="parent"
-        ></plh-template-component>
+        <ng-container *ngFor="let childRow of _row.rows; trackBy: trackByRow">
+          <plh-template-component
+            *ngIf="childRow.type == 'set_variable'"
+            [row]="childRow"
+            [parent]="parent"
+          ></plh-template-component>
+        </ng-container>
       </ng-container>
       <plh-advanced-dashed-box
         *ngSwitchCase="'dashed_box'"

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -14,7 +14,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
       <ng-container *ngSwitchCase="'default'">
         <ng-container *ngFor="let childRow of _row.rows; trackBy: trackByRow">
           <plh-template-component
-            *ngIf="childRow.type == 'set_variable'"
+            *ngIf="childRow.type != 'set_variable'"
             [row]="childRow"
             [parent]="parent"
           ></plh-template-component>


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
Due to the unset value of the 'set_variable' type in Display Group, empty spaces are been created.  We have introduced a check that will restrict the rendering of 'set_variable'.

## Git Issues

https://github.com/IDEMSInternational/parenting-app-ui/issues/925

## Screenshots/Videos

![925_1](https://user-images.githubusercontent.com/45070594/130571696-16489f6c-cb0e-4e5e-af1f-280d6c447c54.png)

