### PR TITLE
pin gh-action upload-google-play version

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -79,7 +79,7 @@ jobs:
           asset_name: app-debug.apk
           asset_content_type: application/zip
       - name: Upload to Google play
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.0.15
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: international.idems.plh_teens


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

A recent API change broke the github action that submits apks to google play as part of the automated release process. This PR pins the version of the github action used to the previous working version

Issue on action: `https://github.com/r0adkll/upload-google-play/issues/80`

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
