### PR TITLE
Feat/accordion component

### DIFF
--- a/packages/app-data/data/template/index.ts
+++ b/packages/app-data/data/template/index.ts
@@ -1,9 +1,11 @@
 import { FlowTypes } from "data-models";
 import template_component_demo from "./template.component_demo";
 import template_debug from "./template.debug";
-import template_2 from "./template";
+import template_debug_accordion from "./template.debug_accordion";
+import template_3 from "./template";
 export const template: FlowTypes.Template[] = [].concat(
   template_component_demo,
   template_debug,
-  template_2
+  template_debug_accordion,
+  template_3
 );

--- a/packages/app-data/data/template/template.debug_accordion.ts
+++ b/packages/app-data/data/template/template.debug_accordion.ts
@@ -1,0 +1,487 @@
+/* eslint-disable */
+import { FlowTypes } from "data-models";
+const template: FlowTypes.Template[] = [
+  {
+    flow_type: "template",
+    flow_name: "example_accordion",
+    status: "released",
+    flow_subtype: "debug_accordion",
+    rows: [
+      {
+        name: "title_1",
+        value: "First title",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "title_1",
+      },
+      {
+        name: "text_1",
+        value: "Text 1",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "text_1",
+      },
+      {
+        name: "title_2",
+        value: "Second title",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "title_2",
+      },
+      {
+        name: "text_2",
+        value: "Text 2",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "text_2",
+      },
+      {
+        name: "button_text_2",
+        value: "Button text 2",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "button_text_2",
+      },
+      {
+        name: "title_3",
+        value: "Third title",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "title_3",
+      },
+      {
+        name: "text_3",
+        value: "Text 3",
+        _translations: {
+          value: {},
+        },
+        type: "set_variable",
+        _nested_name: "text_3",
+      },
+      {
+        type: "title",
+        name: "section_1",
+        value: "Example - open multiple, custom icon",
+        _translations: {
+          value: {},
+        },
+        _nested_name: "section_1",
+      },
+      {
+        type: "accordion",
+        name: "accordion",
+        parameter_list: {
+          open_icon_src: "add",
+          close_icon_src: "remove",
+          openMultiple: "true",
+        },
+        rows: [
+          {
+            type: "accordion_section",
+            name: "first",
+            value: "@local.title_1",
+            parameter_list: {
+              state: "open",
+            },
+            rows: [
+              {
+                type: "template",
+                name: "template_1",
+                value: "example_text",
+                rows: [
+                  {
+                    name: "text",
+                    value: "@local.text_1",
+                    _translations: {
+                      value: {},
+                    },
+                    type: "set_variable",
+                    _nested_name: "accordion.first.template_1.text",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.text_1",
+                          matchedExpression: "@local.text_1",
+                          type: "local",
+                          fieldName: "text_1",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.text_1": ["value"],
+                    },
+                  },
+                ],
+                _nested_name: "accordion.first.template_1",
+              },
+            ],
+            _nested_name: "accordion.first",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_1",
+                  matchedExpression: "@local.title_1",
+                  type: "local",
+                  fieldName: "title_1",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_1": ["value"],
+            },
+          },
+          {
+            type: "accordion_section",
+            name: "second",
+            value: "@local.title_2",
+            rows: [
+              {
+                type: "template",
+                name: "template_2",
+                value: "example_text_button",
+                rows: [
+                  {
+                    name: "text",
+                    value: "@local.text_2",
+                    _translations: {
+                      value: {},
+                    },
+                    type: "set_variable",
+                    _nested_name: "accordion.second.template_2.text",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.text_2",
+                          matchedExpression: "@local.text_2",
+                          type: "local",
+                          fieldName: "text_2",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.text_2": ["value"],
+                    },
+                  },
+                  {
+                    name: "button",
+                    value: "@local.button_text_2",
+                    _translations: {
+                      value: {},
+                    },
+                    action_list: [
+                      {
+                        trigger: "click",
+                        action_id: "pop_up",
+                        args: ["example_text"],
+                        _raw: "click | pop_up: example_text",
+                        _cleaned: "click | pop_up: example_text",
+                      },
+                    ],
+                    type: "set_variable",
+                    _nested_name: "accordion.second.template_2.button",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.button_text_2",
+                          matchedExpression: "@local.button_text_2",
+                          type: "local",
+                          fieldName: "button_text_2",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.button_text_2": ["value"],
+                    },
+                  },
+                ],
+                _nested_name: "accordion.second.template_2",
+              },
+            ],
+            _nested_name: "accordion.second",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_2",
+                  matchedExpression: "@local.title_2",
+                  type: "local",
+                  fieldName: "title_2",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_2": ["value"],
+            },
+          },
+          {
+            type: "accordion_section",
+            name: "third",
+            value: "@local.title_3",
+            rows: [
+              {
+                type: "text",
+                name: "text",
+                value: "@local.text_3",
+                _translations: {
+                  value: {},
+                },
+                _nested_name: "accordion.third.text",
+                _dynamicFields: {
+                  value: [
+                    {
+                      fullExpression: "@local.text_3",
+                      matchedExpression: "@local.text_3",
+                      type: "local",
+                      fieldName: "text_3",
+                    },
+                  ],
+                },
+                _dynamicDependencies: {
+                  "@local.text_3": ["value"],
+                },
+              },
+              {
+                type: "image",
+                name: "image",
+                value: "plh_images/workshops/w_rules/read_1/slide_4.svg",
+                _translations: {
+                  value: {},
+                },
+                _nested_name: "accordion.third.image",
+              },
+            ],
+            _nested_name: "accordion.third",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_3",
+                  matchedExpression: "@local.title_3",
+                  type: "local",
+                  fieldName: "title_3",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_3": ["value"],
+            },
+          },
+        ],
+        _nested_name: "accordion",
+      },
+      {
+        type: "title",
+        name: "section_2",
+        value: "Example - default settings",
+        _translations: {
+          value: {},
+        },
+        _nested_name: "section_2",
+      },
+      {
+        type: "accordion",
+        name: "accordion",
+        rows: [
+          {
+            type: "accordion_section",
+            name: "first",
+            value: "@local.title_1",
+            rows: [
+              {
+                type: "template",
+                name: "template_1",
+                value: "example_text",
+                rows: [
+                  {
+                    name: "text",
+                    value: "@local.text_1",
+                    _translations: {
+                      value: {},
+                    },
+                    type: "set_variable",
+                    _nested_name: "accordion.first.template_1.text",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.text_1",
+                          matchedExpression: "@local.text_1",
+                          type: "local",
+                          fieldName: "text_1",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.text_1": ["value"],
+                    },
+                  },
+                ],
+                _nested_name: "accordion.first.template_1",
+              },
+            ],
+            _nested_name: "accordion.first",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_1",
+                  matchedExpression: "@local.title_1",
+                  type: "local",
+                  fieldName: "title_1",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_1": ["value"],
+            },
+          },
+          {
+            type: "accordion_section",
+            name: "second",
+            value: "@local.title_2",
+            rows: [
+              {
+                type: "template",
+                name: "template_2",
+                value: "example_text_button",
+                rows: [
+                  {
+                    name: "text",
+                    value: "@local.text_2",
+                    _translations: {
+                      value: {},
+                    },
+                    type: "set_variable",
+                    _nested_name: "accordion.second.template_2.text",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.text_2",
+                          matchedExpression: "@local.text_2",
+                          type: "local",
+                          fieldName: "text_2",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.text_2": ["value"],
+                    },
+                  },
+                  {
+                    name: "button",
+                    value: "@local.button_text_2",
+                    _translations: {
+                      value: {},
+                    },
+                    action_list: [
+                      {
+                        trigger: "click",
+                        action_id: "pop_up",
+                        args: ["example_text"],
+                        _raw: "click | pop_up: example_text",
+                        _cleaned: "click | pop_up: example_text",
+                      },
+                    ],
+                    type: "set_variable",
+                    _nested_name: "accordion.second.template_2.button",
+                    _dynamicFields: {
+                      value: [
+                        {
+                          fullExpression: "@local.button_text_2",
+                          matchedExpression: "@local.button_text_2",
+                          type: "local",
+                          fieldName: "button_text_2",
+                        },
+                      ],
+                    },
+                    _dynamicDependencies: {
+                      "@local.button_text_2": ["value"],
+                    },
+                  },
+                ],
+                _nested_name: "accordion.second.template_2",
+              },
+            ],
+            _nested_name: "accordion.second",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_2",
+                  matchedExpression: "@local.title_2",
+                  type: "local",
+                  fieldName: "title_2",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_2": ["value"],
+            },
+          },
+          {
+            type: "accordion_section",
+            name: "third",
+            value: "@local.title_3",
+            rows: [
+              {
+                type: "text",
+                name: "text",
+                value: "@local.text_3",
+                _translations: {
+                  value: {},
+                },
+                _nested_name: "accordion.third.text",
+                _dynamicFields: {
+                  value: [
+                    {
+                      fullExpression: "@local.text_3",
+                      matchedExpression: "@local.text_3",
+                      type: "local",
+                      fieldName: "text_3",
+                    },
+                  ],
+                },
+                _dynamicDependencies: {
+                  "@local.text_3": ["value"],
+                },
+              },
+              {
+                type: "image",
+                name: "image",
+                value: "plh_images/workshops/w_rules/read_1/slide_4.svg",
+                _translations: {
+                  value: {},
+                },
+                _nested_name: "accordion.third.image",
+              },
+            ],
+            _nested_name: "accordion.third",
+            _dynamicFields: {
+              value: [
+                {
+                  fullExpression: "@local.title_3",
+                  matchedExpression: "@local.title_3",
+                  type: "local",
+                  fieldName: "title_3",
+                },
+              ],
+            },
+            _dynamicDependencies: {
+              "@local.title_3": ["value"],
+            },
+          },
+        ],
+        _nested_name: "accordion",
+      },
+    ],
+    _xlsxPath: "quality_assurance/example_templates/example_accordion.xlsx",
+  },
+];
+export default template;

--- a/packages/app-data/data/template/template.debug_accordion.ts
+++ b/packages/app-data/data/template/template.debug_accordion.ts
@@ -85,7 +85,7 @@ const template: FlowTypes.Template[] = [
         parameter_list: {
           open_icon_src: "add",
           close_icon_src: "remove",
-          openMultiple: "true",
+          open_multiple: "true",
         },
         rows: [
           {

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -329,6 +329,7 @@ export namespace FlowTypes {
   }
 
   export type TemplateRowType =
+    | "accordion"
     | "image"
     | "title"
     | "subtitle"

--- a/src/app/shared/components/template/components/accordion/accordion.component.html
+++ b/src/app/shared/components/template/components/accordion/accordion.component.html
@@ -1,0 +1,48 @@
+<ion-accordion-group
+  [multiple]="_row.parameter_list?.openMultiple"
+  [value]="openSections"
+  #accordionGroup
+>
+  <ion-accordion
+    [value]="childRow.name"
+    *ngFor="let childRow of _row.rows; index as i"
+    toggle-icon="arrow-down-circle"
+    [style.z-index]="_row.rows.length - i"
+  >
+    <ion-item slot="header" class="accordion-header clear" lines="none">
+      <ion-label class="accordion-section-title">{{ childRow.value || "" }}</ion-label>
+      <!-- If custom icon supplied override. Otherwise default will be arrow -->
+      <ng-template [ngIf]="_row.parameter_list?.open_icon_src" let-open_icon_src="ngIf">
+        <ng-container
+          [ngTemplateOutlet]="customIcon"
+          [ngTemplateOutletContext]="{open_icon_src,  childRow }"
+        ></ng-container>
+      </ng-template>
+    </ion-item>
+    <!-- Accordion section Content -->
+    <ion-item slot="content" class="accordion-content clear" lines="none">
+      <plh-template-component
+        *ngFor="let contentRow of childRow.rows | filterDisplayComponent"
+        [row]="contentRow"
+        [parent]="parent"
+        [attr.data-rowname]="contentRow.name"
+      >
+      </plh-template-component>
+    </ion-item>
+  </ion-accordion>
+</ion-accordion-group>
+
+<!-- 
+    Template for custom icon - extracted from main inline block as a bit messy 
+    override default icon to replace with empty class and toggle depending on open state 
+-->
+<ng-template #customIcon let-open_icon_src="open_icon_src" let-childRow="childRow">
+  <div class="ion-accordion-toggle-icon"></div>
+  <ion-icon
+    [name]="
+      childRow && accordionGroup.value.indexOf(childRow.name) === -1
+        ? open_icon_src
+        : _row.parameter_list.close_icon_src
+    "
+  ></ion-icon>
+</ng-template>

--- a/src/app/shared/components/template/components/accordion/accordion.component.html
+++ b/src/app/shared/components/template/components/accordion/accordion.component.html
@@ -1,5 +1,5 @@
 <ion-accordion-group
-  [multiple]="_row.parameter_list?.openMultiple"
+  [multiple]="_row.parameter_list?.open_multiple"
   [value]="openSections"
   #accordionGroup
 >

--- a/src/app/shared/components/template/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/template/components/accordion/accordion.component.scss
@@ -7,6 +7,7 @@ ion-accordion {
   border-radius: 10px;
   margin-top: -12px;
   padding-top: 8px;
+  box-shadow: var(--ion-default-box-shadow);
 }
 ion-accordion:first-of-type {
   margin-top: unset;

--- a/src/app/shared/components/template/components/accordion/accordion.component.scss
+++ b/src/app/shared/components/template/components/accordion/accordion.component.scss
@@ -1,0 +1,21 @@
+@import "/src/theme/variables.scss";
+
+// Create overlapping effect
+ion-accordion {
+  background: white;
+  border: 1px solid $primary;
+  border-radius: 10px;
+  margin-top: -12px;
+  padding-top: 8px;
+}
+ion-accordion:first-of-type {
+  margin-top: unset;
+  padding-top: unset;
+}
+ion-label.accordion-section-title {
+  color: $primary;
+  font-size: 1.3rem;
+}
+ion-item.accordion-content {
+  padding-bottom: 1rem;
+}

--- a/src/app/shared/components/template/components/accordion/accordion.component.ts
+++ b/src/app/shared/components/template/components/accordion/accordion.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from "@angular/core";
+import { TemplateBaseComponent } from "../base";
+
+@Component({
+  selector: "plh-accordion-component",
+  templateUrl: "accordion.component.html",
+  styleUrls: ["./accordion.component.scss"],
+})
+export class TmplAccordionComponent extends TemplateBaseComponent implements OnInit {
+  public openSections = [];
+  ngOnInit() {
+    // Initial list of section with state === 'open' must be calculated to provider open value
+    this.openSections = this._row.rows
+      .filter((childRow) => childRow.parameter_list?.state === "open")
+      .map((childRow) => childRow.name);
+  }
+}

--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -46,6 +46,7 @@ import { TmplLottieAnimation } from "./lottie-animation";
 import { PLHDebugToggleComponent } from "../../debug-toggle";
 import { SelectTextComponent } from "./select-text/select-text.component";
 import { TemplateHTMLComponent } from "./html/html.component";
+import { TmplAccordionComponent } from "./accordion/accordion.component";
 
 /** All components should be exported as a single array for easy module import */
 export const TEMPLATE_COMPONENTS = [
@@ -89,6 +90,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplLottieAnimation,
   SelectTextComponent,
   TemplateHTMLComponent,
+  TmplAccordionComponent,
 ];
 
 /***************************************************************************************
@@ -99,6 +101,7 @@ export const TEMPLATE_COMPONENT_MAPPING: Record<
   FlowTypes.TemplateRowType,
   Type<ITemplateRowProps>
 > = {
+  accordion: TmplAccordionComponent,
   text: TmplTextComponent,
   title: TmplTitleComponent,
   subtitle: TmplSubtitleComponent,


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add accordion component
- Update debug template to include standard and fully customised versions

## Author Notes
A few minor alterations were made to the proposed syntax, see comments in purple
https://docs.google.com/spreadsheets/d/1gfnWmr59DF0ZsuSuBh0K1o9fMqEg-z6Qa7eJNsiB-rQ/edit#gid=63099847

I haven't included any documentation for the new component, should ideally be done once finalised

## Review Notes
Have included the updated accordion debug sheet in this PR to allow preview. Flow subtype can be reverted back to `debug` when next updating content.

Code makes no changes to any other parts of the codebase so additional testing not required

## Dev Notes
The accordion component use new `accordion` block and does not attempt to reuse the existing workshop_accordion (judged not worth the effort). However, both the workshop and new accordion use the same component type to define nested children as `accordion_section`. The workshop component creates a second component to handle this, but the new accordion component just renders the nested content directly instead (assumes all direct children of accordion elements will be accordion sections)

This means that for now we are fine with the naming conflict, however if we ever decide to remove/refactor the workshop accordion we will need to remember to leave a blank placeholder to still allow the accordion_section type column (simply as a means of grouping child content in the accordion).

## Git Issues

Closes #1115

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/150464766-4531c4ea-b825-4dd8-b0e0-924c17731bf8.mp4


