### PR TITLE
Fix/display component rendering

### DIFF
--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -112,6 +112,9 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   @HostBinding("attr.data-type") get getComponentType() {
     return this._row?.type || null;
   }
+  @HostBinding("attr.has-child-rows") get getChildRows() {
+    return this._row?.rows ? "true" : null;
+  }
 
   private componentRef: ComponentRef<TemplateContainerComponent | ITemplateRowProps>;
 

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -95,11 +95,22 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   /** reference to parent template container */
   @Input() parent: TemplateContainerComponent;
 
+  // Add bindings to track key data attributes on the component itself, e.g.
+  // <plh-template-component data-debug-hidden="false" data-display-component="TmplNumberComponent" data-name="number_selector_6" data-type="number_selector">
   @HostBinding("attr.data-hidden") get getAttrHidden() {
     return this._row && this._row.hidden;
   }
   @HostBinding("attr.data-debug-hidden") get getAttrDat() {
     return this.parent && this.parent.debugMode;
+  }
+  @HostBinding("attr.data-display-component") get getComponentDisplayType() {
+    return TEMPLATE_COMPONENT_MAPPING[this._row?.type]?.name || "none";
+  }
+  @HostBinding("attr.data-name") get getComponentName() {
+    return this._row?.name || null;
+  }
+  @HostBinding("attr.data-type") get getComponentType() {
+    return this._row?.type || null;
   }
 
   private componentRef: ComponentRef<TemplateContainerComponent | ITemplateRowProps>;

--- a/src/app/shared/components/template/template-container.component.scss
+++ b/src/app/shared/components/template/template-container.component.scss
@@ -9,6 +9,10 @@
 plh-template-container {
   width: 100%;
 }
+// Do not attempt to show components that do not have a display component (e.g. set_variable)
+plh-template-component[data-display-component="none"] {
+  display: none;
+}
 .template-container {
   width: 100%;
   height: 100%;

--- a/src/app/shared/components/template/template-container.component.scss
+++ b/src/app/shared/components/template/template-container.component.scss
@@ -9,8 +9,9 @@
 plh-template-container {
   width: 100%;
 }
-// Do not attempt to show components that do not have a display component (e.g. set_variable)
-plh-template-component[data-display-component="none"] {
+// Do not attempt to show components that do not have a display component
+// and do not have child rows (e.g. set_variable)
+plh-template-component[data-display-component="none"]:not([has-child-rows]) {
   display: none;
 }
 .template-container {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Alternative to #964 - to try and fix issue of non-display components being rendered and affecting parent layouts.
- Add metadata binding to all rendered components to track name, type and display component type
- Add css to prevent display of components without display component type (e.g. set_variable, set_field etc.)

## Git Issues

Closes #925

## Screenshots/Videos

New metadata populated to all rendered components to make it easier to apply styling consistently.
![image](https://user-images.githubusercontent.com/10515065/130677547-7694c265-c888-4228-b770-c8e71dd9ace8.png)

`data-display-component=none` allows us to apply css to all non display components.
![image](https://user-images.githubusercontent.com/10515065/130678088-fb71a2f4-c6db-4c16-92e0-6efc7638bc66.png)

Example output
![image](https://user-images.githubusercontent.com/10515065/130677596-70269248-2407-4bf5-8831-d4ec97206173.png)


