### PR TITLE
fix gdrive download filter

### DIFF
--- a/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
+++ b/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
@@ -146,10 +146,13 @@ class GDriveDownloader {
   private writeCacheContentsFile(files: IGDriveFileWithFolder[]) {
     const { cachePath } = this.options;
     // also add a relativePath for full path to local file
-    const filesWithRelativePath = files.map((f) => ({
-      ...f,
-      relativePath: getRelativeLocalPath(f),
-    }));
+    const filesWithRelativePath = files
+      .map((f) => ({
+        ...f,
+        relativePath: getRelativeLocalPath(f),
+      }))
+      // only include files downloaded in contents
+      .filter((f) => fs.existsSync(path.resolve(cachePath, f.relativePath)));
     const contents = JSON.stringify(filesWithRelativePath, null, 2);
     const contentsPath = path.resolve(cachePath, this.options.contentsFileName);
     fs.writeFileSync(contentsPath, contents);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

hotfix to prevent google drive keeping ignored assets in contents (avoid trying to copy missing file in later processing step)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
