### PR TITLE
Fix type inference issues for translation_strings

### DIFF
--- a/packages/scripts/src/app-data-copy.ts
+++ b/packages/scripts/src/app-data-copy.ts
@@ -85,7 +85,10 @@ function writeTranslationTsFiles(sourceFolder: string, targetFolder: string) {
   );
   convertJsonToTs(sourceFiles, {
     outputDir: targetFolder,
-    indexFile: { namedExport: "TRANSLATION_STRINGS" },
+    defaultExportType: "{[source_text:string]:string}",
+    indexFile: {
+      namedExport: "TRANSLATION_STRINGS",
+    },
   });
 }
 

--- a/packages/scripts/src/utils/file-utils.ts
+++ b/packages/scripts/src/utils/file-utils.ts
@@ -223,19 +223,26 @@ export function encryptFolder(
 }
 
 /**
- * WiP function to simplify process of converting .json files to .ts, with addtional export
+ * Function to simplify process of converting .json files to .ts, with addtional export
  * and index file options
  */
 export function convertJsonToTs(
   filepaths: string[],
   config: {
-    indexFile?: { namedExport?: string };
-    exportDataType?: string;
+    indexFile?: {
+      /** Provide a specific const name for index file to export as, e.g. export const index = [...] */
+      namedExport?: string;
+      /** Specify type definition for individual files, e.g. `string[] => export const index:string[] = [...] */
+      namedExportType?: string;
+    };
+    /** Specify type definition for individual files, e.g. `any` => export const data:any = [...] */
+    defaultExportType?: string;
     outputDir?: string;
-    importStatements?: string[];
+    /** TODO */
+    _wip_importStatements?: string[];
   }
 ) {
-  let { exportDataType, indexFile, importStatements, outputDir } = config;
+  let { defaultExportType, indexFile, _wip_importStatements, outputDir } = config;
   if (outputDir) {
     fs.ensureDirSync(outputDir);
     fs.emptyDirSync(outputDir);
@@ -248,7 +255,12 @@ export function convertJsonToTs(
     outputDir = outputDir || path.dirname(filepath);
     const filename = path.basename(filepath).replace(".json", ".ts");
     const jsonData = fs.readJSONSync(filepath);
-    const tsData = `export default ${JSON.stringify(jsonData, null, 2)}`;
+    let defaultExportName = "data";
+    if (defaultExportType) {
+      defaultExportName += `:${defaultExportType}`;
+    }
+    const defaultExportData = JSON.stringify(jsonData, null, 2);
+    const tsData = `const ${defaultExportName} = ${defaultExportData}; export default data`;
     fs.writeFileSync(path.resolve(outputDir, filename), tsData);
     if (indexFilePath) {
       const importName = path.basename(filename, ".ts");
@@ -262,6 +274,10 @@ export function convertJsonToTs(
   // Create single export, e.g. ```export const NAMED_EXPORT = {import_1,import_2}```
   if (indexFilePath && indexFile.namedExport) {
     const namedExports = filepaths.map((filepath) => path.basename(filepath, ".json")).join(",");
-    fs.appendFileSync(indexFilePath, `export const ${indexFile.namedExport} = { ${namedExports} }`);
+    let exportName = indexFile.namedExport;
+    if (indexFile.namedExportType) {
+      exportName += `:${indexFile.namedExportType}`;
+    }
+    fs.appendFileSync(indexFilePath, `export const ${exportName} = { ${namedExports} }`);
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

_What this PR does_

## Git Issues

Closes #

## Screenshots/Videos
Scripts now automatically assign a hardcoded type definition for translation strings, to prevent the compiler having to infer
![image](https://user-images.githubusercontent.com/10515065/144488986-5c17c7f4-46f4-4dc4-8506-d2045725916c.png)

Add the index-file level this results in a much simpler inference (it still infers the available language codes, but the individual file types are inherited)
![image](https://user-images.githubusercontent.com/10515065/144488949-21d88fe6-53dc-4d20-aff0-851fe2946f8e.png)

