### PR TITLE
Fix/dashed box padding

### DIFF
--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
@@ -1,5 +1,5 @@
-<div class="box-wrapper">
-  <div class="item margin-t-regular default" [class]="style">
+<div class="box-wrapper" [attr.data-hasicon]="icon_src ? true : null">
+  <div class="item default" [class]="style">
     <div class="icon" [class]="icon_position" *ngIf="icon_src">
       <img [src]="icon_src | plhAsset" alt="" />
     </div>

--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.scss
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.scss
@@ -1,7 +1,6 @@
-@import "../../../../../../../theme/mixins.scss";
+@import "src/theme/mixins.scss";
 
 .box-wrapper {
-  padding: var(--large-padding) 0;
   .item {
     @include flex-centered;
     flex-direction: column;
@@ -57,4 +56,8 @@
       color: var(--ion-color-secondary);
     }
   }
+}
+.box-wrapper[data-hasicon="true"] {
+  // add margin to top to account for offset icon
+  margin-top: 8px;
 }

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
@@ -9,7 +9,7 @@ import {
 @Component({
   selector: "plh-tmpl-toggle-bar",
   template: `
-    <div class="container margin-t-regular" [class]="position">
+    <div class="container" [class]="position">
       <div class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
         <ion-toggle
           mode="md"


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
- Remove hardcoded padding from advanced-dashed-box component
- Add style to include smaller margin in advanced-dashed-box component only when icon included (to account for offset when icon appears slightly above container)
- Remove hardcoded top-margin from toggle-bar component

**Note** 
While fixing this I noticed a large number of components with fixed top margins (either using class `margin-t-regular` (or similar), or hardcoded values.

Longer-term I think most instances of these will want to be removed because an individual component really shouldn't be dictating its layout within the page relative to other components (that is the responsibility of default layouts and hardcoded authoring overrides etc.), but I will hold off making larger changes until we have a bit more time for managing (e.g. post next release - have opened #1154 to track)

## Git Issues

Closes #1149

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/148123199-05be6baa-2e13-49d1-a3ef-8ff1b486d932.png)