### PR TITLE
add support for raw values

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -14,6 +14,7 @@ export const DYNAMIC_PREFIXES = [
   "campaign",
   "calc",
   "item",
+  "raw",
 ] as const;
 
 /**

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -143,7 +143,7 @@ export class TemplateVariablesService {
       context.calcContext = calcContext;
 
       // If a raw evaluator exists for any part of expression, return full expression unparsed
-      // e.g. "Example field name syntax is `@field.my_name`"
+      // e.g. "Example syntax is `@field.my_name`" -> "Example syntax is @field.my_name"
       if (type === "raw") {
         return evaluator.fullExpression.replace(/`/gi, "");
       }

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -351,10 +351,6 @@ export class TemplateVariablesService {
           // field may not exist
         }
         break;
-      case "raw":
-        console.log("parse raw", evaluator);
-        parsedValue = evaluator.matchedExpression;
-        break;
       default:
         parseSuccess = false;
         console.error("No evaluator for dynamic field:", evaluator.matchedExpression);

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -142,6 +142,12 @@ export class TemplateVariablesService {
       const { type, fieldName, matchedExpression } = evaluator;
       context.calcContext = calcContext;
 
+      // If a raw evaluator exists for any part of expression, return full expression unparsed
+      // e.g. "Example field name syntax is `@field.my_name`"
+      if (type === "raw") {
+        return evaluator.fullExpression.replace(/`/gi, "");
+      }
+
       // process the main lookup, e.g. @local.some_val, @campaign.some_val
       // NOTE - if parse fail an empty string will be returned
       let { parsedValue, parseSuccess } = await this.processDynamicEvaluator(evaluator, context);
@@ -344,6 +350,10 @@ export class TemplateVariablesService {
         } catch (error) {
           // field may not exist
         }
+        break;
+      case "raw":
+        console.log("parse raw", evaluator);
+        parsedValue = evaluator.matchedExpression;
         break;
       default:
         parseSuccess = false;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Breaking Changes
Assume none. In theory, any strings that use backticks already with dynamic fields e.g. `` `@fields.some_value` ``   would have previously been parsed and rendered between backticks, but no other backticks found in search on plh data so assume non-issue. 
Regular text can still use backticks if required.

## Description

- Add syntax so that dynamic fields wrapped in backticks,e.g. `` `@fields.some_value` `` are not parsed
- Add examples to [example_set_fields_in_action](https://docs.google.com/spreadsheets/d/1YRCwIrsPkTw8S6NRZPyRax0jE8jzHXKy7EoftTK-YXE/edit#gid=41221518)
- Minor improvements to parser regex comments

## Git Issues

Closes #1018

## Screenshots/Videos

[example_set_fields_in_action](https://docs.google.com/spreadsheets/d/1YRCwIrsPkTw8S6NRZPyRax0jE8jzHXKy7EoftTK-YXE/edit#gid=41221518)
![image](https://user-images.githubusercontent.com/10515065/133682592-7891ded4-fc81-4b43-85cd-76a7c2d0c491.png)

![image](https://user-images.githubusercontent.com/10515065/133683748-19df610e-a7a8-4a7b-965e-6004710d47c1.png)


