### PR TITLE
Fix ParentPoint count in Setswana translation

### DIFF
--- a/packages/plh-data/translations/from_translators/translated.za.tsa.json
+++ b/packages/plh-data/translations/from_translators/translated.za.tsa.json
@@ -165,13 +165,13 @@
     },
     {
         "SourceText": "total_parent_point_@local.habit",
-        "text": "ntlha_yotlhe_ya botsadi_@local.habit",
+        "text": "total_parent_point_@local.habit",
         "type": "template",
         "note": "The string @local.habit should not be translated."
     },
     {
         "SourceText": "weekly_parent_point_@local.habit",
-        "text": "ntlha_ya beke le beke_ya botsadi_@local.habit",
+        "text": "weekly_parent_point_@local.habit",
         "type": "template",
         "note": "The string @local.habit should not be translated."
     },


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
In the Setswana translation, some of the strings that should not have been sent in the first place were translated, causing problems with the ParentPoint count.