### PR TITLE
Update display group padding to mimic template

### DIFF
--- a/src/app/shared/components/template/components/layout/display_group.scss
+++ b/src/app/shared/components/template/components/layout/display_group.scss
@@ -21,3 +21,21 @@
 .display-group-wrapper[data-param-style~="wrap"] {
   flex-wrap: wrap;
 }
+
+// Default spacing within display groups. Adapted from `template-component.scss`
+
+.display-group-wrapper > plh-template-component:not([data-hidden="true"]) {
+  margin: 0 0 0 1em;
+}
+.display-group-wrapper > plh-template-component:not([data-hidden="true"]):first-of-type {
+  margin: 0;
+}
+
+.display-group-wrapper[data-param-style~="column"]
+  > plh-template-component:not([data-hidden="true"]) {
+  margin: 1em 0 0 0;
+}
+.display-group-wrapper[data-param-style~="column"]
+  > plh-template-component:not([data-hidden="true"]):first-of-type {
+  margin: 0;
+}

--- a/src/app/shared/components/template/components/layout/display_group.scss
+++ b/src/app/shared/components/template/components/layout/display_group.scss
@@ -24,10 +24,11 @@
 
 // Default spacing within display groups. Adapted from `template-component.scss`
 
-.display-group-wrapper > plh-template-component:not([data-hidden="true"]) {
+.display-group-wrapper[data-param-style~="row"] > plh-template-component:not([data-hidden="true"]) {
   margin: 0 0 0 1em;
 }
-.display-group-wrapper > plh-template-component:not([data-hidden="true"]):first-of-type {
+.display-group-wrapper[data-param-style~="row"]
+  > plh-template-component:not([data-hidden="true"]):first-of-type {
   margin: 0;
 }
 

--- a/src/app/shared/components/template/components/layout/display_group.ts
+++ b/src/app/shared/components/template/components/layout/display_group.ts
@@ -48,7 +48,7 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
   }
 
   getParams() {
-    this.params.style = getStringParamFromTemplateRow(this._row, "style", null);
+    this.params.style = getStringParamFromTemplateRow(this._row, "style", "row");
     this.params.offset = getNumberParamFromTemplateRow(this._row, "offset", 0);
     this.type = this.getTypeFromStyles(this.params.style || "");
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Updates styles so that rows in display groups are spaced the same way that regular rows are (default 16px margin between columns or rows). 

## Review Notes
Style updates have been specifically scoped to children of display groups to avoid wider breaking changes, but still possible to have some knock-ons where display groups used and either margins manually specified or not included (should be picked up by visual test).

The demo template used hasn't been synced to master yet so only available if testing locally. 

## Git Issues

Closes #1147

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/148139424-42f20987-9839-4f15-8b7e-0c9513a70745.png)

