### PR TITLE
Core style refactor fixes

### DIFF
--- a/src/app/shared/components/template/components/audio/audio.component.scss
+++ b/src/app/shared/components/template/components/audio/audio.component.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../theme/mixins.scss";
+@import "src/theme/mixins.scss";
 .container-player {
   background: var(--ion-color-primary-contrast);
   border: var(--ion-border-standard);
@@ -104,7 +104,6 @@
         img {
           position: absolute;
           width: var(--audio-play-img-width);
-          margin-left: var(--tiny-margin);
         }
       }
     }

--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.scss
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.scss
@@ -1,7 +1,6 @@
-@import "../../../../../../theme/mixins.scss";
+@import "src/theme/mixins.scss";
 
 .box-wrapper {
-  padding: var(--large-padding) 0;
   .item {
     @include flex-centered;
     margin-left: auto;

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -27,6 +27,7 @@ import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "..
       *ngSwitchCase="'dashed_box'"
       [inputRow]="_row"
       [parent]="parent"
+      style="flex:1"
     ></plh-advanced-dashed-box>
     <!-- Form layout -->
     <plh-tmpl-form *ngSwitchCase="'form'" [inputRow]="_row" [parent]="parent"></plh-tmpl-form>

--- a/src/app/shared/components/template/components/tile-component/tile-component.component.scss
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.scss
@@ -24,15 +24,20 @@
       height: var(--tile-button-height);
       --background: transparent;
       --box-shadow: none;
-      border: var(--ion-border-light-thicker);
-      --border-radius: var(--ion-border-radius-rounded);
-      border-radius: var(--ion-border-radius-rounded);
+
       box-shadow: none;
       --ripple-color: transparent;
       img {
         width: calc(60px * var(--scale-factor-tile));
         height: calc(60px * var(--scale-factor-tile));
       }
+    }
+    // Note - CC 2021-12-21 - Currently not in use in any templates, but keeping in case we want
+    // to expose as a parameter option in the future
+    .circle-border {
+      border: var(--ion-border-light-thicker);
+      --border-radius: var(--ion-border-radius-rounded);
+      border-radius: var(--ion-border-radius-rounded);
     }
   }
 }

--- a/src/app/shared/components/template/template-component.scss
+++ b/src/app/shared/components/template/template-component.scss
@@ -9,9 +9,10 @@ plh-template-component {
   width: 100%;
 }
 
-/// Do not display hidden components
+/// Do not display hidden components or let them take up flex space
 plh-template-component[data-hidden="true"] {
   display: none !important;
+  flex: 0 !important;
 }
 /// Ensure all directly nested template rows have spacing between elements,
 /// except in case where only one row (e.g. deep-nested)

--- a/src/theme/deployment/_components.scss
+++ b/src/theme/deployment/_components.scss
@@ -6,11 +6,10 @@ plh-template-component[data-name="clicks_this_week"] {
   margin: 0 !important;
 }
 
-/// Move nav footer to bottom of page, and ensure padding above
-plh-template-component[data-name="nav_buttons"],
-plh-template-component[data-name="intro_nav_buttons"] {
-  margin-top: auto !important;
-  padding-top: 1em;
+/// Ensure any container ending with name nav_buttons (intro_nav_button, outro_nav_buttons etc.)
+/// fills all available space so child components can justify-content end
+plh-template-component[data-name$="nav_buttons"] {
+  flex: 1;
 }
 
 /// Ensure animated sections fill all available height

--- a/src/theme/deployment/_components.scss
+++ b/src/theme/deployment/_components.scss
@@ -6,10 +6,11 @@ plh-template-component[data-name="clicks_this_week"] {
   margin: 0 !important;
 }
 
-/// Move nav footer to bottom of page
+/// Move nav footer to bottom of page, and ensure padding above
 plh-template-component[data-name="nav_buttons"],
 plh-template-component[data-name="intro_nav_buttons"] {
   margin-top: auto !important;
+  padding-top: 1em;
 }
 
 /// Ensure animated sections fill all available height

--- a/src/theme/deployment/_templates.scss
+++ b/src/theme/deployment/_templates.scss
@@ -70,7 +70,7 @@ plh-template-container[data-templatename="nav_buttons"] {
   plh-template-component[data-type="display_group"] {
     justify-content: end; // assume parent has flex:1 property
     plh-template-component[data-type="round_button"] {
-      flex: unset !important; // removed incorrect hardcoded flex
+      flex: 0 !important; // removed incorrect hardcoded flex
     }
     // ensure gap between buttons
     plh-template-component:not([data-hidden="true"]) {

--- a/src/theme/deployment/_templates.scss
+++ b/src/theme/deployment/_templates.scss
@@ -63,3 +63,19 @@ plh-template-container[data-templatename="parent_centre_essential_tools"] {
     width: 100%;
   }
 }
+
+/// nav_buttons
+plh-template-container[data-templatename="nav_buttons"] {
+  margin-top: 1em;
+  plh-template-component[data-type="display_group"] {
+    justify-content: end; // assume parent has flex:1 property
+    plh-template-component[data-type="round_button"] {
+      flex: unset !important; // removed incorrect hardcoded flex
+    }
+    // ensure gap between buttons
+    plh-template-component:not([data-hidden="true"]) {
+      margin-left: 8px;
+      margin-right: 8px;
+    }
+  }
+}

--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -15,7 +15,7 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style="parent_point"] {
   // ensure all tiles are at least 120px (wrap to multiple lines if not), and size equally
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  grid-gap: 16px;
+  grid-gap: 4px;
 }
 
 /// Remove additional padding from around images which make


### PR DESCRIPTION
## Description
Following core styles refactor PR (#1131 ), various minor issues to resolve:

- [x] **Navigation buttons spacing when back-button is displayed**
This is now fixed from the dev side. The solution is a bit hardcoded, and depends on the parent container ending `nav_buttons` (e.g. intro_nav_buttons, outro_nav_buttons, etc.). There is also a small amount of padding between start and end, currently required because of not really knowing which of the 4 buttons will be shown and wanting to guarantee there's always spacing (could be fixed later with some additional authoring to change hidden conditions to disabled and updating hardcoded styles)

- [x] **The dashed box display group should always be full width.**
Update styles to make all dashed boxes full width

- [x] **Sometimes there is no vertical padding between the before-last component on the page and the nav buttons.**
Linked to the tricky code referenced above. Now there should always be a gap (there might be instances with a gap twice the size, but assume this won't be much of an issue)

Additional issues resolved:

**Closed with previous PR**
#1121 - manually closed
#1128 - manually closed
#1050 - manually closed
#1120 - believe resolved but left open (pending confirmation)

**Fixed in this PR**
#1051
#1097 - I've removed the circle border for all tile styles but retained code in case we want option in the future
#1118 - included in this pr - although I could not find templates with the `+1` button, so wondering if it got broken somewhere else?... but the main image centring should be fixed at least, let me know if there is anything else outstanding on it


## Git Issues

Closes #1051
Closes #1097
Closes #1118
Closes #1120

## Screenshots/Videos

**Nav buttons with padding**
![image](https://user-images.githubusercontent.com/10515065/146966678-93e86ad2-2327-4026-bbfd-8b13f156a99e.png)

**Full width dashed box**
![image](https://user-images.githubusercontent.com/10515065/146958611-98062f71-46de-4e02-ab64-d55618cef95b.png)

**Parent point padding fix**
![image](https://user-images.githubusercontent.com/10515065/146969657-d6514d04-5b1a-4b51-8f59-ca33e3fa132e.png)

**Paragraph text fix**
![image](https://user-images.githubusercontent.com/10515065/146969947-f781ecd9-38ba-4e44-b18d-95ca2a27dfc7.png)

**Circle border removed**
![image](https://user-images.githubusercontent.com/10515065/146970526-823dc413-51f3-42f1-abfd-dffd0a4cc6fd.png)

**Audio play button alignment fixed**
![image](https://user-images.githubusercontent.com/10515065/146972586-971d43ae-06b4-47a5-99af-ef7bb0630930.png)
