### PR TITLE
Update default parser to trim text by default

### DIFF
--- a/packages/scripts/src/plh-data-convert/parsers/default/default.parser.ts
+++ b/packages/scripts/src/plh-data-convert/parsers/default/default.parser.ts
@@ -81,6 +81,10 @@ export class DefaultParser implements AbstractParser {
           row[field] = row[field].replace(expression, replaceValue);
         }
       }
+      // remove any trailing whitespace from any entries
+      if (typeof row[field] === "string") {
+        row[field] = row[field].trim();
+      }
       // mark fields for translation, rename so can process regularly (add translation data at end)
       // Note, cannot assume all :: statements translations as also used in fields, e.g. fields::favourite
       // TODO - alter fields syntax to avoid potential conflict (e.g. fields::eng)


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

_What this PR does_
Update the default parser so that all cells have text trimmed (hanging whitespace removed from start and end of strings) by default.

An additional PR has been created for the latest content sync with before/after changes for comparison.
See #979

## Git Issues

Closes #974

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/130863562-a7afd5d4-e27c-4a56-8730-99ce720fa29c.png)

