### PR TITLE
Feat/notification reschedule

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -49,6 +49,12 @@ export const NOTIFICATION_DEFAULTS = {
   },
 };
 
+/** How often to attempt to re-evaluate scheduled notifications - currently every minutes */
+export const NOTIFICATIONS_SYNC_FREQUENCY_MS = 1000 * 60 * 3;
+
+/** How often to attempt sync - currently every 15mins */
+export const SERVER_SYNC_FREQUENCY = 1000 * 60 * 15;
+
 export const APP_ROUTE_DEFAULTS = {
   /** Default redirect form landing '/' route */
   home_path: "/template/home_screen",

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -53,7 +53,7 @@ export const NOTIFICATION_DEFAULTS = {
 export const NOTIFICATIONS_SYNC_FREQUENCY_MS = 1000 * 60 * 3;
 
 /** How often to attempt sync - currently every 15mins */
-export const SERVER_SYNC_FREQUENCY_MS = 1000 * 60 * 15;
+export const SERVER_SYNC_FREQUENCY_MS = 1000 * 60 * 5;
 
 export const APP_ROUTE_DEFAULTS = {
   /** Default redirect form landing '/' route */

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -53,7 +53,7 @@ export const NOTIFICATION_DEFAULTS = {
 export const NOTIFICATIONS_SYNC_FREQUENCY_MS = 1000 * 60 * 3;
 
 /** How often to attempt sync - currently every 15mins */
-export const SERVER_SYNC_FREQUENCY = 1000 * 60 * 15;
+export const SERVER_SYNC_FREQUENCY_MS = 1000 * 60 * 15;
 
 export const APP_ROUTE_DEFAULTS = {
   /** Default redirect form landing '/' route */

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -3,7 +3,7 @@ export {
   FIELD_PREFIX,
   DYNAMIC_PREFIXES,
   APP_STRINGS,
-  SERVER_SYNC_FREQUENCY,
+  SERVER_SYNC_FREQUENCY_MS,
   NOTIFICATIONS_SYNC_FREQUENCY_MS,
 } from "./constants";
 export * from "./flowTypes";

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -1,4 +1,11 @@
-export { APP_FIELDS, FIELD_PREFIX, DYNAMIC_PREFIXES, APP_STRINGS } from "./constants";
+export {
+  APP_FIELDS,
+  FIELD_PREFIX,
+  DYNAMIC_PREFIXES,
+  APP_STRINGS,
+  SERVER_SYNC_FREQUENCY,
+  NOTIFICATIONS_SYNC_FREQUENCY_MS,
+} from "./constants";
 export * from "./flowTypes";
 export * from "./tips.model";
 export * from "./functions";

--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -1,14 +1,11 @@
 import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { DeviceInfo, Device } from "@capacitor/device";
-import { APP_FIELDS } from "data-models";
+import { APP_FIELDS, SERVER_SYNC_FREQUENCY } from "data-models";
 import { interval } from "rxjs";
 import { throwError } from "rxjs";
 import { environment } from "src/environments/environment";
 import { generateTimestamp } from "../../utils";
-
-/** How often to attempt sync - currently every 15mins */
-const SYNC_FREQUENCY_MS = 1000 * 60 * 15;
 
 /**
  * Backend API
@@ -23,7 +20,7 @@ const SYNC_FREQUENCY_MS = 1000 * 60 * 15;
 export class ServerService {
   app_user_id: string;
   device_info: DeviceInfo;
-  syncSchedule = interval(SYNC_FREQUENCY_MS);
+  syncSchedule = interval(SERVER_SYNC_FREQUENCY);
   //   Requires update (?) - https://angular.io/api/common/http/HttpContext
   //   context =  new HttpContext().set(SERVER_API, true),
   constructor(private http: HttpClient) {}

--- a/src/app/shared/services/server/server.service.ts
+++ b/src/app/shared/services/server/server.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { DeviceInfo, Device } from "@capacitor/device";
-import { APP_FIELDS, SERVER_SYNC_FREQUENCY } from "data-models";
+import { APP_FIELDS, SERVER_SYNC_FREQUENCY_MS } from "data-models";
 import { interval } from "rxjs";
 import { throwError } from "rxjs";
 import { environment } from "src/environments/environment";
@@ -20,7 +20,7 @@ import { generateTimestamp } from "../../utils";
 export class ServerService {
   app_user_id: string;
   device_info: DeviceInfo;
-  syncSchedule = interval(SERVER_SYNC_FREQUENCY);
+  syncSchedule = interval(SERVER_SYNC_FREQUENCY_MS);
   //   Requires update (?) - https://angular.io/api/common/http/HttpContext
   //   context =  new HttpContext().set(SERVER_API, true),
   constructor(private http: HttpClient) {}


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Add support for `NOTIFICATIONS_SYNC_FREQUENCY_MS` constant to re-evaluate notification schedules on a fixed interval, currently set as every 3 minutes (previously would only re-evaluate on app start)

Also renames and moves `SERVER_SYNC_FREQUENCY_MS` to same folder for better clarity

## Git Issues

Closes #

## Screenshots/Videos
Updated constants available in `packages/data-models/constants`
![image](https://user-images.githubusercontent.com/10515065/146747112-199352b2-4510-4fd8-b847-0d37db4b3bcb.png)


