### PR TITLE
Feat/translated dynamic references

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -450,7 +450,7 @@ export namespace FlowTypes {
     _evalContext?: { itemContext: any }; // force specific context variables when calculating eval statements (such as loop items)
     __EMPTY?: any; // empty cells (can be removed after pr 679 merged)
   }
-  type IDynamicField = { [key: string]: TemplateRowDynamicEvaluator[] | IDynamicField };
+  export type IDynamicField = { [key: string]: TemplateRowDynamicEvaluator[] | IDynamicField };
 
   type IDynamicPrefix = typeof DYNAMIC_PREFIXES[number];
 

--- a/src/app/shared/components/template/services/template-row.service.ts
+++ b/src/app/shared/components/template/services/template-row.service.ts
@@ -219,16 +219,17 @@ export class TemplateRowService {
         return { ...preProcessedRow, condition: false };
       }
     }
+    // As translations are applied in raw format (e.g. "Hello @global.some_field")
+    // strings should be translated before dynamic processing
+    const translatedRow = this.container.templateTranslateService.translateRow(preProcessedRow);
 
     // Continue processing full row
     const parsedRow: FlowTypes.TemplateRow = await templateVariables.evaluatePLHData(
-      { ...preProcessedRow },
+      { ...translatedRow },
       evalContext
     );
-    // assign translated values
-    const translatedRow = this.container.templateTranslateService.translateRow(parsedRow);
 
-    const row = translatedRow;
+    const row = parsedRow;
     const { name, value, type, _dynamicFields } = row;
 
     // Make type assigned to hidden consistent

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -63,6 +63,10 @@ export class TemplateTranslateService {
       Object.keys(row._translations).forEach((field) => {
         translated[field] = this.translateValue(row[field]);
       });
+      // Also assign as the base string for any fields that will be parsed dynamically
+      if (row._dynamicFields) {
+        translated._dynamicFields = this.translateDynamicFields(row._dynamicFields);
+      }
     }
     // Case 2 - row value assigned from data list with translate fields
     const { value } = row;
@@ -72,6 +76,29 @@ export class TemplateTranslateService {
     // Note - there is a third case when row value assigned from calculation (e.g. data list child field)
     // but this is currently manually handled in the template-variables service as required
     return translated;
+  }
+
+  /**
+   * As dynamic fields keep reference to initial full expressions that are used as part of evaluation,
+   * also replace these references with translated ones
+   */
+  private translateDynamicFields(fields: FlowTypes.IDynamicField) {
+    const translatedFields: FlowTypes.IDynamicField = {};
+    // There are 2 cases to handle dependingt on whether the dynamic field represents
+    // an array of dynamic evaluators or a further-nested dynamic field
+    Object.entries(fields).forEach(([field, value]) => {
+      if (Array.isArray(value)) {
+        const dynamicRowEvaluators = value as FlowTypes.TemplateRowDynamicEvaluator[];
+        translatedFields[field] = dynamicRowEvaluators.map((evaluator) => {
+          evaluator.fullExpression = this.translateValue(evaluator.fullExpression);
+          return evaluator;
+        });
+      } else {
+        const nestedDynamic = translatedFields[field] as FlowTypes.IDynamicField;
+        translatedFields[field] = this.translateDynamicFields(nestedDynamic);
+      }
+    });
+    return translatedFields;
   }
 
   public translateValue(value: any) {

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -94,7 +94,7 @@ export class TemplateTranslateService {
           return evaluator;
         });
       } else {
-        const nestedDynamic = translatedFields[field] as FlowTypes.IDynamicField;
+        const nestedDynamic = value as FlowTypes.IDynamicField;
         translatedFields[field] = this.translateDynamicFields(nestedDynamic);
       }
     });


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Breaking Changes
Updates made to the scripts that process all rows (described below), and so a functional test strongly recommended to ensure no accidental knock-ons

## Description

Fix 2 issues identified which prevented translation of dynamic texts:

1. Dynamic fields were processed before translation, meaning that `hello @global.welcome_message` would translate the dynamic global first and no longer match the translation reference which keeps `@global` in the translated text. Now translations are processed before the rest of the row.

2. Dynamic fields keep metadata for the original text used when populating mixed translation content back into strings, meaning that even after translation re-evaluation would use the original text instead of translated. Added a method to also populate the metadata text for populating dynamic content

## Git Issues

Closes #986

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/131161709-e863b848-88d1-47d0-aa14-4bea4e1a57a1.png)

