### PR TITLE
Add support for automated campaign scheduling and translation

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -30,3 +30,12 @@ export const APP_FIELDS = {
   SERVER_SYNC_LATEST: `${FIELD_PREFIX}._server_sync_latest`,
   APP_LANGUAGE: `${FIELD_PREFIX}._app_language`,
 };
+
+/**
+ * Some specific strings are currently hardcoded into the app
+ * TODO - not all strings included, should add to when required
+ */
+export const APP_STRINGS = {
+  NOTIFICATION_DEFAULT_TITLE: "Notification",
+  NOTIFICATION_DEFAULT_TEXT: "You have a new message from PLH",
+};

--- a/packages/scripts/src/plh-data-convert/parsers/data_list/data_list.parser.ts
+++ b/packages/scripts/src/plh-data-convert/parsers/data_list/data_list.parser.ts
@@ -1,3 +1,4 @@
+import { setNestedProperty } from "../../../../../../src/app/shared/utils";
 import { FlowTypes } from "../../../../types";
 import { extractConditionList, parsePLHCollectionString } from "../../utils";
 import { DefaultParser } from "../default/default.parser";
@@ -14,6 +15,11 @@ export class DataListParser extends DefaultParser {
       }
       if (field.endsWith("notification_schedule")) {
         row[field] = parsePLHCollectionString(row[field]);
+      }
+      // assign nested structures, e.g {time.hour : 4} => {time: { hour: 4 }}
+      if (field.includes(".")) {
+        row = setNestedProperty(field, row[field], row);
+        delete row[field];
       }
     });
     return row;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,7 +79,6 @@ export class AppComponent {
       }
       this.analyticsService.init();
       this.renderAppTemplates = true;
-      this.scheduleCampaignNotifications();
       this.scheduleReinitialisation();
     });
   }
@@ -98,27 +97,12 @@ export class AppComponent {
     await this.dataEvaluationService.refreshDBCache();
     await this.templateService.init();
     await this.templateProcessService.init();
+    await this.campaignService.init();
   }
 
   clickOnMenuItem(id: string) {
     this.menuController.close("main-side-menu");
     this.router.navigateByUrl("/" + id);
-  }
-
-  /**
-   * Manually schedule specific campaign notifications
-   * TODO CC 2021-05-14 - Ideally these should be triggered from a template or other general method
-   */
-  async scheduleCampaignNotifications() {
-    const inactiveNotification = await this.campaignService.getNextCampaignRow(
-      "m_inactive_campaign"
-    );
-    if (inactiveNotification) {
-      const notifications = await this.campaignService.scheduleCampaignNotification(
-        inactiveNotification
-      );
-      console.log("scheduled notifications", notifications);
-    }
   }
 
   /** Rewrite default log functions for improved performance when running on device */

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
@@ -60,7 +60,7 @@ export class CampaignDebugPage implements OnInit {
   }
 
   public scheduleNotification(row: FlowTypes.Campaign_listRow) {
-    return this.campaignService.scheduleCampaignNotification(row);
+    return this.campaignService.scheduleCampaignNotification(row, this.debugCampaignId);
   }
 
   /**
@@ -88,7 +88,7 @@ export class CampaignDebugPage implements OnInit {
   private async processCampaign() {
     const debugCampaignRows: IDebugCampaignRows = { activated: [], deactivated: [], pending: [] };
     const campaign_id = this.debugCampaignId;
-    const campaignRows = this.campaignService.campaigns[campaign_id];
+    const campaignRows = this.campaignService.campaigns[campaign_id].rows;
     const evaluated = await Promise.all(
       campaignRows.map(async (row) => {
         return await this.campaignService.evaluateCampaignRow(row);

--- a/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.html
+++ b/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.html
@@ -33,8 +33,10 @@
                 class="no-padding"
                 style="margin: 0"
                 [disabled]="!localNotificationService.enabled"
-              >
-                {{notification.schedule.at | date:'MMM d, h:mm a'}}
+                ><div>
+                  <div>{{notification.schedule.at | date:'MMM d YYYY'}}</div>
+                  <div>{{notification.schedule.at | date: 'h:mm a'}}</div>
+                </div>
               </ion-button>
             </div>
             <div class="divider"></div>

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -83,6 +83,15 @@ export function mergeObjectArrays<T>(
   return Object.values(secondaryHash);
 }
 
+export function randomElementFromArray(arr: any[] = null) {
+  try {
+    const randomItem = arr[Math.floor(Math.random() * arr.length)];
+    return randomItem;
+  } catch (error) {
+    return null;
+  }
+}
+
 /**
  * Retrieve a nested property from a json object
  * using a single path string accessor

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -51,6 +51,17 @@ export function arrayToHashmapArray<T>(arr: T[], keyfield: keyof T) {
 }
 
 /**
+ * Takes an array of arrays and merges into single array
+ * @example ```
+ * mergeArrayOfArrays([['a','b'],['c','d']])
+ * // [ 'a', 'b', 'c', 'd' ]
+ * ```
+ */
+export function mergeArrayOfArrays<T>(arr: T[][]) {
+  return [].concat.apply([], arr);
+}
+
+/**
  * Take 2 object arrays identified by a given key field, and merge rows together.
  * In case of rows with identical keys, only one will be retained
  *


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Update 3 (2021-09-25)
Reverting to draft following issue identified for required updates to APIs. Likely the PR will be merged with another more substantial update

## Update 2 (2021-09-24)
I realised a core limitation in the current system where actions defined in a notification `click_action_list` would not be triggered for 2 main reasons:

1. We did not have bindings that could be used to notify services that notifications had been triggered
2. The capacitor API does not provide any events to respond to when notifications have been triggered while running on web
3. The capacitor API does not persist notifications scheduled on web

So to work around these a custom system has been implemented that tries to keep track of all notifications that have been scheduled in localstorage, and provide an observable event stream that services can use to respond to triggered notifications. This event stream stores a list of any notifications that have never previously been marked as sent (i.e. triggered either since the current app start OR between the current session start and the previous app session end) 

Also includes list of recently sent
![image](https://user-images.githubusercontent.com/10515065/134769864-7f2a3e56-a2de-4ee7-ad44-b4b21ff98edb.png)


## Update 1 2021-09-17)
- Added support for randomisation, so that if multiple satisfied rows have same priority one will be picked at random (new screenshot/video added at bottom)
- Fixed issue where the notification schedule defined in new format wasn't being processed correctly (required adding support to convert nest fields in data lists (e.g. `{time.hour:4}`) into json format (`{time:{hour:4}}`)

## Breaking Changes
There is one notification scheduled under the old system via `m_inactive_campaign` that will not be removed when new notifications are scheduled, and so will still trigger monthly inactive reminder one month after last set. This is because the old system never actually tracked which campaign had been used to set a notification (only the id of the notification itself), and was only ever rescheduled each app load for one month later.

## TODO (authors)
- [x]  The new `notification_schedule` sheet should be used to contain all timing information for campaigns. Currently this is merged with the `notification_schedule` column in individual campaign rows, and so duplicate content should be able to be removed from individual rows. 

NOTE - for now we still want to retain the column as a means to provide title/text for the notification (but will likely refactor later to own columns, e.g. notification.title and notification.text or similar).

- [x] Created sheet [debug_notification_schedule](https://docs.google.com/spreadsheets/d/1Jf38D4pkoBO0QIUcw1IFAqlEokrUzhOESi3hNlW0vZM/edit#gid=998700467) which should be moved to a proper campaign location and updated as required

- [ ] A few previously hardcoded strings have been identified (default values for notification title/text) and moved to a separate list of `APP_STRINGS` in the  `data-models/constants.ts` file. At some point in future we should plan better how these are used/modified/translated (although for now less important as all notifications have title/text provided and so defaults not used)


## Description
Previously scheduling of push notifications was hardcoded, just for the `m_inactive` campaign. The PR adds support for automated scheduling of any campaigns that have a defined schedule. Additionally it fixes the way campaigns are rescheduled (previously old notifications would not be removed), and adds support for translated content. Specifically:

- Add support for data lists with `notification_schedule` subtype used to apply standard scheduling across campaigns
- Refactor and update startup scripts to handle lookup of all campaigns with notification schedules from the campaign feature service, and automatically process any push notifications
- Update scheduling methods to include campaign_id of the campaign that scheduled a push notification, so that when re-evaluated any old notification can be removed
- Add support to translate notification title and text

## Git Issues

Closes #

## Screenshots/Videos




**Notifications now scheduled from multiple campaigns**
![image](https://user-images.githubusercontent.com/10515065/133745226-f5b79995-86ee-43c0-8c82-9bafbf7663ee.png)

**[debug_notification_schedule](https://docs.google.com/spreadsheets/d/1Jf38D4pkoBO0QIUcw1IFAqlEokrUzhOESi3hNlW0vZM/edit#gid=998700467) example to provide auto-scheduling across campaigns and replace hardcoded timing content in campaign rows**
![image](https://user-images.githubusercontent.com/10515065/133745267-685d0b08-e3d9-48d4-9a0e-6e02ae3c8b7f.png)

**Translated notifications rescheduled after language change (and reload)**
![image](https://user-images.githubusercontent.com/10515065/133749959-dc69cc83-04aa-4b1e-86dc-43429bcc0226.png)

**Randomised debug notification from [debug_campaign_rows](https://docs.google.com/spreadsheets/d/1Jf38D4pkoBO0QIUcw1IFAqlEokrUzhOESi3hNlW0vZM/edit#gid=1344817192)**

https://user-images.githubusercontent.com/10515065/133786282-7037e58d-387f-4b60-bec9-fde9f0096a4d.mp4

![image](https://user-images.githubusercontent.com/10515065/133786343-f080c215-1063-4951-81de-043fec584566.png)



