### PR TITLE
add support for global default translations

### DIFF
--- a/packages/plh-data/translations/from_translators/translated.es.spa.json
+++ b/packages/plh-data/translations/from_translators/translated.es.spa.json
@@ -208,5 +208,10 @@
     "SourceText": "sad",
     "text": "triste",
     "type": "template"
+  },
+  {
+    "SourceText": "awesome parent",
+    "text": "Padre asombroso",
+    "type": "template"
   }
 ]

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import { TRANSLATION_STRINGS } from "plh-data";
+import { BehaviorSubject } from "rxjs";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 import { FlowTypes } from "../models";
 
@@ -15,6 +16,9 @@ const DEFAULT_LANGUAGE = "eng";
  * are already pre-populated in the column (so just a case to return the current language field)
  */
 export class TemplateTranslateService {
+  /** Provide an observable so services can subscribe and respond to language changes*/
+  app_language$ = new BehaviorSubject<string>(null);
+
   app_language: string;
   translation_strings = {};
 
@@ -35,6 +39,8 @@ export class TemplateTranslateService {
       }
       this.app_language = code;
       this.translation_strings = TRANSLATION_STRINGS[code] || {};
+      // update observable for subscribers
+      this.app_language$.next(code);
       console.log("[Language Set]", code);
     }
   }

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -67,7 +67,6 @@ export class TemplateService {
             break;
           case "declare_global_constant":
             const translatedGlobal = this.translateService.translateRow(row as any);
-            // console.log("set global", row.value, { row, translatedGlobal });
             this.setGlobal(translatedGlobal as any);
             break;
           default:

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -27,7 +27,10 @@ export class TemplateService {
 
   /** Initialise global and startup templates */
   async init() {
-    this.initialiseGlobals();
+    // wait until app language has been specified before populating, and update on change
+    this.translateService.app_language$.subscribe((lang) => {
+      this.initialiseDefaultFieldAndGlobals();
+    });
   }
 
   /**
@@ -47,15 +50,29 @@ export class TemplateService {
     return data;
   }
 
-  private initialiseGlobals() {
+  /**
+   * Iterate over global template rows, assigning `declare_field_default` values to fields if they do not already exist,
+   * and `declare_global_constant` values to global regardless.
+   * NOTE - globals will always show the latest value as defined in app sheets (with any translations processed)
+   * NOTE - fields will not update if already set
+   */
+  private initialiseDefaultFieldAndGlobals() {
     GLOBAL.forEach((flow) => {
       flow.rows?.forEach((row) => {
-        if (row.type === "declare_field_default") {
-          if (this.localStorageService.getString("rp-contact-field." + row.name) === null) {
-            this.setField(row.name, row.value);
-          }
-        } else {
-          this.setGlobal(row);
+        switch (row.type) {
+          case "declare_field_default":
+            if (this.localStorageService.getString("rp-contact-field." + row.name) === null) {
+              this.setField(row.name, row.value);
+            }
+            break;
+          case "declare_global_constant":
+            const translatedGlobal = this.translateService.translateRow(row as any);
+            // console.log("set global", row.value, { row, translatedGlobal });
+            this.setGlobal(translatedGlobal as any);
+            break;
+          default:
+            console.warn(`[${row.type}] row type not supported in global template`);
+            break;
         }
       });
     });

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -143,6 +143,8 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
         // ensure angular destroys previous row components before rendering new
         // (note - will cause short content flicker)
         this.templateRowService.renderedRows = [];
+        // allow time for other pending ops to finish
+        await _wait(50);
         await this.renderTemplate();
       } else {
         await this.templateRowService.processRowUpdates();


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
As discussed on the call, an issue exists where fields initialised with default values (e.g. `user_name_default: awesome parent`) are not updated when language changed because fields are only ever initialised once.

This PR provides a solution to the issue, by allowing `field_default` rows to point to `global_default` rows (actually no change required as global rows were always processed directly as strings and not evaluated), and adding `global_default` rows to the translation process with update on language change. 

In the user_name case, the field `@fields.user_name_default` is initialised with the value `@global.user_name_default`, so it will always show the updated global value unless the user has replaced with their own name. Even if the name the user replaced with exists in translations, it will not be changed on language change.

- Update global defaults to process translations
- Add bindings to update global defaults on language change
- Tidy code that initialises field and global default values
- Update example templates and clarify comments

## Git Issues

Closes #

## Screenshots/Videos

**[workshop_options](https://docs.google.com/spreadsheets/d/1FXmKOQh-7iqi5JAYmJEQeqa-7C2ISpY4yLghFUV5md0/edit#gid=2025264137) sets field and global defaults**

![image](https://user-images.githubusercontent.com/10515065/132479887-f75a396a-475a-412b-aeb5-7a0c9cb2c3ac.png)

**Example update in [example_lang_template_1](https://docs.google.com/spreadsheets/d/1vv1DbyXEkOEHVEAMwjtQW0vS23DDUBK1oOw24moe64M/edit#gid=1595229908)**

https://user-images.githubusercontent.com/10515065/132480889-0aa086d5-d112-4c6a-a32d-455b0ee6ccc5.mp4