### PR TITLE
Feat/notification schedules

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -192,32 +192,29 @@ export namespace FlowTypes {
     habit_list: string[];
   }
 
-  export interface Campaign_listRow {
-    _id: string;
-    activation_condition_list: DataEvaluationCondition[];
-    deactivation_condition_list: DataEvaluationCondition[];
+  export interface Campaign_listRow extends RowWithActivationConditions {
+    id: string;
     campaign_list: string[]; // ids of campaigns where to run
     priority?: number; // higher numbers will be given more priority
-    notification_schedule?: NotificationSchedule;
-    _activated?: boolean; // all activation criteria satisfied
-    _deactivated?: boolean; // any deactivation criteria satisfied
-    _active?: boolean; // activated and not deactivated
-
     // additional fields for current data_list but not required
     click_action_list?: TemplateRowAction[];
     icon?: string;
     text?: string;
-
     // placeholder for any extra fields to be added
     [field: string]: any;
   }
-  export interface NotificationSchedule {
-    text?: string;
-    title?: string;
-    time?: { minute?: string; hour?: string }; // specified time for notification, e.g. 19:30
-    delay?: { days?: string; hours?: string; minutes?: string }; // delay until first notification, e.g. 7 day
-
-    _schedule_at?: Date; // calculated from above info
+  export interface Campaign_Schedule extends RowWithActivationConditions {
+    id: string;
+    /** specified time for notification, e.g. 19:30. Day indicates day of week, starting with 1 = monday */
+    time?: { minute?: string; hour?: string; day?: number };
+    /** delay until first notification, e.g. 7 day */
+    delay?: { days?: string; hours?: string; minutes?: string };
+    /** fixed dates for start and end of schedule */
+    schedule?: { start_date?: string; end_date?: string };
+    /** computed list of campaign rows merged into campaign */
+    _campaign_rows?: Campaign_listRow[];
+    /** computed date for next notification as required by scheduling service */
+    _schedule_at?: Date;
   }
   export interface DataEvaluationCondition {
     /** specific defined actions that have individual methods to determine completion */
@@ -249,6 +246,18 @@ export namespace FlowTypes {
     _raw?: string;
     _cleaned?: string;
     _parsed?: string[][];
+  }
+  export interface RowWithActivationConditions {
+    /** evaluated statements for activating campaign */
+    activation_condition_list?: DataEvaluationCondition[];
+    /** evaluated statements for deactivating campaign */
+    deactivation_condition_list?: DataEvaluationCondition[];
+    /** all activation criteria satisfied (stored for debugging)*/
+    _activated?: boolean; //
+    /** any deactivation criteria satisfied (stored for debugging)*/
+    _deactivated?: boolean;
+    /** all activation criteria satisfied and not any deactivation criteria satisfied */
+    _active?: boolean;
   }
 
   export interface Habit_ideas extends FlowTypeWithData {

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -205,12 +205,18 @@ export namespace FlowTypes {
   }
   export interface Campaign_Schedule extends RowWithActivationConditions {
     id: string;
-    /** specified time for notification, e.g. 19:30. Day indicates day of week, starting with 1 = monday */
-    time?: { minute?: string; hour?: string; day?: number };
+    /** specified time for notification, e.g. 19:30 */
+    time?: { minute?: string; hour?: string };
     /** delay until first notification, e.g. 7 day */
     delay?: { days?: string; hours?: string; minutes?: string };
-    /** fixed dates for start and end of schedule */
-    schedule?: { start_date?: string; end_date?: string };
+    schedule?: {
+      /** fixed dates for start of schedule */
+      start_date?: string;
+      /** fixed dates for end of schedule */
+      end_date?: string;
+      /** weekday number to schedule from (1-Monday, 7-Sunday etc.) */
+      day_of_week?: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+    };
     /** computed list of campaign rows merged into campaign */
     _campaign_rows?: Campaign_listRow[];
     /** computed date for next notification as required by scheduling service */

--- a/packages/scripts/src/app-data-convert/parsers/default/default.parser.ts
+++ b/packages/scripts/src/app-data-convert/parsers/default/default.parser.ts
@@ -7,6 +7,7 @@ import {
   parseAppDataListString,
   parseAppDataCollectionString,
   parseAppDataActionString,
+  parseAppDateValue,
 } from "../../utils";
 import { SCRIPTS_WORKSPACE_PATH } from "../../../paths";
 import { getActiveDeployment } from "../../../deployments";
@@ -124,6 +125,12 @@ export class DefaultParser implements AbstractParser {
         row[field] = row[field]
           .map((actionString) => parseAppDataActionString(actionString))
           .filter((action) => action != null);
+      }
+      // convert google/excel number dates to dates (https://stackoverflow.com/questions/16229494/converting-excel-date-serial-number-to-date-using-javascript)
+      if (field.endsWith("_date")) {
+        if (typeof row[field] === "number") {
+          row[field] = parseAppDateValue(row[field]);
+        }
       }
       // assign default translation and track as metadata
       if (isTranslateField) {

--- a/packages/scripts/src/app-data-convert/utils/app-data-string.utils.ts
+++ b/packages/scripts/src/app-data-convert/utils/app-data-string.utils.ts
@@ -79,11 +79,15 @@ export function parseAppDataCollectionString(str: string): { [key: string]: stri
 
 /**
  * When excel sheets store dates the store a datevalue as number of days since 1900 (or sometimes 1904!)
- * Convert to corresponding iso date string (e.g. 2021-11-24T18:03:36.002Z)
+ * Convert to corresponding iso date string (e.g. 2021-11-24T18:03:36.002Z) and then leave as a local date string
+ * (without the Z UTC timezone suffix (zero UTC offset) so that it can be used relative to user's own timezone)
  * https://stackoverflow.com/questions/16229494/converting-excel-date-serial-number-to-date-using-javascript
  */
 export function parseAppDateValue(dateValue: number) {
-  return new Date(Date.UTC(0, 0, dateValue - 1)).toISOString();
+  const isoString = new Date(Date.UTC(0, 0, dateValue - 1)).toISOString();
+  // remove zero-utc timezone suffix
+  const localDateString = isoString.slice(0, -1);
+  return localDateString;
 }
 
 /** Convert a deeply nested json object to a flat json object (with nested key references) */

--- a/packages/scripts/src/app-data-convert/utils/app-data-string.utils.ts
+++ b/packages/scripts/src/app-data-convert/utils/app-data-string.utils.ts
@@ -77,6 +77,15 @@ export function parseAppDataCollectionString(str: string): { [key: string]: stri
   return collection;
 }
 
+/**
+ * When excel sheets store dates the store a datevalue as number of days since 1900 (or sometimes 1904!)
+ * Convert to corresponding iso date string (e.g. 2021-11-24T18:03:36.002Z)
+ * https://stackoverflow.com/questions/16229494/converting-excel-date-serial-number-to-date-using-javascript
+ */
+export function parseAppDateValue(dateValue: number) {
+  return new Date(Date.UTC(0, 0, dateValue - 1)).toISOString();
+}
+
 /** Convert a deeply nested json object to a flat json object (with nested key references) */
 export function flattenJson<T>(json: any, tree = {}, nestedPath?: string): { [key: string]: T } {
   Object.entries<T>(json).forEach(([key, value]) => {

--- a/src/app/feature/campaign/campaign.module.ts
+++ b/src/app/feature/campaign/campaign.module.ts
@@ -9,6 +9,7 @@ import { SharedPipesModule } from "src/app/shared/pipes";
 import { CampaignDebugVariablesEditorComponent } from "./pages/campaign-debug/components/campaign-variables-editor";
 import { CampaignDebugRowComponent } from "./pages/campaign-debug/components/campaign-debug-row";
 import { CalcDaysDiffPipe } from "./pages/campaign-debug/components/calcDays.pipe";
+import { CampaignScheduleDebugRowComponent } from "./pages/campaign-debug/components/campaign-schedule-debug-row";
 
 @NgModule({
   imports: [CommonModule, FormsModule, IonicModule, CampaignPageRoutingModule, SharedPipesModule],
@@ -16,6 +17,7 @@ import { CalcDaysDiffPipe } from "./pages/campaign-debug/components/calcDays.pip
     CampaignDebugPage,
     CampaignDebugVariablesEditorComponent,
     CampaignDebugRowComponent,
+    CampaignScheduleDebugRowComponent,
     CalcDaysDiffPipe,
   ],
 })

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.html
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.html
@@ -1,5 +1,24 @@
 <ion-content class="ion-padding">
   <div style="display: flex; align-items: center">
+    <h2 style="flex: 1">Scheduled Campaigns</h2>
+    <ion-item class="clear">
+      <ion-label>Debug Notifications</ion-label>
+      <ion-toggle
+        #debugOptIn
+        [checked]="debugCampaignsEnabled"
+        (ionChange)="setDebugCampaignOptIn(debugOptIn.checked)"
+      ></ion-toggle>
+    </ion-item>
+  </div>
+
+  <ion-list>
+    <campaign-schedule-debug-row
+      *ngFor="let schedule of campaignService.scheduledCampaigns | objectValues"
+      [row]="schedule"
+    ></campaign-schedule-debug-row>
+  </ion-list>
+
+  <div style="display: flex; align-items: center">
     <h2 style="flex: 1">Campaign Debug</h2>
     <ion-button
       fill="outline"
@@ -18,7 +37,7 @@
       [value]="debugCampaignId"
     >
       <ion-select-option
-        *ngFor="let campaign_id of campaignService.campaigns | objectKeys | arraySort"
+        *ngFor="let campaign_id of campaignService.allCampaigns | objectKeys | arraySort"
       >
         <span>{{campaign_id}}</span>
       </ion-select-option>

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.html
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.html
@@ -9,6 +9,14 @@
         (ionChange)="setDebugCampaignOptIn(debugOptIn.checked)"
       ></ion-toggle>
     </ion-item>
+    <ion-button
+      fill="outline"
+      [routerLink]="['/','notifications']"
+      [disabled]="(localNotificationService.pendingNotifications$ | async).length===0"
+    >
+      <ion-icon name="notifications" slot="start"></ion-icon>
+      <span>{{(localNotificationService.pendingNotifications$ | async).length}}</span>
+    </ion-button>
   </div>
 
   <ion-list>
@@ -19,15 +27,7 @@
   </ion-list>
 
   <div style="display: flex; align-items: center">
-    <h2 style="flex: 1">Campaign Debug</h2>
-    <ion-button
-      fill="outline"
-      [routerLink]="['/','notifications']"
-      [disabled]="(localNotificationService.pendingNotifications$ | async).length===0"
-    >
-      <ion-icon name="notifications" slot="start"></ion-icon>
-      <span>{{(localNotificationService.pendingNotifications$ | async).length}}</span>
-    </ion-button>
+    <h2 style="flex: 1">All Campaigns</h2>
   </div>
   <ion-item>
     <ion-label>Campaign</ion-label>

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.scss
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.scss
@@ -17,3 +17,6 @@ ion-list {
 ion-item {
   --background: white;
 }
+ion-item.clear {
+  --background: unset;
+}

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
@@ -1,12 +1,23 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { FlowTypes } from "src/app/shared/model";
+import { CampaignService } from "../../../campaign.service";
 
 @Component({
   selector: "campaign-schedule-debug-row",
   template: ` <ion-item>
     <details style="width:100%">
       <summary class="row-header">
-        <span style="flex:1">{{ row.id }}</span>
+        <span class="row-counter">{{ row._campaign_rows.length }}</span>
+        <span style="flex:1; margin-left:10px">{{ row.id }}</span>
+        <!-- TODO - could be calculated in parent and passed down -->
+        <ion-button
+          fill="clear"
+          style="margin-right:5px"
+          *ngIf="(campaignService.scheduledNotifications[row.id] | objectValues).length > 0"
+        >
+          <ion-icon name="notifications" slot="start"></ion-icon>
+          {{ (campaignService.scheduledNotifications[row.id] | objectValues).length }}
+        </ion-button>
         <span class="tag activated" *ngIf="row._active">Active</span>
         <span class="tag deactivated" *ngIf="!row._active">Inactive</span>
       </summary>
@@ -78,6 +89,14 @@ import { FlowTypes } from "src/app/shared/model";
         padding: 16px;
         width: 100%;
         background: white;
+        align-items: center;
+      }
+      .row-counter {
+        min-width: 28px;
+        text-align: center;
+        border-radius: 8px;
+        border: 1px solid #787878;
+        padding: 2px;
       }
       ion-item {
         --background: white;
@@ -124,7 +143,7 @@ export class CampaignScheduleDebugRowComponent implements OnInit {
   @Output() manageVariablesClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
   @Output() triggerActionsClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
   @Output() scheduleNotificationClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
-  constructor() {}
+  constructor(public campaignService: CampaignService) {}
 
   ngOnInit() {}
 

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
@@ -10,14 +10,17 @@ import { CampaignService } from "../../../campaign.service";
         <span class="row-counter">{{ row._campaign_rows.length }}</span>
         <span style="flex:1; margin-left:10px">{{ row.id }}</span>
         <!-- TODO - could be calculated in parent and passed down -->
-        <ion-button
-          fill="clear"
-          style="margin-right:5px"
-          *ngIf="(campaignService.scheduledNotifications[row.id] | objectValues).length > 0"
+        <div
+          *ngIf="
+            campaignService.scheduledNotifications[row.id] | objectValues as scheduledNotifications
+          "
         >
-          <ion-icon name="notifications" slot="start"></ion-icon>
-          {{ (campaignService.scheduledNotifications[row.id] | objectValues).length }}
-        </ion-button>
+          <span class="next-notification" *ngIf="scheduledNotifications[0] as nextNotification">
+            {{ nextNotification.schedule.at | date: "MMM d h:mm a" }}
+            <ion-icon name="notifications"></ion-icon>
+          </span>
+        </div>
+
         <span class="tag activated" *ngIf="row._active">Active</span>
         <span class="tag deactivated" *ngIf="!row._active">Inactive</span>
       </summary>
@@ -83,6 +86,11 @@ import { CampaignService } from "../../../campaign.service";
       }
       .tag.deactivated {
         background: hsl(0 100% 65%);
+      }
+      .next-notification {
+        margin-right: 10px;
+        font-size: smaller;
+        color: #03598f;
       }
       .row-header {
         display: flex;

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
@@ -1,0 +1,136 @@
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { FlowTypes } from "src/app/shared/model";
+
+@Component({
+  selector: "campaign-schedule-debug-row",
+  template: ` <ion-item>
+    <details style="width:100%">
+      <summary class="row-header">
+        <span style="flex:1">{{ row.id }}</span>
+        <span class="tag activated" *ngIf="row._active">Active</span>
+        <span class="tag deactivated" *ngIf="!row._active">Inactive</span>
+      </summary>
+      <div class="row-content">
+        <!-- Info -->
+        <div style="flex:1">
+          <div style="flex:1">
+            <!-- Activation -->
+            <div *ngIf="row.activation_condition_list && row.activation_condition_list.length > 0">
+              <div class="divider"></div>
+              <h4>Activation</h4>
+              <div
+                *ngFor="let condition of row.activation_condition_list"
+                class="condition-row info-text"
+                (click)="manageVariablesClicked.next(row)"
+              >
+                <ion-checkbox [checked]="condition._satisfied" disabled></ion-checkbox>
+                <span class="condition">{{ condition._raw }}</span>
+              </div>
+            </div>
+            <!-- Deactivation -->
+            <div
+              *ngIf="row.deactivation_condition_list && row.deactivation_condition_list.length > 0"
+            >
+              <div class="divider"></div>
+              <h4>Deactivation</h4>
+              <div
+                *ngFor="let condition of row.deactivation_condition_list"
+                class="condition-row info-text"
+                (click)="manageVariablesClicked.next(row)"
+              >
+                <ion-checkbox [checked]="condition._satisfied" disabled></ion-checkbox>
+                <span class="condition">{{ condition._raw }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Actions -->
+      <ion-button
+        expand="block"
+        fill="clear"
+        (click)="logDebugInfo(row)"
+        class="action-button no-padding"
+      >
+        <ion-icon slot="start" name="information-circle-outline"></ion-icon>
+        Log Full Info
+      </ion-button>
+    </details>
+  </ion-item>`,
+  styles: [
+    `
+      .tag {
+        padding: 4px;
+        color: white;
+        border-radius: 5px;
+        font-size: smaller;
+        text-align: center;
+        font-weight: normal;
+      }
+      .tag.activated {
+        background: hsl(130 40% 55%);
+      }
+      .tag.deactivated {
+        background: hsl(0 100% 65%);
+      }
+      .row-header {
+        display: flex;
+        padding: 16px;
+        width: 100%;
+        background: white;
+      }
+      ion-item {
+        --background: white;
+        --padding-start: 0;
+        --padding-end: 0;
+        --inner-padding-end: 0;
+      }
+      .divider {
+        height: 1em;
+      }
+      summary {
+        list-style: none;
+      }
+      summary::-webkit-details-marker {
+        display: none;
+      }
+      .row-content {
+        padding: 0px 16px 16px 16px;
+        margin-top: -16px;
+        display: flex;
+      }
+      .condition-row {
+        display: flex;
+        align-items: center;
+      }
+      .condition {
+        margin-left: 8px;
+      }
+      h4 {
+        margin-top: 8px;
+        font-size: 16px;
+      }
+      ion-checkbox {
+        margin: 0;
+      }
+      .info-text {
+        font-size: small;
+      }
+    `,
+  ],
+})
+export class CampaignScheduleDebugRowComponent implements OnInit {
+  @Input() row: FlowTypes.Campaign_Schedule;
+  @Output() manageVariablesClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
+  @Output() triggerActionsClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
+  @Output() scheduleNotificationClicked = new EventEmitter<FlowTypes.Campaign_Schedule>();
+  constructor() {}
+
+  ngOnInit() {}
+
+  public logDebugInfo(row: FlowTypes.Campaign_Schedule) {
+    console.group(row.id);
+    console.log(row);
+    console.groupEnd();
+  }
+}

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -83,7 +83,7 @@ export function mergeObjectArrays<T>(
   return Object.values(secondaryHash);
 }
 
-export function randomElementFromArray(arr: any[] = null) {
+export function randomElementFromArray<T>(arr: T[] = null) {
   try {
     const randomItem = arr[Math.floor(Math.random() * arr.length)];
     return randomItem;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
General improvements and refactoring to notifications system to separate out scheduling of campaigns from the main campaign rows. Specifically:

- Create `campaign_schedule` datalist subtype for storing scheduling info
- Add support for schedule-level activation/deactivation, fixed start/end dates, notification day of week and time
- Add contact field and debug toggle for opting in to debug notifications
- Remove support for inline scheduling information (may be added back in future as a means to override defaults)
- Improve campaign debug page
- Update example templates

## For Authors
- All the examples currently sit in [debug_campaigns](https://docs.google.com/spreadsheets/d/1Jf38D4pkoBO0QIUcw1IFAqlEokrUzhOESi3hNlW0vZM/edit#gid=1682205958). The schedule list has been marked as `draft` to avoid breaking type changes, but should be changed to `released` when testing branch locally and after merge

- There are still 2 non-debug schedules in the debug sheet (`inactive_week` and `inactive_month`). These could possibly be moved elsewhere. I've also disabled `inactive_day` as I think this might be temperamental (not tested properly)
There are also multiple additional sheets currently marked as draft which I think may no longer be relevant, but we may wish to review in case there's any useful bits of code in them to add to examples

- Start_date and end_date can be used to constrain date ranges that schedules will run. These should be stored in a date format in the sheets. By default excel might display in US format (mm/dd/yyyy), this can be changed from the sheet under `file -> settings -> locale`

- Custom conversion is required for the `start_date` and `end_date` columns. These are applied in the default parser for any column ending `_date`, so ideally no future sheets should use this convention (fine for field names etc., just not for entire column)

- Schedule.day_of_week can be used to specify a fixed day of the week (1-per-week). If left blank notifications will be scheduled for the next specified time (either same day or next day) at the time of scheduling (e.g. app open or after 15 min app refresh). There is currently no way to schedule other than once-per-day or once-per-week within the same schedule.

- All date and times will be relative to a user's own timezone. There is currently no supported way to send a notification at a universally fixed time.



## For Devs
- `start_date` and `end_date` are stored in google sheets via date format. When this is synced to the app it's converted into a datevalue (e.g. `40128`) which represents the number of days since January 1900. A script has been added to automatically convert this and any other columns ending `_date`, however one minor caveat is that if planning to support conversion directly from excel (i.e. not google sheets -> excel), excel on mac formats these differently as number of days since January 1904 (so could cause future potential issue).

- An extra `hack` function has been added which removes all existing notifications before rescheduling current. This is to allow clearing out of any notifications that may have been set under a different system (e.g. previous version with different campaign names). A better solution could be found for handling this in the future


## TODO (future dev)
- Debugger page is a bit messy, ideally more information should be inlined into each schedule dropdown instead of loading from notifications/bottom of page

- Add support for scheduling in batch so that multiple notifications for a campaign can be scheduled without need for reinitialisation in the app.

- Add support for more advanced scheduling options such as selecting from list at random, allow/avoid reschedule of same notification if sent (global option instead of relying on `notification_id.sent` fields), max_notifications to send in a single campaign etc.

- Efficiency improvements for scheduling/rescheduling processes

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/143499035-e6e99a0d-02a3-4db7-8239-53fa3546b5a0.mp4

[debug_campaign_schedules](https://docs.google.com/spreadsheets/d/1Jf38D4pkoBO0QIUcw1IFAqlEokrUzhOESi3hNlW0vZM/edit#gid=998700467)

[debug_campaign_rows]
![image](https://user-images.githubusercontent.com/10515065/143499009-da77e294-b18c-4592-9c33-50213704da0f.png)

![image](https://user-images.githubusercontent.com/10515065/143498990-7b7f7574-246e-4004-aaec-24f393b387e6.png)

