### PR TITLE
Improve template service dependency handling

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,7 +17,7 @@ import { TemplateService } from "./shared/components/template/services/template.
 import { CampaignService } from "./feature/campaign/campaign.service";
 import { ServerService } from "./shared/services/server/server.service";
 import { DataEvaluationService } from "./shared/services/data/data-evaluation.service";
-import { TemplateProcessService } from "./shared/components/template/services/template-process.service";
+import { TemplateProcessService } from "./shared/components/template/services/instance/template-process.service";
 import { isSameDay } from "date-fns";
 import { AnalyticsService } from "./shared/services/analytics/analytics.service";
 import { LocalNotificationService } from "./shared/services/notification/local-notification.service";

--- a/src/app/shared/components/template/components/layout/layout.ts
+++ b/src/app/shared/components/template/components/layout/layout.ts
@@ -49,7 +49,9 @@ export class TemplateLayoutComponent implements ITemplateRowProps, OnInit {
   public scrollToTop() {
     let parent = this.parent;
     while (parent) {
-      parent.elRef.nativeElement.scrollTop = 0;
+      if (parent.elRef) {
+        parent.elRef.nativeElement.scrollTop = 0;
+      }
       parent = parent.parent;
     }
     const ionContentContainers = document.querySelectorAll("ion-content") || [];

--- a/src/app/shared/components/template/services/instance/README.md
+++ b/src/app/shared/components/template/services/instance/README.md
@@ -1,0 +1,9 @@
+# Instance Services
+
+Some services require being created on demand so that they can operate within a given context, such as a specific template container with rows.
+
+To improve handling of dependency injection, these instantiable services use a custom injector to register services. This allows them to call global services without need to be inherited, and can also help to prevent cyclic dependency issues
+
+As such they are not injected, and it is assumed any services required for injection should already be in the global scope (if not should be added to module)
+
+TODO - add importable service that ensures instantiated dependencies available

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -157,7 +157,10 @@ export class TemplateActionService extends TemplateInstanceService {
         return;
       case "process_template":
         // HACK - create an embedded template processor service instance to process template programatically
-        const templateToProcess = await this.templateService.getTemplateByName(args[0]);
+        const templateToProcess = await this.templateService.getTemplateByName(
+          args[0],
+          this.container?.row?.is_override_target
+        );
         const processor = new TemplateProcessService(this.injector);
         return processor.processTemplateWithoutRender(templateToProcess);
       case "emit":

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -1,11 +1,17 @@
 import { BehaviorSubject } from "rxjs";
 import { takeWhile } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
-import { TemplateContainerComponent } from "../template-container.component";
+import { TemplateContainerComponent } from "../../template-container.component";
 import { SettingsService } from "src/app/shared/services/settings.service";
-import { TemplateProcessService } from "./template-process.service";
+import { TemplateProcessService } from "../template-process.service";
 import { ServerService } from "src/app/shared/services/server/server.service";
 import { AnalyticsService } from "src/app/shared/services/analytics/analytics.service";
+import { Injector } from "@angular/core";
+import { TemplateInstanceService } from "./template-instance.service";
+import { TemplateNavService } from "../template-nav.service";
+import { TemplateService } from "../template.service";
+import { TourService } from "src/app/shared/services/tour/tour.service";
+import { TemplateTranslateService } from "../template-translate.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -17,16 +23,27 @@ let log_groupEnd = SHOW_DEBUG_LOGS ? console.groupEnd : () => null;
  *
  *
  */
-export class TemplateActionService {
+export class TemplateActionService extends TemplateInstanceService {
   private actionsQueue: FlowTypes.TemplateRowAction[] = [];
   private actionsQueueProcessing$ = new BehaviorSubject<boolean>(false);
 
-  constructor(
-    public container: TemplateContainerComponent,
-    private settingsService: SettingsService,
-    private serverService: ServerService,
-    private analyticsService: AnalyticsService
-  ) {}
+  private settingsService: SettingsService;
+  private serverService: ServerService;
+  private analyticsService: AnalyticsService;
+  private templateNavService: TemplateNavService;
+  private templateService: TemplateService;
+  private tourService: TourService;
+  private templateTranslateService: TemplateTranslateService;
+
+  constructor(public container: TemplateContainerComponent, injector: Injector) {
+    super(injector);
+    this.settingsService = this.getGlobalService(SettingsService);
+    this.serverService = this.getGlobalService(ServerService);
+    this.analyticsService = this.getGlobalService(AnalyticsService);
+    this.templateNavService = this.getGlobalService(TemplateNavService);
+    this.templateService = this.getGlobalService(TemplateService);
+    this.tourService = this.getGlobalService(TourService);
+  }
 
   /** Public method to add actions to processing queue and process */
   public async handleActions(
@@ -38,7 +55,7 @@ export class TemplateActionService {
     const res = await this.processActionQueue();
     await this.handleActionsCallback([...unhandledActions], res);
     if (!this.container.parent) {
-      await this.container.templateNavService.handleNavActionsFromChild(actions, this.container);
+      await this.templateNavService.handleNavActionsFromChild(actions, this.container);
     }
   }
   /** Optional method child component can add to handle post-action callback */
@@ -104,7 +121,7 @@ export class TemplateActionService {
         console.log("[SET LOCAL]", { key, value });
         return this.setLocalVariable(key, value);
       case "go_to":
-        return this.container.templateNavService.handleNavAction(action, this.container);
+        return this.templateNavService.handleNavAction(action);
       case "go_to_url":
         // because a normal url starts with https://, the ':' separates it into a key and a value and the value
         // is sufficient for the url to launch.
@@ -115,20 +132,16 @@ export class TemplateActionService {
         if (!value) {
           value = "//" + key;
         }
-        return this.container.templateNavService.handleNavActionExternal(value);
+        return this.templateNavService.handleNavActionExternal(value);
       case "pop_up":
-        return this.container.templateNavService.handlePopupAction(action, this.container);
+        return this.templateNavService.handlePopupAction(action, this.container);
       case "set_field":
         console.log("[SET FIELD]", key, value);
-        return this.container.templateService.setField(key, value);
+        return this.templateService.setField(key, value);
       case "set_theme":
-        return this.container.templateService.setTheme(
-          this.container.template,
-          "set_theme",
-          action.args
-        );
+        return this.templateService.setTheme(this.container.template, "set_theme", action.args);
       case "start_tour":
-        return this.container.tourService.startTour(key);
+        return this.tourService.startTour(key);
       case "track_event":
         this.analyticsService.trackEvent(key);
         break;
@@ -141,18 +154,11 @@ export class TemplateActionService {
         return;
       case "process_template":
         // HACK - create an embedded template processor service instance to process template programatically
-        const templateToProcess = this.container.templateService.getTemplateByName(args[0]);
+        const templateToProcess = this.templateService.getTemplateByName(args[0]);
         const processor = new TemplateProcessService(
-          this.container.templateService,
-          this.container.templateVariables,
-          this.container.templateTranslateService,
-          this.container.tourService,
-          this.container.router,
-          this.container.route,
-          this.container.templateNavService,
-          this.container.settingsService,
-          this.container.serverService,
-          this.analyticsService
+          this.templateService,
+          this.templateNavService,
+          this.injector
         );
         return processor.processTemplateWithoutRender(templateToProcess);
       case "emit":
@@ -170,7 +176,7 @@ export class TemplateActionService {
         console.log("[EMIT]", `${name || templatename}:${emit_value}`);
         if (emit_value === "completed") {
           // write completions to the database for data tracking
-          await this.container.templateService.recordEvent(template, "emit", emit_value);
+          await this.templateService.recordEvent(template, "emit", emit_value);
         }
         // TODO - trigger emit in shared service to allow individual services/components to subscribe
         // themselves instead of relying on hardcoded calls here
@@ -183,7 +189,7 @@ export class TemplateActionService {
           await this.container.forceRerender(false);
         }
         if (emit_value === "set_language") {
-          this.container.templateTranslateService.setLanguage(args[1]);
+          this.templateTranslateService.setLanguage(args[1]);
         }
         if (emit_value === "server_sync") {
           await this.serverService.syncUserData();

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -3,7 +3,7 @@ import { takeWhile } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
 import { TemplateContainerComponent } from "../../template-container.component";
 import { SettingsService } from "src/app/shared/services/settings.service";
-import { TemplateProcessService } from "../template-process.service";
+import { TemplateProcessService } from "./template-process.service";
 import { ServerService } from "src/app/shared/services/server/server.service";
 import { AnalyticsService } from "src/app/shared/services/analytics/analytics.service";
 import { Injector } from "@angular/core";
@@ -158,11 +158,7 @@ export class TemplateActionService extends TemplateInstanceService {
       case "process_template":
         // HACK - create an embedded template processor service instance to process template programatically
         const templateToProcess = await this.templateService.getTemplateByName(args[0]);
-        const processor = new TemplateProcessService(
-          this.templateService,
-          this.templateNavService,
-          this.injector
-        );
+        const processor = new TemplateProcessService(this.injector);
         return processor.processTemplateWithoutRender(templateToProcess);
       case "emit":
         const [emit_value, emit_from] = args;

--- a/src/app/shared/components/template/services/instance/template-instance.service.ts
+++ b/src/app/shared/components/template/services/instance/template-instance.service.ts
@@ -1,0 +1,10 @@
+import { Injectable, Injector, ProviderToken } from "@angular/core";
+
+@Injectable({ providedIn: "root" })
+export class TemplateInstanceService {
+  constructor(public injector: Injector) {}
+
+  getGlobalService<T>(token: ProviderToken<T>) {
+    return this.injector.get(token);
+  }
+}

--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Injector } from "@angular/core";
 import { FlowTypes } from "data-models";
 import { TEMPLATE } from "src/app/shared/services/data/data.service";
-import { TemplateContainerComponent } from "../template-container.component";
-import { TemplateNavService } from "./template-nav.service";
-import { TemplateService } from "./template.service";
+import { TemplateContainerComponent } from "../../template-container.component";
+import { TemplateNavService } from "../template-nav.service";
+import { TemplateService } from "../template.service";
+import { TemplateInstanceService } from "./template-instance.service";
 
 /**
  * The template process service is a slightly hacky wrapper around the template container component so that
@@ -13,15 +14,20 @@ import { TemplateService } from "./template.service";
  * component extending it (instead of vice-versa)
  */
 @Injectable({ providedIn: "root" })
-export class TemplateProcessService {
+export class TemplateProcessService extends TemplateInstanceService {
   container: TemplateContainerComponent;
-  constructor(
-    templateService: TemplateService,
-    templateNavService: TemplateNavService,
-    injector: Injector
-  ) {
+  templateService: TemplateService;
+  templateNavService: TemplateNavService;
+  constructor(injector: Injector) {
+    super(injector);
+    this.templateService = this.getGlobalService(TemplateService);
+    this.templateNavService = this.getGlobalService(TemplateNavService);
     // Create mock template container component
-    this.container = new TemplateContainerComponent(templateService, templateNavService, injector);
+    this.container = new TemplateContainerComponent(
+      this.templateService,
+      this.templateNavService,
+      injector
+    );
   }
 
   public async init() {

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -1,5 +1,6 @@
 import { Location } from "@angular/common";
 import { Injectable } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
 import { ModalController } from "@ionic/angular";
 import { FlowTypes } from "src/app/shared/model";
 import { arrayToHashmapArray } from "src/app/shared/utils";
@@ -19,7 +20,12 @@ const log = SHOW_DEBUG_LOGS ? console.log : () => null;
  * ...
  */
 export class TemplateNavService {
-  constructor(private modalCtrl: ModalController, private location: Location) {}
+  constructor(
+    private modalCtrl: ModalController,
+    private location: Location,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
 
   public async handleQueryParamChange(
     params: INavQueryParams,
@@ -57,10 +63,7 @@ export class TemplateNavService {
   /*****************************************************************************************************
    *  Nav Actions
    ****************************************************************************************************/
-  public handleNavAction(
-    action: FlowTypes.TemplateRowAction,
-    container: TemplateContainerComponent
-  ) {
+  public handleNavAction(action: FlowTypes.TemplateRowAction) {
     // TODO: Find more elegant way to get current root level template name
     const parentName = location.pathname.replace("/template/", "");
     const [templatename] = action.args;
@@ -68,7 +71,7 @@ export class TemplateNavService {
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
     // handle direct page or template navigation
     const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
-    return container.router.navigate(navTarget, {
+    return this.router.navigate(navTarget, {
       queryParams,
       queryParamsHandling: "merge",
     });
@@ -85,7 +88,7 @@ export class TemplateNavService {
     container: TemplateContainerComponent
   ) {
     const { nav_child_emit, nav_parent_triggered_by } = params;
-    const { router, template } = container;
+    const { template } = container;
     log("[Nav] - Parent", { params, container });
     // remove query param
     const queryParams: INavQueryParams = {
@@ -94,7 +97,7 @@ export class TemplateNavService {
       nav_parent: null,
       nav_parent_triggered_by: null,
     };
-    router.navigate([], {
+    this.router.navigate([], {
       queryParams,
       replaceUrl: true,
       queryParamsHandling: "merge",
@@ -124,8 +127,7 @@ export class TemplateNavService {
     actions: FlowTypes.TemplateRowAction[],
     container: TemplateContainerComponent
   ) {
-    const { route, router } = container;
-    const params = route.snapshot.queryParams as INavQueryParams;
+    const params = this.route.snapshot.queryParams as INavQueryParams;
     const { nav_parent, popup_parent } = params;
     log("[Nav] - Child", { params, container });
     // only process nav events for child if a nav_parent has been set
@@ -170,7 +172,7 @@ export class TemplateNavService {
     action: FlowTypes.TemplateRowAction,
     container: TemplateContainerComponent
   ) {
-    const { router, name } = container;
+    const { name } = container;
     const templatename = action.args[0];
     // simply set the query params which will be handled in method below so that
     // opening can also be handled following navigation or on refresh
@@ -179,7 +181,7 @@ export class TemplateNavService {
       popup_parent: name,
       popup_parent_triggered_by: action._triggeredBy.name,
     };
-    router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
+    this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
   }
 
   private async handlePopupActionsFromParent(
@@ -248,8 +250,7 @@ export class TemplateNavService {
       nav_parent: null,
       nav_parent_triggered_by: null,
     };
-    const { router } = container;
-    router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
+    this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
   }
 
   /** Popups persist nav operations, so also need to handle from top-level templates that are not the parent */

--- a/src/app/shared/components/template/services/template-process.service.ts
+++ b/src/app/shared/components/template/services/template-process.service.ts
@@ -1,15 +1,8 @@
-import { Injectable } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { Injectable, Injector } from "@angular/core";
 import { FlowTypes } from "data-models";
-import { SettingsService } from "src/app/shared/services/settings.service";
-import { AnalyticsService } from "src/app/shared/services/analytics/analytics.service";
 import { TEMPLATE } from "src/app/shared/services/data/data.service";
-import { ServerService } from "src/app/shared/services/server/server.service";
-import { TourService } from "src/app/shared/services/tour/tour.service";
 import { TemplateContainerComponent } from "../template-container.component";
 import { TemplateNavService } from "./template-nav.service";
-import { TemplateTranslateService } from "./template-translate.service";
-import { TemplateVariablesService } from "./template-variables.service";
 import { TemplateService } from "./template.service";
 
 /**
@@ -24,33 +17,11 @@ export class TemplateProcessService {
   container: TemplateContainerComponent;
   constructor(
     templateService: TemplateService,
-    templateVariables: TemplateVariablesService,
-    templateTranslateService: TemplateTranslateService,
-    tourService: TourService,
-    router: Router,
-    route: ActivatedRoute,
-    // elRef: ElementRef,
     templateNavService: TemplateNavService,
-    // cdr: ChangeDetectorRef,
-    settingsService: SettingsService,
-    serverService: ServerService,
-    analyticsService: AnalyticsService
+    injector: Injector
   ) {
     // Create mock template container component
-    this.container = new TemplateContainerComponent(
-      templateService,
-      templateVariables,
-      templateTranslateService,
-      tourService,
-      router,
-      route,
-      null as any,
-      templateNavService,
-      null as any,
-      settingsService,
-      serverService,
-      analyticsService
-    );
+    this.container = new TemplateContainerComponent(templateService, templateNavService, injector);
   }
 
   public async init() {

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -5,7 +5,7 @@ import { evaluateJSExpression, getNestedProperty, setNestedProperty } from "src/
 import { TemplateService } from "./template.service";
 import { ICalcContext, TemplateCalcService } from "./template-calc.service";
 import { TemplateTranslateService } from "./template-translate.service";
-import { ITemplateRowMap } from "./template-row.service";
+import { ITemplateRowMap } from "./instance/template-row.service";
 import { extractDynamicEvaluators } from "data-models";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */

--- a/src/app/shared/components/template/services/template.service.ts
+++ b/src/app/shared/components/template/services/template.service.ts
@@ -85,18 +85,16 @@ export class TemplateService {
    * Load a template by a given name. If overrides exist for the template they will be evaluated
    * and returned instead.
    * @param templateName name of template to load
-   * @param row container row as source of getTemplate request
+   * @param is_override_target boolean (passed from row property) to identify if self has been overridden
+   * (and could therefore lead to infinite loop overwise)
    */
   public async getTemplateByName(
     templateName: string,
-    row?: FlowTypes.TemplateRow
+    is_override_target: boolean
   ): Promise<FlowTypes.Template> {
     const foundTemplate: FlowTypes.Template = TEMPLATE.find((t) => t.flow_name === templateName);
     if (foundTemplate) {
-      const overiddenTemplate = await this.getTemplateOverride(
-        foundTemplate,
-        row?.is_override_target
-      );
+      const overiddenTemplate = await this.getTemplateOverride(foundTemplate, is_override_target);
       // create a deep clone of the object to prevent accidental reference changes
       // assign a name (in case top-level template) and store breadcrumb path for nested
       // (NOTE - would no longer be required if reading in json objects instead of ts import)

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -1,29 +1,23 @@
 import {
-  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   HostBinding,
+  Injector,
   Input,
   OnDestroy,
   OnInit,
   Output,
 } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import { takeUntil } from "rxjs/operators";
 import { Subject } from "rxjs";
-import { TourService } from "../../services/tour/tour.service";
 import { FlowTypes, ITemplateContainerProps } from "./models";
-import { TemplateActionService } from "./services/template-action.service";
+import { TemplateActionService } from "./services/instance/template-action.service";
 import { TemplateNavService } from "./services/template-nav.service";
-import { TemplateRowService } from "./services/template-row.service";
-import { TemplateVariablesService } from "./services/template-variables.service";
+import { TemplateRowService } from "./services/instance/template-row.service";
 import { TemplateService } from "./services/template.service";
 import { getIonContentScrollTop, setElStyleAnimated, setIonContentScrollTop } from "./utils";
-import { TemplateTranslateService } from "./services/template-translate.service";
-import { SettingsService } from "src/app/shared/services/settings.service";
-import { ServerService } from "../../services/server/server.service";
-import { AnalyticsService } from "../../services/analytics/analytics.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -67,26 +61,15 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   debugMode: boolean;
 
   constructor(
-    public templateService: TemplateService,
-    public templateVariables: TemplateVariablesService,
-    public templateTranslateService: TemplateTranslateService,
-    public tourService: TourService,
-    public router: Router,
-    public route: ActivatedRoute,
-    public elRef: ElementRef,
-    public templateNavService: TemplateNavService,
-    public cdr: ChangeDetectorRef,
-    public settingsService: SettingsService,
-    public serverService: ServerService,
-    public analyticsService: AnalyticsService
+    private templateService: TemplateService,
+    private templateNavService: TemplateNavService,
+    injector: Injector,
+    // Containers created in headless context may not have specific injectors
+    public elRef?: ElementRef,
+    private route?: ActivatedRoute
   ) {
-    this.templateActionService = new TemplateActionService(
-      this,
-      this.settingsService,
-      this.serverService,
-      this.analyticsService
-    );
-    this.templateRowService = new TemplateRowService(this);
+    this.templateActionService = new TemplateActionService(this, injector);
+    this.templateRowService = new TemplateRowService(this, injector);
   }
   /** Assign the templatename as metdaata on the component for easier debugging and testing */
   @HostBinding("attr.data-templatename") get getTemplatename() {
@@ -161,20 +144,22 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
       if (this.parent) {
         return this.parent.forceRerender(full, shouldProcess);
       } else {
-        // we have the top-most parent. Process re-renders, taking note of current
-        // page scroll position and trying to return to it once complete
-        shouldProcess = true;
-        const top = getIonContentScrollTop(this.elRef);
-        // if page scrolled, fade the content out and in during re-render to avoid ugly content flicker
-        if (full && top > 0) {
-          await setElStyleAnimated(this.elRef, "opacity", 0, { duration: 100 });
-        }
-        await this.forceRerender(full, shouldProcess);
-        if (full && top > 0) {
-          setTimeout(async () => {
-            setIonContentScrollTop(this.elRef, top);
-            await setElStyleAnimated(this.elRef, "opacity", 1, { duration: 200 });
-          }, 0);
+        if (this.elRef) {
+          // we have the top-most parent. Process re-renders, taking note of current
+          // page scroll position and trying to return to it once complete
+          shouldProcess = true;
+          const top = getIonContentScrollTop(this.elRef);
+          // if page scrolled, fade the content out and in during re-render to avoid ugly content flicker
+          if (full && top > 0) {
+            await setElStyleAnimated(this.elRef, "opacity", 0, { duration: 100 });
+          }
+          await this.forceRerender(full, shouldProcess);
+          if (full && top > 0) {
+            setTimeout(async () => {
+              setIonContentScrollTop(this.elRef, top);
+              await setElStyleAnimated(this.elRef, "opacity", 1, { duration: 200 });
+            }, 0);
+          }
         }
       }
     }
@@ -221,13 +206,15 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
   /** Query params are used to track state across navigation events */
   private subscribeToQueryParamChanges() {
-    this.route.queryParams
-      .pipe(takeUntil(this.componentDestroyed$))
-      .subscribe(async (params: any) => {
-        this.debugMode = params.debugMode ? true : false;
-        // allow templateNavService to process actions based on query param change
-        await this.templateNavService.handleQueryParamChange(params, this);
-      });
+    if (this.route) {
+      this.route.queryParams
+        .pipe(takeUntil(this.componentDestroyed$))
+        .subscribe(async (params: any) => {
+          this.debugMode = params.debugMode ? true : false;
+          // allow templateNavService to process actions based on query param change
+          await this.templateNavService.handleQueryParamChange(params, this);
+        });
+    }
   }
 
   private setLogging(showLogs: boolean) {

--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -171,7 +171,10 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
 
   private async renderTemplate() {
     // Lookup template
-    const template = await this.templateService.getTemplateByName(this.templatename, this.row);
+    const template = await this.templateService.getTemplateByName(
+      this.templatename,
+      this.row?.is_override_target
+    );
     this.name = this.name || this.templatename;
     this.templateBreadcrumbs = [...(this.parent?.templateBreadcrumbs || []), this.name];
     this.template = template;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Refactor template services to provide slightly cleaner and more scalable sharing of code both within the templating system and external modules

## Dev Notes
The templating system is broken down into various components and services tasked with different aspects of the system, such as processing templates, rendering rows or triggering actions. One of the downsides of this modularity is that sharing code between services can be tricky given the nature of cyclic dependencies (e.g. the template-processor service can't import from template-actions if template-actions also has a call to the template-processor, e.g. trigger re-process)

Another layer of complexity is added when we take into account that some services exist globally (single instance), whilst others are created at a per-template container level (because this vastly simplifies doing things like adding local context to services; it also provides a pathway to calling template services from outside the core templating system, such as programmatically processing a template that has not been rendered). 

Longer term the general architecture could do with a bit of a rethink (likely leveraging more event messaging/callback systems of communication and/or adding full separation between template rendering and processing logic), however some small steps are required short term to start enabling more required functionality (namely triggering actions from notifications using the existing template-action system)

This PR takes a small step to differentiate between services which are created globally, and services which are instantiated multiple times. It also changes how instantiated services call global services, previously relying on having the service specifically passed as an argument when instantiating (leading to very long and messy lists of args), to using a custom injector that pulls from the global scope instead.

![image](https://user-images.githubusercontent.com/10515065/148316946-51a4815d-a509-40c1-8d8d-df83610cc34e.png)
_Distinction between global and per-template (instanced) - differences always existed in codebase, but made explicit with folder structure_ 

See inline comments for more explanation of the code.

## Review Notes
The code changes are only to with processing, and so should not result in any visual diffs except in case where a component is no longer rendered (unlikely). 

The main area to functional test would be logic that triggers/cascades through multiple levels of templates, such as steppers and popups.

## Git Issues

Closes #

## Screenshots/Videos



