### PR TITLE
Feat/e2e test db

### DIFF
--- a/packages/data-models/db.model.ts
+++ b/packages/data-models/db.model.ts
@@ -1,0 +1,87 @@
+import { FlowTypes } from "./flowTypes";
+
+const FLOW_EVENT_INDEXES: (keyof IFlowEvent)[] = ["type", "name", "event", "_created", "_synced"];
+
+/**
+ * All tables used must be defined with any indices required (other columns freely added)
+ * Include auto-increment primary key via `++`
+ * https://dexie.org/docs/API-Reference#quick-reference
+ *
+ * NOTE - tables that use compound queries should have indexes specified (as queries often fail otherwise)
+ */
+export const DB_TABLES = {
+  /** Track template flow events such as completion emit **/
+  flow_events: "++id," + FLOW_EVENT_INDEXES.join(","),
+  /** Long term tracking of changes to user data, such as contact fields */
+  data_events: "++id," + FLOW_EVENT_INDEXES.join(","),
+
+  /**********************************************************************************************************
+   * 2021-04-06
+   * TODO - Resolve tables below and determine which are still relevant, or could be merged into tables above
+   **********************************************************************************************************/
+  surveys: "++id,surveyId",
+  reminders: "++id,type",
+  reminder_events: "++id,event_id",
+  /** task_actions track content the user has interacted with */
+  task_actions: "id,task_id,_created",
+  /** session_actions track meta interactions such as start and end of session */
+  session_actions: "id,task_id,_created",
+  /** track app events such as open */
+  app_events: "++id,event_id,_created",
+  /** user */
+  user_meta: "key,value",
+  /** habits */
+  habits: "habitId",
+  habit_activity_ideas: "++id,flowName",
+  habit_occurrence: "++id,habitId,created",
+};
+
+export type IDBTable = keyof typeof DB_TABLES;
+/**
+ * For any tables with automatic id assignment the following fields will be populated
+ */
+export interface IDBDoc {
+  id: number;
+}
+
+/**
+ * All databases must contain an incremented version number, and any migration logic
+ * required between versions. Currently using app version number to track when the
+ * breaking changes occurred (does not need to be updated every version)
+ * e.g. v1.5.3 => 100500300
+ * e.g. v0.1.0 => 000001000
+ * e.g. v0.10.4 => 000010004
+ */
+export const DB_VERSION = 10005;
+
+export interface IDBEvent {
+  topic: "DB";
+  payload: {
+    id?: string;
+    tableId: keyof typeof DB_TABLES;
+    operation: "CREATE" | "UPDATE" | "DELETE";
+    data: any;
+  };
+  eventId?: string;
+}
+
+/**
+ * Data written to the database from flows will usually retain the following format
+ * @param type flow type triggering the event, e.g. 'template'
+ * @param name identifier for the source of the event, i.e. the flow_name
+ * @param event name given to the event for indexing/query/lookup, e.g. 'emit'
+ * @param value (not indexed) - specific value corresponding to the event
+ * @param _created timestamp in isostring format generated on write
+ * @param _synced whether the data has been succesfully synced to the database
+ */
+export interface IFlowEvent extends IDBMeta {
+  type: FlowTypes.FlowType;
+  name: string;
+  event: string;
+  value: any;
+}
+
+export interface IDBMeta {
+  _created: string;
+  _synced: boolean;
+}

--- a/packages/test-e2e/package.json
+++ b/packages/test-e2e/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^15.12.4",
     "concurrently": "^6.2.1",
     "cypress": "^8.3.0",
+    "data-models": "1.0.0",
     "typescript": "~4.2.4",
     "wait-on": "^6.0.0"
   }

--- a/packages/test-e2e/projects/plh/fixtures/profiles/default.json
+++ b/packages/test-e2e/projects/plh/fixtures/profiles/default.json
@@ -1,0 +1,9 @@
+{
+  "fields": { "_app_language": "eng", "name": "default" },
+  "tables": {
+    "user_meta": [
+      { "key": "first_app_open", "value": "2021-09-02" },
+      { "key": "uuid", "value": "TEST_CI_DEFAULT" }
+    ]
+  }
+}

--- a/packages/test-e2e/projects/plh/fixtures/profiles/default.json
+++ b/packages/test-e2e/projects/plh/fixtures/profiles/default.json
@@ -1,9 +1,6 @@
 {
-  "fields": { "_app_language": "eng", "name": "default" },
+  "fields": { "_app_language": "eng", "name": "test default user" },
   "tables": {
-    "user_meta": [
-      { "key": "first_app_open", "value": "2021-09-02" },
-      { "key": "uuid", "value": "TEST_CI_DEFAULT" }
-    ]
+    "user_meta": [{ "key": "first_app_open", "value": "2021-09-02" }]
   }
 }

--- a/packages/test-e2e/projects/plh/fixtures/profiles/new-user.json
+++ b/packages/test-e2e/projects/plh/fixtures/profiles/new-user.json
@@ -1,0 +1,9 @@
+{
+  "fields": { "_app_language": "eng", "name": "new_user" },
+  "tables": {
+    "user_meta": [
+      { "key": "first_app_open", "value": "2021-09-02" },
+      { "key": "uuid", "value": "TEST_CI_NEW_USER" }
+    ]
+  }
+}

--- a/packages/test-e2e/projects/plh/fixtures/profiles/new-user.json
+++ b/packages/test-e2e/projects/plh/fixtures/profiles/new-user.json
@@ -1,9 +1,6 @@
 {
-  "fields": { "_app_language": "eng", "name": "new_user" },
+  "fields": { "_app_language": "eng", "name": "test new user" },
   "tables": {
-    "user_meta": [
-      { "key": "first_app_open", "value": "2021-09-02" },
-      { "key": "uuid", "value": "TEST_CI_NEW_USER" }
-    ]
+    "user_meta": []
   }
 }

--- a/packages/test-e2e/projects/plh/integration/common/home.spec.ts
+++ b/packages/test-e2e/projects/plh/integration/common/home.spec.ts
@@ -38,6 +38,9 @@ describe("[First Load]", () => {
     // so just search for anything containing the word Continue
     cy.get("analytics-survey").contains("Continue").click();
   });
+  it("[Shows language select template]", () => {
+    cy.get("[data-templatename=language_select]").contains("English").click();
+  });
   it("[Shows intro.js tooltip]", () => {
     cy.get(".introjs-tooltip").should("be.visible");
   });
@@ -53,8 +56,7 @@ describe("[Not First Load]", () => {
   });
   it("[Should load homescreen template]", () => {
     // check template component loaded
-    // NOTE - could also have better identifier
-    cy.get('[ng-reflect-templatename="home_screen"]').should("be.visible");
+    cy.get('[data-templatename="home_screen"]').should("be.visible");
     // example if screenshots required.
     // Include extra wait time because likely content will not be visible immediately when template loaded
     // (alternatively could wait for specific element from the content to be visible if known)

--- a/packages/test-e2e/projects/plh/support/commands.ts
+++ b/packages/test-e2e/projects/plh/support/commands.ts
@@ -1,25 +1,64 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+import Dexie from "dexie";
+import { DB_TABLES, DB_VERSION } from "data-models/db.model";
+
+// as importing additional modules need to declare as global (https://github.com/cypress-io/cypress/issues/1065)
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /** Load a custom user profile from fixture data, assigning profile data to contact fields */
+      setProfile(profile: IProfileName): Chainable<Element>;
+    }
+  }
+}
+
+Cypress.Commands.add("skipIntro", () => {
+  console.log("skipping intro");
+});
+
+/** Load a custom user profile from fixture data, assigning profile data to contact fields */
+Cypress.Commands.add("setProfile", (profile: IProfileName = "new-user") => {
+  let profileData: IProfileData = { fields: {}, tables: {} };
+  let appWindow: Cypress.AUTWindow;
+  cy.window().then((w) => (appWindow = w));
+
+  cy.fixture(`profiles/${profile}`).then((data: IProfileData) => {
+    profileData = data;
+  });
+  cy.wrap("setting profile fields").then(() => {
+    // set localstorage fields
+    Object.keys(profileData.fields).forEach((field) => {
+      appWindow.localStorage.setItem(`rp-contact-field.${field}`, profileData.fields[field]);
+    });
+  });
+  cy.wrap("setting indexeddb tables").then(() => {
+    // use dexie with the existing app window
+    const db = new Dexie("plh-app-db", { indexedDB: appWindow.indexedDB });
+    db.version(DB_VERSION).stores(DB_TABLES);
+    console.log("db init", DB_VERSION, DB_TABLES);
+    return setDbTables(db, profileData.tables);
+  });
+});
+
+function setDbTables(db: Dexie, tables: IProfileData["tables"]) {
+  return new Cypress.Promise(async (resolve, reject) => {
+    await db.open().catch((err) => {
+      console.error("could not open db", err);
+      reject(err);
+    });
+
+    for (const table_id of Object.keys(tables)) {
+      const rows = tables[table_id];
+      console.log("setting", table_id, rows);
+
+      await db.table(table_id).bulkPut(rows);
+    }
+    db.close();
+    resolve();
+  });
+}
+
+type IProfileName = "new-user" | "default";
+interface IProfileData {
+  fields: { [field: string]: string };
+  tables: { [table_id: string]: any[] };
+}

--- a/packages/test-e2e/projects/plh/support/hooks.ts
+++ b/packages/test-e2e/projects/plh/support/hooks.ts
@@ -7,4 +7,6 @@
  * Additionally any aliases created in before will not be passed to test instance,
  * put aliases created in beforeAll will be (not currently required)
  */
-before(() => {});
+before(() => {
+  cy.setProfile("default");
+});

--- a/packages/test-e2e/tsconfig.json
+++ b/packages/test-e2e/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es5", "dom"],
-    "types": ["cypress"]
+    "target": "ES2015",
+    "lib": ["ES2015", "dom"],
+    "types": ["cypress", "node"],
+    "moduleResolution": "node"
   },
   "include": ["**/*.ts"]
 }

--- a/src/app/feature/chat/services/offline/contact-field.service.ts
+++ b/src/app/feature/chat/services/offline/contact-field.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from "@angular/core";
-import { DbService, IFlowEvent } from "src/app/shared/services/db/db.service";
+import { DbService } from "src/app/shared/services/db/db.service";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 import { CONVERSATION } from "src/app/shared/services/data/data.service";
 import { environment } from "src/environments/environment";
+import { IFlowEvent } from "packages/data-models/db.model";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/feature/reminders/reminders.model.ts
+++ b/src/app/feature/reminders/reminders.model.ts
@@ -1,5 +1,5 @@
 import { FormControl, Validators } from "@angular/forms";
-import { IDBDoc, IDBTable } from "src/app/shared/services/db/db.service";
+import { IDBDoc, IDBTable } from "packages/data-models/db.model";
 
 /******************************************************************************************
  * Typings

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -1,13 +1,14 @@
 import { Injectable } from "@angular/core";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 import { GLOBAL, PLHDataService, TEMPLATE } from "src/app/shared/services/data/data.service";
-import { DbService, IFlowEvent } from "src/app/shared/services/db/db.service";
+import { DbService } from "src/app/shared/services/db/db.service";
 import { FlowTypes } from "src/app/shared/model";
 import { booleanStringToBoolean, getNestedProperty } from "src/app/shared/utils";
 import { BehaviorSubject } from "rxjs";
 import { ModalController } from "@ionic/angular";
 import { TemplatePopupComponent } from "../components/layout/popup";
 import { TemplateTranslateService } from "./template-translate.service";
+import { IFlowEvent } from "packages/data-models/db.model";
 
 @Injectable({
   providedIn: "root",

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostBinding,
   Input,
   OnDestroy,
   OnInit,
@@ -77,6 +78,10 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   ) {
     this.templateActionService = new TemplateActionService(this, this.settingsService);
     this.templateRowService = new TemplateRowService(this);
+  }
+  /** Assign the templatename as metdaata on the component for easier debugging and testing */
+  @HostBinding("attr.data-templatename") get getTemplatename() {
+    return this.templatename;
   }
 
   async ngOnInit() {

--- a/src/app/shared/services/data/data-evaluation.service.ts
+++ b/src/app/shared/services/data/data-evaluation.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from "@angular/core";
 import { differenceInHours } from "date-fns";
+import { IDBTable } from "packages/data-models/db.model";
 import { FlowTypes } from "src/app/shared/model";
 import { TemplateService } from "../../components/template/services/template.service";
 import { arrayToHashmapArray } from "../../utils";
 import { AppEventService } from "../app-events/app-events.service";
-import { DbService, IDBTable } from "../db/db.service";
+import { DbService } from "../db/db.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;

--- a/src/app/shared/services/db/db.service.ts
+++ b/src/app/shared/services/db/db.service.ts
@@ -5,7 +5,14 @@ import "dexie-syncable";
 // import "./db-sync.service";
 import { ICreateChange, IDatabaseChange, IDeleteChange, IUpdateChange } from "dexie-observable/api";
 import { Subject } from "rxjs";
-import { FlowTypes } from "src/app/shared/model";
+import {
+  DB_TABLES,
+  DB_VERSION,
+  IDBMeta,
+  IDBEvent,
+  IDBTable,
+  IFlowEvent,
+} from "data-models/db.model";
 import { arrayToHashmapArray, generateTimestamp } from "../../utils";
 import { EventService } from "../event/event.service";
 
@@ -17,59 +24,6 @@ window.addEventListener("unhandledrejection", (event) => {
   console.warn("Unhandled promise rejection:", reason && (reason.stack || reason));
 });
 
-const FLOW_EVENT_INDEXES: (keyof IFlowEvent)[] = ["type", "name", "event", "_created", "_synced"];
-
-/**
- * All tables used must be defined with any indices required (other columns freely added)
- * Include auto-increment primary key via `++`
- * https://dexie.org/docs/API-Reference#quick-reference
- *
- * NOTE - tables that use compound queries should have indexes specified (as queries often fail otherwise)
- */
-const DB_TABLES = {
-  /** Track template flow events such as completion emit **/
-  flow_events: "++id," + FLOW_EVENT_INDEXES.join(","),
-  /** Long term tracking of changes to user data, such as contact fields */
-  data_events: "++id," + FLOW_EVENT_INDEXES.join(","),
-
-  /**********************************************************************************************************
-   * 2021-04-06
-   * TODO - Resolve tables below and determine which are still relevant, or could be merged into tables above
-   **********************************************************************************************************/
-  surveys: "++id,surveyId",
-  reminders: "++id,type",
-  reminder_events: "++id,event_id",
-  /** task_actions track content the user has interacted with */
-  task_actions: "id,task_id,_created",
-  /** session_actions track meta interactions such as start and end of session */
-  session_actions: "id,task_id,_created",
-  /** track app events such as open */
-  app_events: "++id,event_id,_created",
-  /** user */
-  user_meta: "key,value",
-  /** habits */
-  habits: "habitId",
-  habit_activity_ideas: "++id,flowName",
-  habit_occurrence: "++id,habitId,created",
-};
-
-export type IDBTable = keyof typeof DB_TABLES;
-/**
- * For any tables with automatic id assignment the following fields will be populated
- */
-export interface IDBDoc {
-  id: number;
-}
-
-/**
- * All databases must contain an incremented version number, and any migration logic
- * required between versions. Currently using app version number to track when the
- * breaking changes occurred (does not need to be updated every version)
- * e.g. v1.5.3 => 100500300
- * e.g. v0.1.0 => 000001000
- * e.g. v0.10.4 => 000010004
- */
-const DB_VERSION = 10005;
 db.version(DB_VERSION).stores(DB_TABLES);
 
 @Injectable({
@@ -200,40 +154,9 @@ export class DbService {
     });
   }
 }
-export interface IDBEvent {
-  topic: "DB";
-  payload: {
-    id?: string;
-    tableId: keyof typeof DB_TABLES;
-    operation: "CREATE" | "UPDATE" | "DELETE";
-    data: any;
-  };
-  eventId?: string;
-}
 
 type IDBChangEvent = (
   eventName: "changes",
   subscriber: (changes: IDatabaseChange[]) => any,
   bSticky?: boolean
 ) => void;
-
-/**
- * Data written to the database from flows will usually retain the following format
- * @param type flow type triggering the event, e.g. 'template'
- * @param name identifier for the source of the event, i.e. the flow_name
- * @param event name given to the event for indexing/query/lookup, e.g. 'emit'
- * @param value (not indexed) - specific value corresponding to the event
- * @param _created timestamp in isostring format generated on write
- * @param _synced whether the data has been succesfully synced to the database
- */
-export interface IFlowEvent extends IDBMeta {
-  type: FlowTypes.FlowType;
-  name: string;
-  event: string;
-  value: any;
-}
-
-interface IDBMeta {
-  _created: string;
-  _synced: boolean;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -20962,6 +20962,7 @@ fsevents@^1.2.7:
     "@types/node": ^15.12.4
     concurrently: ^6.2.1
     cypress: ^8.3.0
+    data-models: 1.0.0
     typescript: ~4.2.4
     wait-on: ^6.0.0
   languageName: unknown


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

As mentioned when reviewing #995, most tests written will fail on first run because they automatically start with a clean localstorage database, which the app takes as a prompt to start the first-user flow (e.g. showing welcome slides and language select), instead of the expected templates and content.

This pr adds methods to pre-populate both localstorage and the dexie indexeddb database before load, allowing us to simulate a more consistent workflow for a particular user type (included are `new-user` and `default` (non-new)).

Specific code updates:
- Refactor the database type definitions to the shared `data-models` package (like flowtypes), so that they can be more easily shared with both frontend app code and test code
- Add methods to allow pre-population of both localstorage and dexie indexeddb databases
- Add seed data to mock different user profiles (new users and non-new user)
- Update broken home screen test (to include language select screen)

@saqlainrasheed - I've added you as a reviewer so you can also see the code changes. I hope they make sense to you.

@volloholic - This doesn't have knock-on for the main app code, but thought you might be interested for future reference as it may feed into our longer term testing strategy (of different environments, deployments etc.)

## Git Issues

Closes #

## Screenshots/Videos

Tests now all use a default `before_all` hook to specify default user profile and indexeddb fields
![image](https://user-images.githubusercontent.com/10515065/132059890-6c2be9d6-2e43-493d-b240-f2da0d38f28a.png)

