### PR TITLE
Visual test dynamic config

### DIFF
--- a/.github/workflows/test-visual-compare.yml
+++ b/.github/workflows/test-visual-compare.yml
@@ -55,7 +55,7 @@ jobs:
           npx concurrently --kill-others \
           "yarn start" \
           "npx wait-on --timeout 1200000 http-get://localhost:4200 && \
-          yarn workspace test-visual start compare --concurrency 5 --page-wait 1000"
+          yarn workspace test-visual start compare --concurrency 5"
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-visual-generate.yml
+++ b/.github/workflows/test-visual-generate.yml
@@ -38,7 +38,7 @@ jobs:
           npx concurrently --kill-others \
           "yarn start" \
           "npx wait-on --timeout 1200000  http-get://localhost:4200 && \
-          yarn workspace test-visual start generate --concurrency 5 --page-wait 1000"
+          yarn workspace test-visual start generate --concurrency 5"
       - name: test
         run: ls packages/test-visual/output/screenshots
       - name: Upload screenshots

--- a/packages/app-data/test/index.ts
+++ b/packages/app-data/test/index.ts
@@ -11,7 +11,7 @@ const ADDITIONAL_TEMPLATE_NAMES = ["home_screen", "weekly_workshops"];
 const SKIPPED_TEMPLATE_NAMES = [];
 
 /** Default time spent waiting to ensure page elements rendered fully */
-const PAGE_WAIT_DEFAULT = 500;
+const PAGE_WAIT_DEFAULT = 1000;
 
 /** Default viewport height used for test, in pixels */
 const PAGE_WIDTH_DEFAULT = 360;
@@ -23,9 +23,10 @@ const PAGE_HEIGHT_DEFAULT = 1280;
 const PAGE_WAIT_OVERRIDES = {
   example_lang_template_1: 2000,
   debug_advanced_dashed_box_1: 2000,
+  home_screen: 2000,
 };
 
-/** Custom overrides to set height for larger pages */
+/** Custom overrides to set height for larger pages, in pixels */
 const PAGE_HEIGHT_OVERRIDES = {
   example_lang_template_1: 3600,
 };

--- a/packages/app-data/test/index.ts
+++ b/packages/app-data/test/index.ts
@@ -3,9 +3,20 @@ import { template } from "../data/template";
 /** List of template flow subtypes to test */
 const TEST_FLOW_SUBTYPES = ["debug"];
 
+/** List of additional template names to test */
+const ADDITIONAL_TEMPLATE_NAMES = ["home_screen", "weekly_workshops"];
+
+/** List of template names to skip */
+const SKIPPED_TEMPLATE_NAMES = [];
+
 /** Combined list of templates to test */
 export const VISUAL_TEST_TEMPLATE_LIST = template
-  .filter((t) => TEST_FLOW_SUBTYPES.includes(t.flow_subtype))
+  .filter((t) => {
+    if (SKIPPED_TEMPLATE_NAMES.includes(t.flow_name)) return false;
+    if (ADDITIONAL_TEMPLATE_NAMES.includes(t.flow_name)) return true;
+    if (TEST_FLOW_SUBTYPES.includes(t.flow_subtype)) return true;
+    return false;
+  })
   .map((t) => ({
     name: t.flow_name,
     url: `template/${t.flow_name}`,

--- a/packages/app-data/test/index.ts
+++ b/packages/app-data/test/index.ts
@@ -1,3 +1,4 @@
+import { DB_TABLES, DB_VERSION } from "data-models/db.model";
 import { template } from "../data/template";
 
 /** List of template flow subtypes to test */
@@ -9,8 +10,28 @@ const ADDITIONAL_TEMPLATE_NAMES = ["home_screen", "weekly_workshops"];
 /** List of template names to skip */
 const SKIPPED_TEMPLATE_NAMES = [];
 
-/** Combined list of templates to test */
-export const VISUAL_TEST_TEMPLATE_LIST = template
+/** Default time spent waiting to ensure page elements rendered fully */
+const PAGE_WAIT_DEFAULT = 500;
+
+/** Default viewport height used for test, in pixels */
+const PAGE_WIDTH_DEFAULT = 360;
+
+/** Default viewport width used for test, in pixels */
+const PAGE_HEIGHT_DEFAULT = 1280;
+
+/** Custom wait times for pages that require longer loading */
+const PAGE_WAIT_OVERRIDES = {
+  example_lang_template_1: 2000,
+  debug_advanced_dashed_box_1: 2000,
+};
+
+/** Custom overrides to set height for larger pages */
+const PAGE_HEIGHT_OVERRIDES = {
+  example_lang_template_1: 3600,
+};
+
+/** Combined list of templates to test and map properties */
+const VISUAL_TEST_TEMPLATE_LIST = template
   .filter((t) => {
     if (SKIPPED_TEMPLATE_NAMES.includes(t.flow_name)) return false;
     if (ADDITIONAL_TEMPLATE_NAMES.includes(t.flow_name)) return true;
@@ -21,4 +42,27 @@ export const VISUAL_TEST_TEMPLATE_LIST = template
     name: t.flow_name,
     url: `template/${t.flow_name}`,
     selector: `plh-template-container[data-templatename="${t.flow_name}"]`,
+    pageWait: PAGE_WAIT_OVERRIDES[t.flow_name] || PAGE_WAIT_DEFAULT,
+    width: PAGE_WIDTH_DEFAULT,
+    height: PAGE_HEIGHT_OVERRIDES[t.flow_name] || PAGE_HEIGHT_DEFAULT,
   }));
+
+/** Main export for use in test runner */
+export const VISUAL_TEST_CONFIG = {
+  localStorageFields: { _app_language: "za_en", name: "test default user" },
+  dexieConfig: {
+    version: DB_VERSION,
+    tableSchema: DB_TABLES,
+    data: {
+      user_meta: [{ key: "first_app_open", value: "2021-09-02" }],
+    },
+  },
+  pageDefaults: {
+    width: PAGE_WIDTH_DEFAULT,
+    height: PAGE_HEIGHT_DEFAULT,
+    // TODO - allow passing function to calculate resize
+    // e.g. https://stackoverflow.com/questions/61886891/how-to-get-maximum-scroll-height-for-ion-content
+  },
+  pageList: VISUAL_TEST_TEMPLATE_LIST,
+  appServerUrl: "http://localhost:4200",
+} as const;

--- a/packages/app-data/test/index.ts
+++ b/packages/app-data/test/index.ts
@@ -24,6 +24,7 @@ const PAGE_WAIT_OVERRIDES = {
   example_lang_template_1: 2000,
   debug_advanced_dashed_box_1: 2000,
   home_screen: 2000,
+  example_calc_2: 2000,
 };
 
 /** Custom overrides to set height for larger pages, in pixels */

--- a/packages/app-data/tsconfig.json
+++ b/packages/app-data/tsconfig.json
@@ -6,8 +6,9 @@
     "typeRoots": ["node_modules/@types"],
     "declaration": true,
     "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "lib": ["ESNext"]
   },
-  "include": ["**/*.ts","index.ts"],
-  "exclude": ["node_modules","dist"]
+  "include": ["**/*.ts", "index.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/test-visual/src/commands/compare.ts
+++ b/packages/test-visual/src/commands/compare.ts
@@ -29,7 +29,6 @@ export default program
   .option("-c, --clean", "Clean output folder before generating")
   .option("-D --debug", "Run in debug mode (not headless)")
   .option("-C --concurrency <string>", "Max number of browser pages to process in parallel")
-  .option("-PW --page-wait <string>", "Additional wait time given to help ensure page loaded")
   .action(async (opts) => {
     const options = { ...DEFAULT_OPTIONS, ...opts };
     await new ScreenshotComparator(options).run();

--- a/packages/test-visual/src/commands/compare.ts
+++ b/packages/test-visual/src/commands/compare.ts
@@ -50,16 +50,18 @@ class ScreenshotComparator {
     // const latestRelease = await this.getLatestRelease();
     // const { tag_name } = latestRelease;
     // this.releaseScreenshotsFolder = path.resolve(paths.DOWNLOADED_SCREENSHOTS_FOLDER, tag_name);
-    const comparisonScreenshotsFolder = paths.DOWNLOADED_SCREENSHOTS_FOLDER;
+    const beforeScreenshotsFolder = paths.DOWNLOADED_SCREENSHOTS_FOLDER;
     // folder ensured in paths so check if empty
-    const existingScreenshots = fs.readdirSync(comparisonScreenshotsFolder);
+    const existingScreenshots = fs.readdirSync(beforeScreenshotsFolder);
     if (existingScreenshots.length === 0) {
       // Ensure latest target screenshots are downloaded
       // TODO - could handle with github action and passing compare folder name
       await new ScreenshotDownload().run({
         latest: true,
-        outputFolder: comparisonScreenshotsFolder,
+        outputFolder: beforeScreenshotsFolder,
       });
+    } else {
+      console.log("skipping screenshot download");
     }
     fs.emptyDirSync(paths.SCREENSHOT_DIFFS_FOLDER);
 
@@ -69,8 +71,8 @@ class ScreenshotComparator {
       ...this.options,
       onScreenshotGenerated: async ({ screenshotPath, counter, total }) => {
         const filename = path.basename(screenshotPath);
-        const releaseScreenshotPath = path.resolve(comparisonScreenshotsFolder, filename);
-        await this.compareScreenshots(releaseScreenshotPath, screenshotPath);
+        const beforeScreenshotPath = path.resolve(beforeScreenshotsFolder, filename);
+        await this.compareScreenshots(beforeScreenshotPath, screenshotPath);
         const msg = `${counter}/${total} [${path.basename(screenshotPath, ".png")}]`;
         return process.env.CI
           ? console.log(msg)

--- a/packages/test-visual/src/commands/generate.ts
+++ b/packages/test-visual/src/commands/generate.ts
@@ -44,8 +44,6 @@ interface IProgramOptions {
   debug?: boolean;
   /** maximum templates to process in parallel. Default: 10 */
   concurrency?: string;
-  /** additional wait time (ms) added to ensure content loaded. Default: 500 */
-  pageWait?: string;
 }
 
 const DEFAULT_OPTIONS: IProgramOptions = {
@@ -64,7 +62,6 @@ const DEFAULT_OPTIONS: IProgramOptions = {
   clean: false,
   concurrency: "10",
   debug: false,
-  pageWait: "500",
 };
 
 const program = new Command("generate");
@@ -73,7 +70,6 @@ export default program
   .option("-c, --clean", "Clean output folder before generating")
   .option("-D --debug", "Run in debug mode (not headless)")
   .option("-C --concurrency <string>", "Max number of browser pages to process in parallel")
-  .option("-PW --page-wait <string>", "Additional wait time given to help ensure page loaded")
   .action(async (opts) => {
     console.log("Generating screenshots...");
     await new ScreenshotGenerate(opts).run().then(() => process.exit(0));
@@ -230,7 +226,7 @@ export class ScreenshotGenerate {
     await page.waitForSelector(selector);
     // Additional timeout to support page fully loading
     // TODO - replace with function call from the app
-    await page.waitForTimeout(Number(this.options.pageWait));
+    await page.waitForTimeout(pageConfig.pageWait);
     // Try to ensure all rendering complete by requesting animation frame
     await page.evaluate(async () => {
       async function waitForAnimationFrame() {

--- a/packages/test-visual/src/data/profiles.ts
+++ b/packages/test-visual/src/data/profiles.ts
@@ -1,6 +1,6 @@
 // TODO - merge with cypress profiles
 export const USER_PROFILE_DEFAULT = {
-  fields: { _app_language: "eng", name: "test default user" },
+  fields: { _app_language: "za_en", name: "test default user" },
   tables: {
     user_meta: [{ key: "first_app_open", value: "2021-09-02" }],
   },

--- a/packages/test-visual/src/data/profiles.ts
+++ b/packages/test-visual/src/data/profiles.ts
@@ -1,7 +1,0 @@
-// TODO - merge with cypress profiles
-export const USER_PROFILE_DEFAULT = {
-  fields: { _app_language: "za_en", name: "test default user" },
-  tables: {
-    user_meta: [{ key: "first_app_open", value: "2021-09-02" }],
-  },
-};


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
A small set of configuration changes and refactoring to give more control to authors for how tests will be run. Specifically:

- Add support for additional template names to include/exclude alongside template flow_types
- Refactor default page height, width and page-wait to app-data variables
- Add support for custom template page-wait and height overrides

## Authors Notes
Most of the changes should hopefully be obvious by the new fields available in `packages\app-data\test\index.ts` (see screenshot below)

As the test configuration changes defined here won't have yet been run on master branch, expect the compare script to still generate a number of differences (particularly where the 'before' image is not rendered) - should be more consistent moving forwards

## Dev Notes
The process of configuring page sizes is actually quite tricky. The app has a fixed header and then uses an element within the page to provide a scrollable view (and that element also has its own sandbox or 'shadow dom' which protects the element from the outside world). So from the outside perspective, the page is a fixed/static size and fills the current viewport perfectly.

A future improvement could be passing a function that is executed to find the scrollable element (in this case it is `ion-content`), filter the results (to select the main content and not the sidebar content), query the nested shadow dom for the element that controls the actual scroll height and size, and pass that back to resize the page dynamically. At this point it's probably not worth the effort, but remains an experimental future option.

## Git Issues

Closes #

## Screenshots/Videos
**Example of new config options available in `packages\app-data\test\index.ts`**
![image](https://user-images.githubusercontent.com/10515065/143141386-121c517f-4af7-45a5-80da-31f158c37c99.png)

**Example of home_screen now included within tests**
![home_screen](https://user-images.githubusercontent.com/10515065/143142170-4442624f-a081-4ba4-9452-64c4ebbc0cee.png)

**Custom override for template to produce much larger screenshot for full page**
![example_lang_template_1](https://user-images.githubusercontent.com/10515065/143141223-4dde282b-be39-4991-9786-4d8b65da3612.png)

