### PR TITLE
remove data-display-component styles

### DIFF
--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -82,12 +82,9 @@ export class TemplateComponent implements OnInit, ITemplateRowProps {
   @Input() parent: TemplateContainerComponent;
 
   // Add bindings to track key data attributes on the component itself, e.g.
-  // <plh-template-component data-display-component="TmplNumberComponent" data-name="number_selector_6" data-type="number_selector">
+  // <plh-template-component data-name="number_selector_6" data-type="number_selector">
   @HostBinding("attr.data-hidden") get getAttrHidden() {
     return this._row && this._row.hidden ? true : false; // explictly state for all components to allow css selection
-  }
-  @HostBinding("attr.data-display-component") get getComponentDisplayType() {
-    return TEMPLATE_COMPONENT_MAPPING[this._row?.type]?.name || "none";
   }
   @HostBinding("attr.data-name") get getComponentName() {
     return this._row?.name || null;

--- a/src/theme/deployment/templates/_home_screen.scss
+++ b/src/theme/deployment/templates/_home_screen.scss
@@ -11,7 +11,7 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style~="home_screen"] {
     height: var(--home-screen-height-small);
   }
   // animated start icon
-  plh-template-component[data-display-component="TmplLottieAnimation"] {
+  plh-template-component[data-type="lottie_animation"] {
     @include flex-centered;
     flex-direction: column;
     // make offset slightly out of top
@@ -56,12 +56,12 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style~="home_screen"] {
     }
   }
   // title text
-  plh-template-component[data-display-component="TmplTitleComponent"] {
+  plh-template-component[data-type="title"] {
     margin-left: unset !important;
   }
 
   // quick-access button
-  plh-template-component[data-display-component="RoundIconButtonComponent"] {
+  plh-template-component[data-type="round_button"] {
     position: absolute;
     right: -15px;
     bottom: -15px;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Home screen animations have breakpoints to prevent animation getting too large at certain sizes, however they had been refactored to depend on the name of their parent component which gets changed during production build. Minor fix to make the styles depend on the row type instead (as all row types are mapped to the display component, but are not optimised in the same way)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
