### PR TITLE
Fix/dl script rate limit error

### DIFF
--- a/packages/scripts/src/commands/app-data/download.ts
+++ b/packages/scripts/src/commands/app-data/download.ts
@@ -79,14 +79,22 @@ async function appDataDownload(options: IProgramOptions) {
   const sheetsDLCmd = `${gdriveToolsExec} download ${commonArgs} ${sheetsArgs}`;
   console.log(chalk.yellow("-----Sheets-----"));
   console.log(chalk.gray(sheetsDLCmd));
-  spawnSync(sheetsDLCmd, { shell: true, stdio: "inherit" });
+  const { status: sheetsDlStatus } = spawnSync(sheetsDLCmd, { shell: true, stdio: "inherit" });
+  // pass any null exit code back up
+  if (sheetsDlStatus === 1) {
+    process.exit(1);
+  }
 
   // download assets
   const assetsArgs = `--folder-id ${assets_folder_id} --output-path "${assetsOutput}" --cache-path "${assetsCachePath}" --log-name assets.log --filter-function-64 "${assetsFilter}"`;
   const assetsDLCmd = `${gdriveToolsExec} download ${commonArgs} ${assetsArgs}`;
   console.log(chalk.yellow("-----Assets-----"));
   console.log(chalk.gray(assetsDLCmd));
-  spawnSync(assetsDLCmd, { shell: true, stdio: "inherit" });
+  const { status: assetDlStatus } = spawnSync(assetsDLCmd, { shell: true, stdio: "inherit" });
+  // pass any null exit code back up
+  if (assetDlStatus === 1) {
+    process.exit(1);
+  }
 }
 
 /**

--- a/packages/scripts/src/commands/app-data/sync.ts
+++ b/packages/scripts/src/commands/app-data/sync.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawnSync } from "child_process";
+import { execSync, spawn, spawnSync } from "child_process";
 import { Command } from "commander";
 import fs from "fs-extra";
 import { getActiveDeployment } from "../deployment/get";
@@ -41,7 +41,14 @@ async function syncAppData(options: IProgramOptions) {
   if (options.clean) {
     cleanFolders();
   }
-  spawnSync(`${scriptsExec} ${downloadCmd}`, { stdio: "inherit", shell: true });
+  const { status } = spawnSync(`${scriptsExec} ${downloadCmd}`, {
+    stdio: "inherit",
+    shell: true,
+  });
+  if (status === 1) {
+    process.exit(1);
+  }
+
   // Convert
   let convertCmd = "app-data convert";
   spawnSync(`${scriptsExec} ${convertCmd}`, { stdio: "inherit", shell: true });

--- a/packages/scripts/src/commands/index.ts
+++ b/packages/scripts/src/commands/index.ts
@@ -16,6 +16,7 @@ program.version("1.0.0").description("IDEMS App Scripts");
 // Handle legacy command renames so can still run `npm run scripts gdrive-download`
 const legacyCommandMappings = {
   "gdrive-download": ["app-data", "download"],
+  "gdrive-auth": ["app-data", "download", "--authorize"],
   "decrypt-config": ["config", "decrypt"],
   "encrypt-config": ["config", "encrypt"],
   "sync-plh-content": ["app-data", "sync"],


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Sync scripts seemed to fail from time to time due to an unknown `forbidden` reason. Additional logging was added to track down more information about the error, and to prevent continued processing of scripts when sync failed.

The root cause of the issue appears to be api limits imposed by google apis. Despite a quick search to try and identify the issue it remains a bug (I checked the google drive api quotas page for the plh project which is linked to the downloader, but could see nothing oviously wrong. Additionally the sync typically worked again after waiting a few minutes, instead of waiting for a full daily reset which happens at midnight) 

## Update - 2021-12-15
Root cause identified, the max-requests-per-100s limit was in fact being hit (despite not being reported correctly in google quotas console). I've added a rate-limiter to the download request to try and cap downloads at 20 per second (to keep within google's project quota of 2000 requests per 100s overall limit). 

Fixed code included in this PR

## Git Issues

Closes #

## Screenshots/Videos
**Improved logs links to full error and prevents further processing**
![image](https://user-images.githubusercontent.com/10515065/146098978-44d3e634-f55b-438e-a0e2-1a6335a50c36.png)

**Following the link provides clearer error message**
![image](https://user-images.githubusercontent.com/10515065/146099456-b359cb9a-be65-469d-8a95-0cd1b1bcb61e.png)

**Google API Quotas** - appear well within limits although there might be other quotas elsewhere related to the owner of the gdrive content
![image](https://user-images.githubusercontent.com/10515065/146099213-1fc10d11-d435-4a50-9dbd-3303440fde20.png)


