### PR TITLE
update app data assets path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -34,7 +34,7 @@
               {
                 "glob": "**/*",
                 "input": "node_modules/app-data/assets",
-                "output": "assets/_app_data_assets"
+                "output": "assets/app_data_assets"
               },
               {
                 "glob": "**/*.svg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": "IDEMS International",
   "homepage": "https://idems.international/",
   "description": "",

--- a/src/app/shared/components/template/services/template-asset.service.ts
+++ b/src/app/shared/components/template/services/template-asset.service.ts
@@ -3,7 +3,7 @@ import { ASSETS_CONTENTS_LIST } from "app-data";
 import { TemplateTranslateService } from "./template-translate.service";
 
 /** Synced assets are automatically copied during build to asset subfolder */
-const ASSETS_BASE = `assets/_app_data_assets`;
+const ASSETS_BASE = `assets/app_data_assets`;
 
 /** Expected folder containing global assets (TODO - merge with scripts) */
 const ASSETS_GLOBAL_FOLDER_NAME = "global";

--- a/src/assets/_app_assets/README.md
+++ b/src/assets/_app_assets/README.md
@@ -6,7 +6,7 @@ Example `angular.json` config snippet
 {
     "glob": "**/*",
     "input": "node_modules/app-data/assets",
-    "output": "assets/_app_data_assets"
+    "output": "assets/app_data_assets"
 },
 ```
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Fix issue where app assets are not shown on device. Culprit appears to be android/capacitor unhappy with asset paths starting with underscore prefixes.

Linked issue, was supposedly fixed in Capacitor v3 (which we are running) but perhaps was not: `https://github.com/ionic-team/capacitor/commit/c23d99315acea2f0894e5ff8a08dd42a867b2982`

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
