### PR TITLE
fix server sync timestamp

### DIFF
--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -51,6 +51,11 @@ export class ServerService {
   syncUserData() {
     console.log("[SERVER] sync data");
     const contact_fields = this.getUserStorageData();
+
+    // apply temp timestamp to contact fields to sync as latest
+    const timestamp = generateTimestamp();
+    contact_fields[APP_FIELDS.SERVER_SYNC_LATEST] = timestamp;
+
     // TODO - get DTO from api (?)
     const data = {
       contact_fields,
@@ -60,6 +65,7 @@ export class ServerService {
     return new Promise<string>((resolve, reject) => {
       this.http
         .post(`/app_users/${this.app_user_id}`, data)
+        /* WiP - code to handle optional automated retry */
         // .pipe(
         //   catchError(this.handleError)
         //   // retryWhen((errors) =>
@@ -72,8 +78,8 @@ export class ServerService {
         // )
         .subscribe(
           (res) => {
-            const timestamp = generateTimestamp();
             console.log("User data synced", res);
+            // finalise timestamp by storing locally
             localStorage.setItem(APP_FIELDS.SERVER_SYNC_LATEST, timestamp);
             resolve(timestamp);
           },


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Previously the contact field that records last sync was outdated on the server because it only tracked the last saved value (which only is saved after a successful sync).

This PR changes the behaviour so that the time sync initiated is recorded, and if successful written locally so that server and local fields will match

## Git Issues

Closes #

## Screenshots/Videos

After clean start, initial sync now has a populated contact field for `_server_sync_latest`.

![image](https://user-images.githubusercontent.com/10515065/141601117-fbf685b2-9a45-4a10-b2f4-2550939865ef.png)

