### PR TITLE
feat: add appetize gh action

### DIFF
--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -8,7 +8,7 @@ on:
       - master
 jobs:
   build:
-    if: contains(github.event.pull_request.labels.*.name, 'Test - device appetize')
+    if: contains(github.event.pull_request.labels.*.name, 'Test - appetize')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -52,13 +52,16 @@ jobs:
         working-directory: android
         run: ./gradlew :app:assembleDebug
       - name: Upload to Appetize.io
+        id: upload
         uses: maxep/appetize-upload-action@0.1.0
         with:
           api-token: ${{ secrets.APPETIZE_TOKEN }}
           file-path: android/app/build/outputs/apk/debug/app-debug.apk
           platform: "android"
-      - name: Upload to Appetize.io
+      - name: Log outputs
         run: |
-          echo $APP_URL
+          echo $APP_URL;
+          echo $OUTPUTS;
         env:
           APP_URL: ${{steps.upload.outputs.APPETIZE_APP_URL}}
+          OUTPUTS: ${{join(steps.upload.outputs.*, '\n')}}

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -1,0 +1,59 @@
+# Manually trigger an android build and deploy to Appetize.io
+
+name: Test Appetize
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    branches:
+      - master
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'Test - device appetize')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: ./.yarn/cache
+          # If cachebusting required (e.g. breaking yarn changes on update) change `v1` to another number
+          key: ${{ runner.os }}-node-modules-yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v1-
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+      - name: Populate firebaseConfig.ts
+        env:
+          FIREBASE_CONFIG_TS: ${{ secrets.FIREBASE_CONFIG_TS }}
+        run: echo $FIREBASE_CONFIG_TS > src/environments/firebaseConfig.ts
+      - name: Populate google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo $GOOGLE_SERVICES_JSON > android/app/google-services.json
+      - name: Install Dependencies
+        run: yarn install
+      - name: Build Angular Project
+        run: yarn build
+      - name: Sync Android Files
+        run: npx cap sync
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+      - name: Build Android Debug APK
+        working-directory: android
+        run: ./gradlew :app:assembleDebug
+      - name: Upload to Appetize.io
+        uses: maxep/github-action-appetize@0.1.0
+        with:
+          api-token: ${{ secrets.APPETIZE_TOKEN }}
+          file-path: android/app/build/outputs/apk/debug/app-debug.apk
+          platform: "android"

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -59,11 +59,11 @@ jobs:
           file-path: android/app/build/outputs/apk/debug/app-debug.apk
           platform: "android"
           timeout: 30
-          # Include to overwrite existing app instead of creating new
+          # Include to overwrite existing app instead of creating new (will only allow single build at a time)
           public-key: ${{secrets.APPETIZE_APP_KEY}}
       - name: "Post to PR"
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
             **Android Appetize URL**
-            ${{ steps.upload.outputs.APPETIZE_APP_URL }}
+            ${{ steps.upload.outputs.APPETIZE_APP_URL }}?device=nexus5&osVersion=10.0&scale=75

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 jobs:
+  log_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Labels ${{github.event.pull_request.labels}}"
   build:
     if: contains(github.event.pull_request.labels.*.name, 'Test - appetize')
     runs-on: ubuntu-latest

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -58,10 +58,12 @@ jobs:
           api-token: ${{ secrets.APPETIZE_TOKEN }}
           file-path: android/app/build/outputs/apk/debug/app-debug.apk
           platform: "android"
-      - name: Log outputs
-        run: |
-          echo $APP_URL;
-          echo $OUTPUTS;
-        env:
-          APP_URL: ${{steps.upload.outputs.APPETIZE_APP_URL}}
-          OUTPUTS: ${{join(steps.upload.outputs.*, '\n')}}
+          timeout: 30
+          # Include to overwrite existing app instead of creating new
+          public-key: ${{secrets.APPETIZE_APP_KEY}}
+      - name: "Post to PR"
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            **Android Appetize URL**
+            ${{ steps.upload.outputs.APPETIZE_APP_URL }}

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -57,3 +57,8 @@ jobs:
           api-token: ${{ secrets.APPETIZE_TOKEN }}
           file-path: android/app/build/outputs/apk/debug/app-debug.apk
           platform: "android"
+      - name: Upload to Appetize.io
+        run: |
+          echo $APP_URL
+        env:
+          APP_URL: ${{steps.upload.outputs.APPETIZE_APP_URL}}

--- a/.github/workflows/test-appetize.yml
+++ b/.github/workflows/test-appetize.yml
@@ -7,10 +7,6 @@ on:
     branches:
       - master
 jobs:
-  log_labels:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Labels ${{github.event.pull_request.labels}}"
   build:
     if: contains(github.event.pull_request.labels.*.name, 'Test - appetize')
     runs-on: ubuntu-latest
@@ -56,7 +52,7 @@ jobs:
         working-directory: android
         run: ./gradlew :app:assembleDebug
       - name: Upload to Appetize.io
-        uses: maxep/github-action-appetize@0.1.0
+        uses: maxep/appetize-upload-action@0.1.0
         with:
           api-token: ${{ secrets.APPETIZE_TOKEN }}
           file-path: android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds a github action to generate an android build and deploy to appetize.io for testing on a web-based android emulator.

## Review Notes
Adding the label `Test - appetize` will trigger the process. This usually takes around 5-10 minutes and a preview URL will be recorded in the pr comments section.

The workflow is currently configured so that ONLY 1 build will be available at a time. That means if the label is added to multiple PRs only the one most recently updated will be the live build (the same URL will be shared for both). 

For testing, appetize.io provide a free tier that allows 100 minutes per month. I've used my own personal account/key for now, but in the future we should create a new account for the project and change the key.

The app does not appear to work on the emulator android 8.1 or 9 (works on local emulator so assume issue with version of chrome/webview installed on the emulators), and so by default the URL points to an emulator running android 10

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/150627211-043a9d26-6ce1-4271-8b65-06e6195cdd64.mp4


