### PR TITLE
add type definitions for tour message_template

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -344,6 +344,7 @@ export namespace FlowTypes {
   export interface TourStep extends Row_with_translations {
     type: "step";
     message_text?: string;
+    message_template?: string;
     title?: string;
     template_component_name?: string;
     element?: string;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Merge required updates to type definitions to support templates in tour messages (#1008) so that example templates can be marked as released without breaking build

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
