### PR TITLE
Feat/notification fixes

### DIFF
--- a/.idems_app/.gitignore
+++ b/.idems_app/.gitignore
@@ -1,0 +1,3 @@
+deployments/**/*.*
+!deployments/example/config.ts
+!deployments/plh/config.ts

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -36,7 +36,13 @@ export const APP_FIELDS = {
  * Some specific strings are currently hardcoded into the app
  * TODO - not all strings included, should add to when required
  */
-export const APP_STRINGS = {
-  NOTIFICATION_DEFAULT_TITLE: "Notification",
-  NOTIFICATION_DEFAULT_TEXT: "You have a new message from PLH",
+export const APP_STRINGS = {};
+
+export const NOTIFICATION_DEFAULTS = {
+  title: "Notification",
+  text: "You have a new message from PLH",
+  time: {
+    hour: 12,
+    minute: 0,
+  },
 };

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -206,7 +206,7 @@ export namespace FlowTypes {
   export interface Campaign_Schedule extends RowWithActivationConditions {
     id: string;
     /** specified time for notification, e.g. 19:30 */
-    time?: { minute?: string; hour?: string };
+    time?: { minute: number; hour: number };
     /** delay until first notification, e.g. 7 day */
     delay?: { days?: string; hours?: string; minutes?: string };
     schedule?: {

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { addDays } from "@fullcalendar/angular";
 import { addHours, addMinutes, isBefore, setISODay } from "date-fns";
-import { APP_STRINGS } from "packages/data-models/constants";
+import { NOTIFICATION_DEFAULTS } from "packages/data-models/constants";
 import { Subscription } from "rxjs";
 import { TemplateTranslateService } from "src/app/shared/components/template/services/template-translate.service";
 import { TemplateService } from "src/app/shared/components/template/services/template.service";
@@ -177,8 +177,8 @@ export class CampaignService {
     let { title, text } = row;
     let { _schedule_at } = notification_schedule;
 
-    title = this.translateService.translateValue(title || APP_STRINGS.NOTIFICATION_DEFAULT_TITLE);
-    text = this.translateService.translateValue(text || APP_STRINGS.NOTIFICATION_DEFAULT_TEXT);
+    title = this.translateService.translateValue(title || NOTIFICATION_DEFAULTS.title);
+    text = this.translateService.translateValue(text || NOTIFICATION_DEFAULTS.text);
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
       body: text,
@@ -306,6 +306,8 @@ export class CampaignService {
   }
 
   private evaluateCampaignNotification(scheduleRow: FlowTypes.Campaign_Schedule) {
+    // apply default settings
+    scheduleRow.time = scheduleRow.time || NOTIFICATION_DEFAULTS.time;
     const { time, delay } = scheduleRow;
     const schedule: FlowTypes.Campaign_Schedule["schedule"] = scheduleRow.schedule || {};
     // set a base date from today or schedule start (if provided)

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -6,7 +6,7 @@ import {
   ActionType,
 } from "@capacitor/local-notifications";
 import { addSeconds } from "date-fns";
-import { APP_STRINGS } from "packages/data-models/constants";
+import { NOTIFICATION_DEFAULTS } from "packages/data-models/constants";
 import { BehaviorSubject } from "rxjs";
 import { generateTimestamp } from "../../utils";
 import { DbService } from "../db/db.service";
@@ -160,7 +160,7 @@ export class LocalNotificationService {
   public async scheduleNotification(options: ILocalNotification, reloadNotifications = true) {
     if (!this.permissionGranted) return;
     options.extra = { ...options.extra };
-    const notifications = [{ ...NOTIFICATION_DEFAULTS, ...options }];
+    const notifications = [{ ...LOCAL_NOTIFICATION_DEFAULTS, ...options }];
     await LocalNotifications.schedule({ notifications });
     // ensure extra field populated (TODO - could make stronger requirement elsewhere)
     options.extra = { ...options.extra };
@@ -319,10 +319,10 @@ const NOTIFICATION_ACTIONS: {
 /**
  * Default settings used where otherwise not specified
  */
-const NOTIFICATION_DEFAULTS: LocalNotificationSchema = {
+const LOCAL_NOTIFICATION_DEFAULTS: LocalNotificationSchema = {
   id: new Date().getUTCMilliseconds(),
-  title: APP_STRINGS.NOTIFICATION_DEFAULT_TITLE,
-  body: APP_STRINGS.NOTIFICATION_DEFAULT_TEXT,
+  title: NOTIFICATION_DEFAULTS.title,
+  body: NOTIFICATION_DEFAULTS.text,
   sound: null,
   attachments: null,
   // actionTypeId: "action_1", // Currently no action buttons included

--- a/src/app/shared/services/tour/tour.service.ts
+++ b/src/app/shared/services/tour/tour.service.ts
@@ -141,7 +141,7 @@ export class TourService {
       //   const src = i.match(imgSrcExp);
       //   const finallySrc = i.replace(
       //     src,
-      //     `src="/assets/plh_assets/${src[0]
+      //     `src="${src[0]
       //       .split("=")[1]
       //       .split("")
       //       .filter((v) => v !== '"')


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add default time (see screenshot below - can be changed by authors if required)
- Add `debug_december_early` example (6am notifications) to test if schedule correctly for next day
- Fix scheduling so that if schedule time already passed for the day (or week if day_of_week provided) selects next day (or week)

## Git Issues

Closes #1101

## Screenshots/Videos

- No time notification now triggers at 12pm
- Early notification now schedules for next day (time already passed for today)

![image](https://user-images.githubusercontent.com/10515065/144482067-fbff7b90-eb78-4267-ab82-411002c48025.png)

Updated notification defaults (can be modified from `packages\data-models\constants.ts`
![image](https://user-images.githubusercontent.com/10515065/144482398-8fb5ada5-de73-4a4b-8fd5-d7b363f330dc.png)


