### PR TITLE
add translations to tour service

### DIFF
--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -31,6 +31,8 @@ export class TourService {
       this.introJS.setOptions({
         tooltipClass: "tooltipClass",
         buttonClass: "buttonClass",
+        nextLabel: this.translateService.translateValue("Next"),
+        prevLabel: this.translateService.translateValue("Previous"),
         steps: matchingTour.rows.map((row) => {
           // HACK - Ensure tour rows translated
           const translatedRow: FlowTypes.TourStep = this.translateService.translateRow(

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -4,6 +4,8 @@ import { Router } from "@angular/router";
 import introJs from "intro.js";
 import { TOUR } from "../data/data.service";
 import { TemplateService } from "../../components/template/services/template.service";
+import { TemplateTranslateService } from "../../components/template/services/template-translate.service";
+import { FlowTypes } from "packages/data-models/dist";
 
 @Injectable({
   providedIn: "root",
@@ -13,7 +15,11 @@ export class TourService {
 
   waitForRoutingDelay = 1000;
 
-  constructor(private router: Router, private templateService: TemplateService) {}
+  constructor(
+    private router: Router,
+    private templateService: TemplateService,
+    private translateService: TemplateTranslateService
+  ) {}
 
   listTourNames(): string[] {
     return TOUR.map((t) => t.flow_name);
@@ -21,19 +27,25 @@ export class TourService {
 
   async startTour(tourName = "test_tour") {
     let matchingTour = TOUR.find((t) => t.flow_name === tourName);
-
     if (matchingTour && matchingTour.rows && matchingTour.rows.length > 0) {
       this.introJS.setOptions({
         tooltipClass: "tooltipClass",
         buttonClass: "buttonClass",
         steps: matchingTour.rows.map((row) => {
-          let elementSelector = row.element;
-          if (row.template_component_name && row.template_component_name.trim().length > 0) {
-            elementSelector = `[data-rowname="${row.template_component_name}"]`;
+          // HACK - Ensure tour rows translated
+          const translatedRow: FlowTypes.TourStep = this.translateService.translateRow(
+            row as any
+          ) as any;
+          let elementSelector = translatedRow.element;
+          if (
+            translatedRow.template_component_name &&
+            translatedRow.template_component_name.trim().length > 0
+          ) {
+            elementSelector = `[data-rowname="${translatedRow.template_component_name}"]`;
           }
           return {
-            intro: this.replaceGlobalInRowMessage(row.message_text),
-            title: this.replaceGlobalInRowMessage(row.title),
+            intro: this.hackReplaceGlobalInRowMessage(translatedRow.message_text),
+            title: this.hackReplaceGlobalInRowMessage(translatedRow.title),
             element: elementSelector,
             elementSelector,
           } as any;
@@ -90,7 +102,11 @@ export class TourService {
       }
     });
   }
-  replaceGlobalInRowMessage(field: any) {
+  /**
+   * Legacy hardcoded method to replace tour data manually
+   * TODO - should be integrated with existing template parsing methods
+   */
+  hackReplaceGlobalInRowMessage(field: any) {
     const regExs = new RegExp(/([@]+[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/gi);
     const globalVariables = field ? field.match(regExs) : field;
     const regExpImg = new RegExp(/<img .*?>/g);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The tour service currently implements its own methods for parsing rows (including manual replacement of global fields etc.), and so a manual method needs to be added to process translations

## Future TODOs
Would be better to fully integrate with exiting row processing service

## Git Issues

Closes #987

## Screenshots/Videos
https://user-images.githubusercontent.com/10515065/131152748-329b34c2-2f7a-48ce-924c-c7b276ec59c1.mp4

