### PR TITLE
fix tile image heights

### DIFF
--- a/src/app/shared/components/template/components/tile-component/tile-component.component.scss
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.scss
@@ -28,8 +28,8 @@
       box-shadow: none;
       --ripple-color: transparent;
       img {
-        width: calc(60px * var(--scale-factor-tile));
-        height: calc(60px * var(--scale-factor-tile));
+        width: 60px;
+        height: 60px;
       }
     }
     // Note - CC 2021-12-21 - Currently not in use in any templates, but keeping in case we want
@@ -58,70 +58,36 @@
   flex-direction: column;
   justify-content: space-between;
   width: 8rem;
-  height: 7rem;
+  min-height: 7rem;
   border-radius: var(--ion-border-radius-standard);
   border: var(--ion-border-thin-standard);
   background: var(--ion-color-primary-contrast);
   text-align: center;
   padding: var(--tiny-padding);
   box-shadow: var(--ion-default-box-shadow);
-  @media (max-width: 375px) {
-    width: 7rem;
-    height: 6rem;
-    padding: calc(var(--tiny-padding) * var(--scale-factor-tile));
-    &.default_style {
-      min-height: unset;
-    }
-  }
-  @media (max-width: 320px) {
-    width: 6rem;
-    height: 5rem;
-  }
-  @media (max-width: 319px) {
-    max-width: calc(var(--tile-workshop-page-width) * var(--scale-factor-tile));
-    max-height: calc(var(--tile-workshop-page-height) * var(--scale-factor-tile));
-  }
+
   .button-wrapper {
     order: 1;
     width: 100%;
-    @media (max-width: 320px) {
-      width: unset;
-    }
+
     .btn-tile {
       pointer-events: none;
       border: 0;
-      margin-top: 0;
+      margin: 0;
       --border-radius: unset;
       border-radius: unset;
       width: 100%;
       height: 100%;
-      @media (max-width: 375px) {
-        height: 4rem;
-      }
-      @media (max-width: 320px) {
-        height: 3rem;
-      }
+
       img {
         width: 6rem;
         height: 4.5rem;
-        @media (max-width: 375px) {
-          width: 5.5rem;
-          height: 4rem;
-        }
-        @media (max-width: 320px) {
-          height: 3.5rem;
-        }
-        @media (max-width: 320px) {
-          max-height: calc(4.5rem * var(--scale-factor-tile));
-        }
       }
     }
   }
   .text {
     order: 2;
     div {
-      font-size: calc(var(--font-size-text-small) * var(--scale-factor-tile));
-      line-height: calc(var(--line-height-text-tiny) * var(--scale-factor-tile));
       color: var(--ion-color-primary);
     }
   }
@@ -173,7 +139,7 @@
     order: 1;
     height: auto;
     width: 100%;
-    margin-bottom: calc(10px * var(--scale-factor-tile));
+    margin-bottom: 1em;
     .btn-tile {
       pointer-events: none;
       border: 0;
@@ -188,12 +154,8 @@
     }
   }
   .text {
-    //height: 3rem;
-    //overflow-y: scroll;
     order: 2;
     div {
-      font-size: calc(var(--font-size-text-small) * var(--scale-factor-tile));
-      line-height: calc(var(--line-height-text-tiny) * var(--scale-factor-tile));
       color: var(--ion-color-primary);
       text-align: center;
     }
@@ -203,12 +165,6 @@
 .two_columns {
   &.image_text {
     height: 100%;
-    @media (max-width: 375px) {
-      width: 9rem;
-    }
-    @media (max-width: 325px) {
-      width: 8rem;
-    }
   }
 }
 

--- a/src/app/shared/components/template/components/tile-component/tile-component.component.scss
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.scss
@@ -50,6 +50,8 @@
 
 /***********************************************************************************************
 *     PLH-specific page type stylings
+    TODO - CC 2022-01-13 - Most of this should be reviewed and ideally replaced with more
+    simple components (e.g. display groups)
 ************************************************************************************************/
 .workshop_page {
   display: flex;
@@ -91,8 +93,8 @@
       margin-top: 0;
       --border-radius: unset;
       border-radius: unset;
-      width: calc(var(--tile-workshop-page-button-width) * var(--scale-factor-tile));
-      height: calc(100% * var(--scale-factor-tile));
+      width: 100%;
+      height: 100%;
       @media (max-width: 375px) {
         height: 4rem;
       }

--- a/src/app/shared/components/template/components/tile-component/tile-component.component.ts
+++ b/src/app/shared/components/template/components/tile-component/tile-component.component.ts
@@ -1,7 +1,7 @@
-import { Component, ElementRef, HostBinding, HostListener, OnInit } from "@angular/core";
+import { Component, ElementRef, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { ITemplateRowProps } from "../../models";
-import { getStringParamFromTemplateRow } from "../../../../utils";
+import { getStringParamFromTemplateRow } from "src/app/shared/utils";
 
 @Component({
   selector: "plh-tile-component",
@@ -18,22 +18,14 @@ export class TmplTileComponent extends TemplateBaseComponent implements ITemplat
   icon_result: string;
   is_play_icon: boolean;
   windowWidth: number;
-  scaleFactor: number = 1;
   isCustomIcon: boolean;
-  @HostListener("window:resize", ["$event"]) onResize(event) {
-    this.windowWidth = event.target.innerWidth - 10;
-    this.getScaleFactor();
-  }
-  @HostBinding("style.--scale-factor-tile") get scale() {
-    return this.scaleFactor;
-  }
+
   constructor(private elRef: ElementRef) {
     super();
   }
 
   ngOnInit() {
     this.getParams();
-    this.getScaleFactor();
   }
 
   getParams() {
@@ -76,13 +68,5 @@ export class TmplTileComponent extends TemplateBaseComponent implements ITemplat
 
   isPlayIcon(iconSrc: string): boolean {
     if (iconSrc) return iconSrc.includes("play");
-  }
-
-  getScaleFactor(): number {
-    this.scaleFactor =
-      this.windowWidth / (this.isParentPoint() ? 470 : 400) > 1
-        ? 1
-        : this.windowWidth / (((this.isParentPoint() ? 220 : 200) + 20) * 2);
-    return this.scaleFactor;
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
The code used to display workshop tiles contains a lot of hardcoded styles which are unmaintainable and leading to some confusing behaviours. 

This PR removes all styles related to changing screen size breakpoints (which are yet to be consistently defined across the app) and auto text size scaling based on screen width (which is just a bad idea). It also removes some of the fixed heights which will cut off content when not fitting perfectly, although means that not all the tiles will stay the same height if text is longer in one than the other (previously heights stayed fixed but text scaled to fit outside the box, which is also not good)

## Review Notes
On first glance it appears to make content display better across screen sizes, although I'm basing this just on the `debug_dg_tile` and `weekly_workshop` templates so not sure if there's other templates which have additional custom styles applied for the tiles.

If this is the case it will probably be better to rework tiles more generally and display in a grid format (as I did for parent points and parent library pages)

## Git Issues

Closes #1162

## Screenshots/Videos

Debug template on different screen sizes, starting at 320px (which should be considered absolute minimum for any mobile device)

https://user-images.githubusercontent.com/10515065/149447717-5f025417-a660-4384-847f-765ed1d7b753.mp4

https://user-images.githubusercontent.com/10515065/149448153-3c2dae4d-c93e-499b-8d1a-14672f700372.mp4


