### PR TITLE
Feat/server sync action

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -15,3 +15,18 @@ export const DYNAMIC_PREFIXES = [
   "calc",
   "item",
 ] as const;
+
+/**
+ * All localstorage fields will be prefixed with this
+ * TODO - this has not been consistently applied so refactoring required
+ * */
+export const FIELD_PREFIX = "rp-contact-field";
+
+/**
+ * Fieldnames hardcoded into the app
+ * TODO - these have not been consistently applied so refactoring required
+ * */
+export const APP_FIELDS = {
+  SERVER_SYNC_LATEST: `${FIELD_PREFIX}._server_sync_latest`,
+  APP_LANGUAGE: `${FIELD_PREFIX}._app_language`,
+};

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -1,4 +1,4 @@
-export * from "./constants";
+export { APP_FIELDS, FIELD_PREFIX, DYNAMIC_PREFIXES } from "./constants";
 export * from "./flowTypes";
 export * from "./rapidpro.model";
 export * from "./tips.model";

--- a/src/app/shared/components/template/services/template-action.service.ts
+++ b/src/app/shared/components/template/services/template-action.service.ts
@@ -4,6 +4,7 @@ import { FlowTypes } from "src/app/shared/model";
 import { TemplateContainerComponent } from "../template-container.component";
 import { SettingsService } from "src/app/pages/settings/settings.service";
 import { TemplateProcessService } from "./template-process.service";
+import { ServerService } from "src/app/shared/services/server/server.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -21,7 +22,8 @@ export class TemplateActionService {
 
   constructor(
     public container: TemplateContainerComponent,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private serverService: ServerService
   ) {}
 
   /** Public method to add actions to processing queue and process */
@@ -143,7 +145,8 @@ export class TemplateActionService {
           this.container.router,
           this.container.route,
           this.container.templateNavService,
-          this.container.settingsService
+          this.container.settingsService,
+          this.container.serverService
         );
         return processor.processTemplateWithoutRender(templateToProcess);
       case "emit":
@@ -175,6 +178,9 @@ export class TemplateActionService {
         }
         if (emit_value === "set_language") {
           this.container.templateTranslateService.setLanguage(args[1]);
+        }
+        if (emit_value === "server_sync") {
+          await this.serverService.syncUserData();
         }
         if (parent) {
           // continue to emit any actions to parent where defined

--- a/src/app/shared/components/template/services/template-process.service.ts
+++ b/src/app/shared/components/template/services/template-process.service.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { FlowTypes } from "data-models";
 import { SettingsService } from "src/app/pages/settings/settings.service";
 import { TEMPLATE } from "src/app/shared/services/data/data.service";
+import { ServerService } from "src/app/shared/services/server/server.service";
 import { TourService } from "src/app/shared/services/tour/tour.service";
 import { TemplateContainerComponent } from "../template-container.component";
 import { TemplateNavService } from "./template-nav.service";
@@ -30,7 +31,8 @@ export class TemplateProcessService {
     // elRef: ElementRef,
     templateNavService: TemplateNavService,
     // cdr: ChangeDetectorRef,
-    settingsService: SettingsService
+    settingsService: SettingsService,
+    serverService: ServerService
   ) {
     // Create mock template container component
     this.container = new TemplateContainerComponent(
@@ -43,7 +45,8 @@ export class TemplateProcessService {
       null as any,
       templateNavService,
       null as any,
-      settingsService
+      settingsService,
+      serverService
     );
   }
 

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -21,6 +21,7 @@ import { TemplateService } from "./services/template.service";
 import { getIonContentScrollTop, setElStyleAnimated, setIonContentScrollTop } from "./utils";
 import { TemplateTranslateService } from "./services/template-translate.service";
 import { SettingsService } from "src/app/pages/settings/settings.service";
+import { ServerService } from "../../services/server/server.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -73,9 +74,14 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
     public elRef: ElementRef,
     public templateNavService: TemplateNavService,
     public cdr: ChangeDetectorRef,
-    public settingsService: SettingsService
+    public settingsService: SettingsService,
+    public serverService: ServerService
   ) {
-    this.templateActionService = new TemplateActionService(this, this.settingsService);
+    this.templateActionService = new TemplateActionService(
+      this,
+      this.settingsService,
+      this.serverService
+    );
     this.templateRowService = new TemplateRowService(this);
   }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add `emit: server_sync` to trigger manual server sync
- Update sync code to also populate `_server_sync_latest` field on successful sync for tracking
- Update `user_code` template to include sync button, disabled state, and last sync text
- Code tidying to start storing hardcoded contact field mapping in data-models models

## TODO (authoring)
- Review/tidy updated template text (e.g. sync message)
- Possibly add sync fail message (although would take extra authoring to use possibly use multiple before/after sync variables to see if latest sync changed or not)
- Recommend specifying in message that they can just provide the first digits of the code if easier (likely uniquely identified after just first block of characters), or in future adding a button to make it easier to copy/screenshot 

## Git Issues

Closes #998

## Screenshots/Videos

**Updated `user_code` template**
![image](https://user-images.githubusercontent.com/10515065/132072194-a5586cf7-d775-422e-8e37-c959bc441599.png)

**When sync successful contact field updated and shown in template**

https://user-images.githubusercontent.com/10515065/132071630-2577b536-956b-4fa4-878e-9ad475a6daf6.mp4

**Button disabled while sync pending. On fail reverts to original template**

https://user-images.githubusercontent.com/10515065/132071635-66e80c41-eb5f-435b-9427-405985759eaf.mp4

**App data synced to db**

![image](https://user-images.githubusercontent.com/10515065/132072069-37353168-a1f6-471f-b26e-b5e2800864aa.png)

![image](https://user-images.githubusercontent.com/10515065/132072036-e4137a6d-c64b-471e-92e1-b63da2b6be85.png)



