### PR TITLE
Fix legacy asset paths

### DIFF
--- a/packages/app-data/data/template/template.component_demo.ts
+++ b/packages/app-data/data/template/template.component_demo.ts
@@ -142,6 +142,58 @@ const template: FlowTypes.Template[] = [
   },
   {
     flow_type: "template",
+    flow_name: "comp_number_button_5",
+    status: "released",
+    flow_subtype: "component_demo",
+    rows: [
+      {
+        type: "number_selector",
+        name: "default",
+        _nested_name: "default",
+      },
+      {
+        type: "number_selector",
+        name: "par_5_1",
+        parameter_list: {
+          category_list: "",
+        },
+        _nested_name: "par_5_1",
+      },
+      {
+        name: "category_list",
+        value: ["0-10", "11-20", "21-30", "31-40", "41-50", "51-60", "61-70", "71-80", "80+"],
+        type: "set_variable",
+        _nested_name: "category_list",
+      },
+      {
+        type: "number_selector",
+        name: "par_5_2",
+        parameter_list: {
+          category_list: "@local.category_list",
+        },
+        _nested_name: "par_5_2",
+        _dynamicFields: {
+          parameter_list: {
+            category_list: [
+              {
+                fullExpression: "@local.category_list",
+                matchedExpression: "@local.category_list",
+                type: "local",
+                fieldName: "category_list",
+              },
+            ],
+          },
+        },
+        _dynamicDependencies: {
+          "@local.category_list": ["parameter_list.category_list"],
+        },
+      },
+    ],
+    _xlsxPath:
+      "plh_sheets_beta/plh_templating/quality_assurance/components_demo/component_number_selector.xlsx",
+  },
+  {
+    flow_type: "template",
     flow_name: "comp_round_button_3",
     status: "released",
     flow_subtype: "component_demo",

--- a/packages/app-data/data/template/template.component_demo.ts
+++ b/packages/app-data/data/template/template.component_demo.ts
@@ -142,58 +142,6 @@ const template: FlowTypes.Template[] = [
   },
   {
     flow_type: "template",
-    flow_name: "comp_number_button_5",
-    status: "released",
-    flow_subtype: "component_demo",
-    rows: [
-      {
-        type: "number_selector",
-        name: "default",
-        _nested_name: "default",
-      },
-      {
-        type: "number_selector",
-        name: "par_5_1",
-        parameter_list: {
-          category_list: "",
-        },
-        _nested_name: "par_5_1",
-      },
-      {
-        name: "category_list",
-        value: ["0-10", "11-20", "21-30", "31-40", "41-50", "51-60", "61-70", "71-80", "80+"],
-        type: "set_variable",
-        _nested_name: "category_list",
-      },
-      {
-        type: "number_selector",
-        name: "par_5_2",
-        parameter_list: {
-          category_list: "@local.category_list",
-        },
-        _nested_name: "par_5_2",
-        _dynamicFields: {
-          parameter_list: {
-            category_list: [
-              {
-                fullExpression: "@local.category_list",
-                matchedExpression: "@local.category_list",
-                type: "local",
-                fieldName: "category_list",
-              },
-            ],
-          },
-        },
-        _dynamicDependencies: {
-          "@local.category_list": ["parameter_list.category_list"],
-        },
-      },
-    ],
-    _xlsxPath:
-      "plh_sheets_beta/plh_templating/quality_assurance/components_demo/component_number_selector.xlsx",
-  },
-  {
-    flow_type: "template",
     flow_name: "comp_round_button_3",
     status: "released",
     flow_subtype: "component_demo",

--- a/packages/translations/examples/compiled/jsons/data_list.json
+++ b/packages/translations/examples/compiled/jsons/data_list.json
@@ -7,8 +7,8 @@
     "rows": [
       {
         "id": "example_lang_1",
-        "image_asset": "assets/plh_assets/plh_images/habits/habit_relax.svg",
-        "lottie_asset": "assets/plh_assets/plh_lottie/habits/habit_relax.json",
+        "image_asset": "plh_images/habits/habit_relax.svg",
+        "lottie_asset": "plh_lottie/habits/habit_relax.json",
         "title": "Example Data List Title 1",
         "_translations": {
           "title": {
@@ -30,8 +30,8 @@
       },
       {
         "id": "example_lang_2",
-        "image_asset": "assets/plh_assets/plh_images/habits/habit_treat_yourself.svg",
-        "lottie_asset": "assets/plh_assets/plh_lottie/habits/habit_treat_yourself.json",
+        "image_asset": "plh_images/habits/habit_treat_yourself.svg",
+        "lottie_asset": "plh_lottie/habits/habit_treat_yourself.json",
         "title": "Example Data List Title 2",
         "_translations": {
           "title": {

--- a/packages/translations/examples/source/data_list.json
+++ b/packages/translations/examples/source/data_list.json
@@ -7,8 +7,8 @@
     "rows": [
       {
         "id": "example_lang_1",
-        "image_asset": "assets/plh_assets/plh_images/habits/habit_relax.svg",
-        "lottie_asset": "assets/plh_assets/plh_lottie/habits/habit_relax.json",
+        "image_asset": "plh_images/habits/habit_relax.svg",
+        "lottie_asset": "plh_lottie/habits/habit_relax.json",
         "title": "Example Data List Title 1",
         "_translatedFields": {
           "title": {
@@ -22,8 +22,8 @@
       },
       {
         "id": "example_lang_2",
-        "image_asset": "assets/plh_assets/plh_images/habits/habit_treat_yourself.svg",
-        "lottie_asset": "assets/plh_assets/plh_lottie/habits/habit_treat_yourself.json",
+        "image_asset": "plh_images/habits/habit_treat_yourself.svg",
+        "lottie_asset": "plh_lottie/habits/habit_treat_yourself.json",
         "title": "Example Data List Title 2",
         "_translatedFields": {
           "title": {

--- a/src/app/feature/chat/components/chat.page.html
+++ b/src/app/feature/chat/components/chat.page.html
@@ -22,28 +22,31 @@
         <div *ngIf="msg.character && !sameAsLastCharacter(msg, messages[i - 1])">
           <img
             class="character-image"
-            [src]="'assets/plh_assets/plh_images/characters/' + msg.character.toLowerCase().trim() + '/neutral.svg'"
+            [src]="'plh_images/characters/' + msg.character.toLowerCase().trim() + '/neutral.svg'"
           />
         </div>
-        <div class="msg-bubble-container"
-          [ngClass]="{'bot': msg.sender === 'bot', 'user': msg.sender === 'user'}">
+        <div
+          class="msg-bubble-container"
+          [ngClass]="{'bot': msg.sender === 'bot', 'user': msg.sender === 'user'}"
+        >
           <svg
-            *ngIf="msg.sender === 'bot'"class="bot-msg-triangle"
+            *ngIf="msg.sender === 'bot'"
+            class="bot-msg-triangle"
             width="15"
             height="20"
             viewBox="0 0 15 20"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
           >
-          <path d="M15 20V0L0 10L15 20Z" fill="grey" />
+            <path d="M15 20V0L0 10L15 20Z" fill="grey" />
           </svg>
           <div class="msg-bubble">
             <div *ngIf="!msg.hideText" [innerHTML]="msg.text"></div>
-            <img *ngIf="msg.innerImageUrl" [src]="msg.innerImageUrl">
+            <img *ngIf="msg.innerImageUrl" [src]="msg.innerImageUrl" />
           </div>
           <svg
             *ngIf="msg.sender === 'user'"
-            class="user-msg-triangle" 
+            class="user-msg-triangle"
             width="15"
             height="20"
             viewBox="0 0 15 20"

--- a/src/app/feature/chat/utils/message.converter.ts
+++ b/src/app/feature/chat/utils/message.converter.ts
@@ -59,7 +59,7 @@ export async function convertFromRapidProMsg(rpMsg: IRapidProMessage): Promise<C
   msg = applyCustomMessageInfo(urlPartsList, msg);
   if (msg.choiceMediaUrls) {
     msg.responseOptions.forEach((option, idx) => {
-      option.imageUrl = "assets/plh_assets/" + msg.choiceMediaUrls[idx];
+      option.imageUrl = msg.choiceMediaUrls[idx];
       option.hideText = msg.choiceMediaDisplay === "media";
     });
   }
@@ -199,7 +199,8 @@ export function isHiddenURL(urlParts: URLParts): boolean {
 }
 
 export function getURLSInText(text: string): URLParts[] {
-  let urlRegex = /(?<protocol>http[s]?):\/\/(?<domain>[a-zA-Z0-9\.\-\_]*)(?:[\:]?(?<port>[0-9]*))(?<path>\/[^?#\s]*)?[\?]?(?:(?<query>[^?#\s]*))?[#]?(?<fragment>[^?#\s]*)?/gm;
+  let urlRegex =
+    /(?<protocol>http[s]?):\/\/(?<domain>[a-zA-Z0-9\.\-\_]*)(?:[\:]?(?<port>[0-9]*))(?<path>\/[^?#\s]*)?[\?]?(?:(?<query>[^?#\s]*))?[#]?(?<fragment>[^?#\s]*)?/gm;
   const urls: URLParts[] = [];
   let regexResult: RegExpExecArray;
   while ((regexResult = urlRegex.exec(text))) {
@@ -248,9 +249,6 @@ export async function convertRapidProAttachments(attachments: string[]): Promise
       let urlRegexResult = urlRegex.exec(url);
       // Handle local asset
       if (!urlRegexResult) {
-        if (!url.startsWith("assets/plh_assets/")) {
-          url = `assets/plh_assets/${url}`;
-        }
         return { type, url };
       }
       // Handle web asset

--- a/src/app/shared/components/template/services/template-asset.service.ts
+++ b/src/app/shared/components/template/services/template-asset.service.ts
@@ -18,14 +18,21 @@ export class TemplateAssetService {
    */
   getTranslatedAssetPath(value: string) {
     const currentLanguageCode = this.translateService.app_language;
-    const assetEntry = ASSETS_CONTENTS_LIST[value];
+    const assetName = this.cleanAssetName(value);
+    const assetEntry = ASSETS_CONTENTS_LIST[assetName];
     if (!assetEntry) {
-      console.error("Asset missing", value);
+      console.error("Asset missing", value, assetName);
     }
     if (assetEntry?.translations?.[currentLanguageCode]) {
-      return this.convertPLHRelativePathToAssetPath(`${currentLanguageCode}/${value}`);
+      return this.convertPLHRelativePathToAssetPath(`${currentLanguageCode}/${assetName}`);
     }
-    return this.convertPLHRelativePathToAssetPath(`${ASSETS_GLOBAL_FOLDER_NAME}/${value}`);
+    return this.convertPLHRelativePathToAssetPath(`${ASSETS_GLOBAL_FOLDER_NAME}/${assetName}`);
+  }
+
+  private cleanAssetName(value: string) {
+    // remove prefix slash
+    if (value.startsWith("/")) value = value.replace("/", "");
+    return value;
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Update some legacy example data that still used `assets/plh_assets` prefixes, 
- Add fix to handle assets that start with `/` (e.g. `/plh_images/icons/heart.svg` instead of `plh_images/icons/heart.svg`)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
