### PR TITLE
chore: rename click_action_list to action_list

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -205,7 +205,7 @@ export namespace FlowTypes {
     campaign_list: string[]; // ids of campaigns where to run
     priority?: number; // higher numbers will be given more priority
     // additional fields for current data_list but not required
-    click_action_list?: TemplateRowAction[];
+    action_list?: TemplateRowAction[];
     icon?: string;
     text?: string;
     // placeholder for any extra fields to be added

--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -38,7 +38,7 @@ export default program
 
 class AppDataConverter {
   /** Change version to invalidate any cached conversions */
-  public converterVersion = 1;
+  public converterVersion = 1.1;
 
   private activeDeployment = getActiveDeployment();
   private paths = {

--- a/packages/scripts/src/commands/app-data/convert/parsers/default/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/parsers/default/default.parser.ts
@@ -83,6 +83,15 @@ export class DefaultParser implements AbstractParser {
       if (field.startsWith("comment")) {
         delete row[field];
       }
+      // rename legacy fields
+      if (LEGACY_FIELD_RENAME.hasOwnProperty(field)) {
+        const replacement = LEGACY_FIELD_RENAME[field];
+        const warning = `[${field}] is deprecated and should be replaced with [${replacement}]`;
+        console.warn(chalk.gray(warning));
+        row[replacement] = JSON.parse(JSON.stringify(row[field]));
+        delete row[field];
+        field = replacement;
+      }
       // replace any self references, i.e "hello @row.id" => "hello some_id", @row.text::eng
       // TODO - should find better long term option that can update based on dynamic value and translations
       if (typeof row[field] === "string") {
@@ -135,6 +144,7 @@ export class DefaultParser implements AbstractParser {
           row[field] = parseAppDateValue(row[field]);
         }
       }
+
       // assign default translation and track as metadata
       if (isTranslateField) {
         row["_translatedFields"] = {
@@ -224,3 +234,7 @@ function throwRowParseError(error: Error, row: IRowData) {
   // add more context to error
   throw error;
 }
+
+const LEGACY_FIELD_RENAME = {
+  click_action_list: "action_list",
+};

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -101,14 +101,14 @@ export class CampaignService {
    * Utilise template services to process campaign actions
    */
   public async triggerRowActions(row: FlowTypes.Campaign_listRow) {
-    if (row.click_action_list) {
+    if (row.action_list) {
       // make a dynamic call to TemplateVariablesService as it also has handling
       // for @campaigns which would otherwise result in cyclic dependency in constructor
       const templateVariablesService = this.injector.get(TemplateVariablesService);
 
       // Process any dynamic variables that might be present in args
       const parsedActions = [];
-      for (const action of row.click_action_list) {
+      for (const action of row.action_list) {
         action.args = await Promise.all(
           action.args.map(
             async (arg) => await templateVariablesService.evaluateConditionString(arg)

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
@@ -74,7 +74,7 @@ export class CampaignDebugPage implements OnInit {
    *
    * @param row
    * TODO - find better way to link with template actions
-   * TODO - find way to identify any named action list (not just click_action_list)
+   * TODO - find way to identify any named action list (not just action_list)
    */
   public async triggerRowActions(row: FlowTypes.Campaign_listRow) {
     await this.campaignService.triggerRowActions(row);

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-debug-row.ts
@@ -12,12 +12,12 @@ import { FlowTypes } from "src/app/shared/model";
         <!-- Info -->
         <div style="flex:1">
           <!-- Click Action List -->
-          <div *ngIf="row.click_action_list && row.click_action_list.length > 0">
+          <div *ngIf="row.action_list && row.action_list.length > 0">
             <div class="divider"></div>
             <h4>Click Action List</h4>
             <div style="display: flex" class="info-text">
               <div style="flex: 1">
-                <div *ngFor="let action of row.click_action_list">{{ action._raw }}</div>
+                <div *ngFor="let action of row.action_list">{{ action._raw }}</div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Following comments in #1193, added a `LEGACY_FIELD_RENAME` to the default parser that can be used to convert all fields named one thing to another as a means to temporarily support both while deprecating legacy field names. This is currently set to rename any `click_action_list` to `action_list`.

## Author Notes
We don't have a fixed date for removing support (expect won't be any time soon), but recommend renaming click_action_list to action_list on at least the main example/debug sheets at first so that anyone using or modifying them has the correct column names.

There are a limited number of cases where this will not run, searching the codebase for `click_action_list` after implementing the changes shows a handful of debug sheets where the field is referred to as dynamic text. These will need to be updated once merged.

![image](https://user-images.githubusercontent.com/10515065/150834194-f80ca5fe-509b-4a97-8508-c2de6c0cf143.png)

## Review Notes
The easiest time to review will be just after content merge so that the only changes seen will be from the script updates and not just from new/edited forms. 

## Git Issues

Closes #

## Screenshots/Videos

Small warning message displayed in parser. Eventually we will want to better collate these and present an overall summary at the end (possibly as linked json file)
![image](https://user-images.githubusercontent.com/10515065/150834435-1de9180c-43c4-457e-833a-a3766c1661d1.png)

