### PR TITLE
fix notification permissions

### DIFF
--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -73,13 +73,24 @@ export class LocalNotificationService {
   }
 
   public async requestPermission(): Promise<boolean> {
-    if ("Notification" in window) {
-      const { display } = await LocalNotifications.requestPermissions();
-      return display === "granted";
-    } else {
-      console.log("notifications not supported");
-      return false;
+    // If running in browser first check to ensure notification api exists
+    if (!Capacitor.isNativePlatform()) {
+      if (!window.Notification) {
+        console.log("[Notifications Unsupported]");
+        return false;
+      }
     }
+    // Use notifications api to check permissions. Run in parallel with a 5-second
+    // timeout to resolve in cases where prompt does not appear or user fails to interact with it
+    const granted = await Promise.race([
+      new Promise<boolean>((resolve) => setTimeout(resolve, 5000, false)),
+      new Promise<boolean>(async (resolve) => {
+        const { display } = await LocalNotifications.requestPermissions();
+        resolve(display === "granted");
+      }),
+    ]);
+    console.log("[Notifications Enabled]", granted);
+    return granted;
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Fix bug where notifications would not request permission on android due to irrelevant browser check failure
- Fix bug where app would not load on web if user fails to interact with notification enable prompt

## Git Issues

Closes #

## Screenshots/Videos

**Notifications now show as scheduled from the Notifications page**
![image](https://user-images.githubusercontent.com/10515065/146530936-e47d7585-bef2-4154-971a-5df56d6b2b8b.png)

