### PR TITLE
Fix/popup nav

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -27,6 +27,15 @@ export class TemplateNavService {
     private route: ActivatedRoute
   ) {}
 
+  /**
+   * Track list of modals created. As we can navigate repeatedly to the same page we want to avoid recreating same modals
+   * We also want to retain modal open state following circular navigate (a->b->c->a), so by default we leave modals opened
+   * unless specifically closed (e.g. nav triggered from modal)
+   */
+  private openPopupsByName: {
+    [templatename: string]: { modal: HTMLIonModalElement; props: ITemplateContainerProps };
+  } = {};
+
   public async handleQueryParamChange(
     params: INavQueryParams,
     container: TemplateContainerComponent
@@ -190,7 +199,7 @@ export class TemplateNavService {
   ) {
     const { popup_child, nav_child_emit, popup_parent_triggered_by } = params;
     const { template } = container;
-    const existingPopup = await this.modalCtrl.getTop();
+    const existingPopup = this.openPopupsByName[popup_child];
     log("[Popup] - parent", { params, parent: container.name });
 
     // process any actions triggered by nav from the popup
@@ -204,17 +213,17 @@ export class TemplateNavService {
         const emittedActions = actionsByTrigger[nav_child_emit];
         if (emittedActions) {
           await container.templateActionService.handleActions(emittedActions, triggerRow);
-          await this.modalCtrl.dismiss(nav_child_emit);
+          await this.dismissPopup(popup_child, nav_child_emit);
         }
         // if the popup does not have any actions triggered by the nav_emit, leave open if there
         // is a trigger for the alternate completed/uncompleted event (otherwise dismiss)
         // - confusing logic I know!
         else {
           if (!actionsByTrigger["completed"] && !actionsByTrigger["uncompleted"]) {
-            await this.modalCtrl.dismiss(nav_child_emit);
+            await this.dismissPopup(popup_child, nav_child_emit);
           } else {
             // ensure popup visible if previously put behind on navigated template
-            existingPopup.classList.remove("hide-popup-on-template");
+            existingPopup.modal.classList.remove("hide-popup-on-template");
           }
         }
       }
@@ -237,20 +246,29 @@ export class TemplateNavService {
     container: TemplateContainerComponent
   ) {
     const childTemplateModal = await this.createChildPopupModal(popup_child, container);
-    await childTemplateModal.present();
-    const { data } = await childTemplateModal.onDidDismiss();
-    log("dismissed", data);
-    // clear both popup and query params
-    const queryParams: INavQueryParams = {
-      popup_child: null,
-      popup_parent: null,
-      popup_parent_triggered_by: null,
-      nav_child_emit: null,
-      nav_child: null,
-      nav_parent: null,
-      nav_parent_triggered_by: null,
-    };
-    this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
+    if (childTemplateModal) {
+      await childTemplateModal.present();
+      const { data } = await childTemplateModal.onDidDismiss();
+      // remove reference to popup (will be auto removed if dismissed programatically, but not by background dismiss)
+      if (this.openPopupsByName[popup_child]) {
+        delete this.openPopupsByName[popup_child];
+      }
+      log("dismissed", data);
+      // clear any existing popup query params on dismiss
+      const queryParams: INavQueryParams = {
+        popup_child: null,
+        popup_parent: null,
+        popup_parent_triggered_by: null,
+      };
+      this.router.navigate([], { queryParams, replaceUrl: true, queryParamsHandling: "merge" });
+    }
+  }
+  private async dismissPopup(name: string, data: any = undefined) {
+    const existingPopup = this.openPopupsByName[name];
+    if (existingPopup) {
+      await existingPopup.modal.dismiss(data);
+      delete this.openPopupsByName[name];
+    }
   }
 
   /** Popups persist nav operations, so also need to handle from top-level templates that are not the parent */
@@ -259,9 +277,10 @@ export class TemplateNavService {
     container: TemplateContainerComponent
   ) {
     // Hide any open popup that was trigggered on a previous page prior to navigation (unless new popup)
-    const existingPopup = await this.modalCtrl.getTop();
-    if (existingPopup?.id === `popup-${params.popup_child}`) {
-      existingPopup.classList.add("hide-popup-on-template");
+    const { popup_child } = params;
+    const existingPopup = this.openPopupsByName[popup_child];
+    if (existingPopup) {
+      existingPopup.modal.classList.add("hide-popup-on-template");
     } else {
       this.createPopupAndWaitForDismiss(params.popup_child, container);
     }
@@ -274,7 +293,14 @@ export class TemplateNavService {
       templatename: popup_child,
       parent: container,
     };
-    return this.modalCtrl.create({
+    // If trying to recreate a popup that already exists simply mark as visible
+    const existingPopup = this.openPopupsByName[popup_child];
+    if (existingPopup) {
+      existingPopup.modal.classList.remove("hide-popup-on-template");
+      return;
+    }
+
+    const modal = await this.modalCtrl.create({
       component: TemplatePopupComponent,
       componentProps: childContainerProps,
       id: `popup-${popup_child}`,
@@ -282,6 +308,8 @@ export class TemplateNavService {
       cssClass: "template-popup-modal",
       showBackdrop: false,
     });
+    this.openPopupsByName[popup_child] = { modal, props: childContainerProps };
+    return modal;
   }
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Improvements to templating system meant that a single template-nav service is created instead of multiple, which has the knock-on of not correctly dismissing all popups in the case where multiple popups of the same template are created.

This PR adds a tracking variable to the template-nav service to check if a popup already exists before recreating, and just makes visible if that is the case (by default open popups are hidden when navigating to new pages from the popup so that we can restore the popup to pre-nav state when returning to the original page, or reaching it anew via navigation from a->b->c->a.

## Git Issues

Closes #1157

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/149046609-7842c955-462e-4a8f-ad9a-5fb03288d26b.mp4


