### PR TITLE
Minor radio group image and text fixes

### DIFF
--- a/src/app/shared/components/template/components/radio-group/radio-group.component.scss
+++ b/src/app/shared/components/template/components/radio-group/radio-group.component.scss
@@ -63,10 +63,10 @@ $primary-radio-border-rd: calc(15px * var(--scale-factor));
             margin-bottom: calc(3px * var(--scale-factor));
 
             svg {
-              max-width: 95%;
-              max-height: 95%;
-              width: 95%;
-              height: 95%;
+              max-width: 100%;
+              max-height: 100%;
+              width: 100%;
+              height: 100%;
             }
           }
         }
@@ -102,10 +102,10 @@ $primary-radio-border-rd: calc(15px * var(--scale-factor));
             margin-bottom: calc(3px * var(--scale-factor));
 
             svg {
-              max-width: 95%;
-              max-height: 95%;
-              width: 95%;
-              height: 95%;
+              max-width: 100%;
+              max-height: 100%;
+              width: 100%;
+              height: 100%;
             }
           }
         }
@@ -189,4 +189,8 @@ label {
   font-weight: 700;
   text-align: center;
   transition: 0.3s linear;
+}
+
+span {
+  font-size: initial;
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes the radio group image and text on web and also the group image size for radio groups.

## Git Issues

Closes #1015 

## Screenshots/Videos

- Tested for web
![image](https://user-images.githubusercontent.com/62892109/141301317-74229638-c019-4bc2-8d5e-00de1e06f442.png)

-Tested for mobile
![image](https://user-images.githubusercontent.com/62892109/141301501-895fab22-13cc-4658-ab76-7c2f171cf4c1.png)

