### PR TITLE
Fix/nav group layout

### DIFF
--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -8,29 +8,32 @@ import { TemplateFieldService } from "../../services/template-field.service";
 @Component({
   selector: "plh-tmpl-nav-group",
   animations: PLHAnimations.fadeEntryExit,
-  template: ` <div class="nav-group">
+  template: `
     <div class="nav-progress">
       <div
         *ngFor="let templateName of templateNames; index as i"
         class="nav-progress-part"
-        [ngClass]="{ seen: i <= sectionIndex }"
+        [attr.data-seen]="i <= sectionIndex ? true : null"
         (click)="goToSection(i)"
       ></div>
     </div>
-    <ng-template ngFor let-i="index" let-templateName [ngForOf]="templateNames">
-      <div class="nav-section" [class.selected]="sectionIndex === i">
-        <div *ngIf="sectionIndex === i" @fadeEntryExit>
-          <plh-template-container
-            [name]="templateName"
-            [templatename]="templateName"
-            [parent]="parent"
-            [row]="containerRow"
-          >
-          </plh-template-container>
-        </div>
-      </div>
-    </ng-template>
-  </div>`,
+    <!-- Render placeholders for each section but omit content -->
+    <div
+      *ngFor="let templateName of templateNames; index as i"
+      class="nav-section"
+      [attr.data-selected]="sectionIndex === i ? true : null"
+    >
+      <plh-template-container
+        *ngIf="sectionIndex === i"
+        [name]="templateName"
+        [templatename]="templateName"
+        [parent]="parent"
+        [row]="containerRow"
+        @fadeEntryExit
+      >
+      </plh-template-container>
+    </div>
+  `,
   styles: [
     `
       :host {
@@ -38,35 +41,22 @@ import { TemplateFieldService } from "../../services/template-field.service";
         display: flex;
         flex-direction: column;
       }
-
-      .slide {
-        width: 95vw;
-      }
-
-      .nav-group {
-        flex: 1;
-      }
-
-      .nav-buttons {
-        width: 100%;
+      .nav-section {
         display: flex;
-        justify-content: center;
-        flex-wrap: wrap;
+        flex-direction: column;
+        position: relative;
+        /* sections not active are kept off-screen to avoid content height jump */
+        right: 100vw;
       }
-
-      .selected {
-        height: 100%;
+      .nav-section[data-selected] {
+        flex: 1;
+        right: unset;
       }
-
       .nav-progress {
         display: flex;
         flex-direction: row;
         justify-content: space-evenly;
-        padding: var(--small-padding) 0;
-      }
-
-      .nav-section :nth-child(1) {
-        height: 100%;
+        padding-bottom: 1em;
       }
 
       .nav-progress-part {
@@ -78,7 +68,7 @@ import { TemplateFieldService } from "../../services/template-field.service";
         max-width: 40px;
       }
 
-      .nav-progress-part.seen {
+      .nav-progress-part[data-seen] {
         background-color: var(--ion-primary-color, #f88923);
       }
 

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -56,7 +56,7 @@ import { TemplateFieldService } from "../../services/template-field.service";
         display: flex;
         flex-direction: row;
         justify-content: space-evenly;
-        padding-bottom: 1em;
+        padding: 1em 0;
       }
 
       .nav-progress-part {

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -71,11 +71,6 @@ import { TemplateFieldService } from "../../services/template-field.service";
       .nav-progress-part[data-seen] {
         background-color: var(--ion-primary-color, #f88923);
       }
-
-      ion-button {
-        --border-radius: 20px;
-        --background: linear-gradient(to bottom, #ffb833 28.12%, #f88923 100%);
-      }
     `,
   ],
 })


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Nav groups have fixed 100% height values which can stretch to fit too much space when specific components have margins and/or padding applied. This pr replaces fixed height layouts with flex layout, set to expand to fill available space.

It also removes various pieces of outdated code and tidies what is left.

## Git Issues

Closes #1163

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/149459576-5e123c04-cb3b-493d-bed1-8c6bd060ba0f.png)

