### PR TITLE
fix parent point flicker

### DIFF
--- a/src/app/shared/components/template/components/points-item/points-item.component.html
+++ b/src/app/shared/components/template/components/points-item/points-item.component.html
@@ -1,5 +1,5 @@
 <div class="wrapper-point">
-  <div #celebretionAnim class="celebrationAnim">
+  <div *ngIf="showCelebrationAnimation" class="celebrationAnim">
     <ng-lottie [options]="animCelebrationOptions"></ng-lottie>
   </div>
   <div class="item" #item (click)="clickPointItem()">

--- a/src/app/shared/components/template/components/points-item/points-item.component.scss
+++ b/src/app/shared/components/template/components/points-item/points-item.component.scss
@@ -59,10 +59,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: -1;
-  &.play {
-    z-index: 1 !important;
-  }
+  z-index: 1;
   width: 100%;
 }
 .on-add {

--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -11,7 +11,6 @@ import { TemplateBaseComponent } from "../base";
 import { FlowTypes, ITemplateRowProps } from "../../models";
 import { getBooleanParamFromTemplateRow, getStringParamFromTemplateRow } from "../../../../utils";
 import { AnimationOptions } from "ngx-lottie";
-import player from "lottie-web";
 import { getImageAssetPath } from "../../utils/template-utils";
 
 @Component({
@@ -26,7 +25,6 @@ export class TmplParentPointBoxComponent
 {
   @Input() template: FlowTypes.Template;
   @ViewChild("star", { static: false }) star: ElementRef;
-  @ViewChild("celebretionAnim", { static: false }) celebretionAnim: ElementRef;
   @ViewChild("item", { static: false }) item: ElementRef;
   icon_src: string | null;
   lottie_src: string | null;
@@ -38,6 +36,7 @@ export class TmplParentPointBoxComponent
   animOptions: AnimationOptions;
   animCelebrationOptions: AnimationOptions;
   play_celebration: boolean;
+  showCelebrationAnimation = false;
   @HostListener("window:resize", ["$event"]) onResize(event) {
     this.windowWidth = event.target.innerWidth - 10;
     this.getScaleFactor();
@@ -65,7 +64,7 @@ export class TmplParentPointBoxComponent
     this.animCelebrationOptions = {
       path: getImageAssetPath("/plh_lottie/habits/cascading_stars.json"),
       name: "celebration",
-      autoplay: false,
+      autoplay: true,
       loop: false,
       rendererSettings: {
         // svg scaling options: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
@@ -93,13 +92,11 @@ export class TmplParentPointBoxComponent
     this.value = this._row.value;
     this.star.nativeElement.classList.add("on-add");
     if (this.play_celebration) {
-      this.celebretionAnim.nativeElement.classList.add("play");
-      player.play("celebration");
+      this.showCelebrationAnimation = true;
     }
     setTimeout((_) => {
       this.star.nativeElement.classList.remove("on-add");
-      this.celebretionAnim.nativeElement.classList.remove("play");
-      player.stop("celebration");
+      this.showCelebrationAnimation = false;
     }, 1000);
     if (!this.wasClicked) {
       this.item.nativeElement.classList.add("complete");

--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -68,6 +68,7 @@ export class TmplParentPointBoxComponent
       loop: false,
       rendererSettings: {
         // svg scaling options: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
+        z-index: 999,
         preserveAspectRatio: "xMinYMin slice",
       },
     };

--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -68,7 +68,6 @@ export class TmplParentPointBoxComponent
       loop: false,
       rendererSettings: {
         // svg scaling options: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
-        z-index: 999,
         preserveAspectRatio: "xMinYMin slice",
       },
     };


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

After various other discussions and PRs (see slack thread), the cause of the screen flicker issue seems to be linked to the implementation of the parent point tiles (namely the celebration animation)

Previously every parent point renders a celebration animation component, and toggles a start play function when called. For whatever reason this proved problematic in recent versions of chrome (possibly because of too many animations on the page, how lottie implements non-started animations, the fact the animation is duplicated for each tile or any other combination of factors etc.)

This pr changes the celebration implementation to conditionally render the animation, only when it is triggered (to remove the duplicate animations from the dom). It appears to fix the screen flicker image when testing locally.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
