### PR TITLE
fix dynamic list translation methods

### DIFF
--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -313,17 +313,6 @@ export class TemplateVariablesService {
         break;
       case "data":
         parsedValue = this.templateService.getDataListByPath(fieldName);
-        // HACK - make sure data lists are translated (ideally should find way to handle alongside main translations)
-        // TODO - review if similar methods required for campaign, global etc.
-        if (parsedValue && typeof parsedValue === "object") {
-          Object.keys(parsedValue).forEach((k) => {
-            parsedValue[k] = this.templateTranslateService.translateRow(parsedValue[k]);
-          });
-        } else {
-          parsedValue = {};
-          console.error("Data list could not be processed", { fieldName, parsedValue });
-        }
-
         break;
       // TODO - ideally campaign lookup should be merged into data list lookup with additional query/params
       // e.g. evaluate conditions, take first etc.
@@ -353,9 +342,32 @@ export class TemplateVariablesService {
         // This will be checked a second time and could cause an infinite loop
         parsedValue = "";
     }
+    parsedValue = this.ensureValueTranslated(parsedValue);
     return { parsedValue, parseSuccess };
   }
+
+  /**
+   * HACK - make sure objects (e.g. campaign, global, data_lists) are translated
+   * (ideally should find way to handle alongside main translations)
+   * TODO - could also merge with standalone global method
+   */
+  private ensureValueTranslated(value: any) {
+    // If translatable value should be an object with _tranlsations property
+    // TODO - check if case needs to be added to translate arrays
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      if (value.hasOwnProperty("_translations")) {
+        value = this.templateTranslateService.translateRow(value);
+      } else {
+        // Check in case object with nested translations (e.g. data list)
+        Object.keys(value).forEach((k) => {
+          value[k] = this.ensureValueTranslated(value[k]);
+        });
+      }
+    }
+    return value;
+  }
 }
+
 function _arrayToObject(arr: any[]) {
   const obj = {};
   arr.forEach((el, i) => (obj[i] = el));


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Reviewing the issue, I can't actually figure out a) why the translations worked initially (I though only support had been added for data lists, but the template uses campaigns) and b) why it stopped working. I think there might be something a bit deeper to do with the excel sheets (did maybe the global use to refer to one data list and then that changed?). But in any case a good reason to add a better/more general fix for translating dynamic content

- Add improved method to handle translation of dynamic objects (e.g. data lists and campaigns)

I've tested with the [debug_translation](https://docs.google.com/spreadsheets/d/1Bwh8eb2B43AAlDND4q0b4E-EXgnd6IRjmIFIf1Jbk1c/edit#gid=2032321486) sheet and also as a quick run through the first few app screens and all seems to be working as intended to me, although would be good to get a second check as there is some potential for breaking changes (the initial code was applied only to data lists, but the new code applies to all dynamic content, e.g. campaign, calc, data, global etc.).

## Git Issues

Closes #1012

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/133282846-5e5c1d97-dcd0-4d61-bf35-db1f5a104d7c.png)

