### PR TITLE
fix(1199): injected translate service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ import { AnalyticsService } from "./shared/services/analytics/analytics.service"
 import { LocalNotificationService } from "./shared/services/notification/local-notification.service";
 import { APP_INITIALISATION_DEFAULTS, APP_SIDEMENU_DEFAULTS } from "packages/data-models/constants";
 import { TemplateFieldService } from "./shared/components/template/services/template-field.service";
+import { TemplateTranslateService } from "./shared/components/template/services/template-translate.service";
 
 @Component({
   selector: "app-root",
@@ -54,6 +55,7 @@ export class AppComponent {
     private dataEvaluationService: DataEvaluationService,
     private analyticsService: AnalyticsService,
     private localNotificationService: LocalNotificationService,
+    private templateTranslateService: TemplateTranslateService,
     /** Inject in the main app component to start tracking actions immediately */
     public taskActions: TaskActionService,
     public serverService: ServerService
@@ -104,6 +106,7 @@ export class AppComponent {
     await this.appEventService.init();
     await this.serverService.init();
     await this.dataEvaluationService.refreshDBCache();
+    await this.templateTranslateService.init();
     await this.templateService.init();
     await this.templateProcessService.init();
     await this.localNotificationService.init();

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -48,6 +48,7 @@ export class TemplateActionService extends TemplateInstanceService {
     this.templateService = this.getGlobalService(TemplateService);
     this.tourService = this.getGlobalService(TourService);
     this.templateFieldService = this.getGlobalService(TemplateFieldService);
+    this.templateTranslateService = this.getGlobalService(TemplateTranslateService);
     this.eventService = this.getGlobalService(EventService);
   }
 

--- a/src/app/shared/components/template/services/instance/template-instance.service.ts
+++ b/src/app/shared/components/template/services/instance/template-instance.service.ts
@@ -5,6 +5,10 @@ export class TemplateInstanceService {
   constructor(public injector: Injector) {}
 
   getGlobalService<T>(token: ProviderToken<T>) {
-    return this.injector.get(token);
+    const service = this.injector.get(token);
+    if (!service) {
+      console.warn("Global service requested but not found", token);
+    }
+    return service;
   }
 }

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -32,6 +32,8 @@ export class TemplateTranslateService {
       this.setLanguage(DEFAULT_LANGUAGE, true);
     }
   }
+  // Init handled in constructor, but kept here as reminder to import/call from main app component
+  public async init() {}
 
   get app_language() {
     return this.app_language$.value;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Following previous core template service refactor the translate service was no longer included with the action service, breaking the language select sheet. Fixes the issue and attempts to add an additional warning to help catch some similar issues in the future.

## Review Notes
Minor fix working locally for me. I'm also tempted to suggest this might be the time to create another issue to add some more basic end-to-end tests that automate a few core functions and cover a reasonable amount of our manual testing strategy to make sure they always work. E.g. start app, select language, navigate to specific template, open popup, click button etc.

We already have a large part of the core in place needed for this so would hope it would only be a day or so's work to add some specific testing and action integration. We could also consider creating a small syntax for authoring explicit testing templates that cover similar case (e.g. adding a `test_step` row type alongside existing action list to manage `go_to`, `click` etc.).

## Git Issues

Closes #1199

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/150842617-8466a5b0-56ef-403f-b48f-b4ec39c11fdc.mp4

