### PR TITLE
styles: reduce banner_short margin

### DIFF
--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -85,10 +85,10 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style="parent_point"] {
   background: var(--ion-color-primary-contrast);
 }
 .display-group-wrapper[data-param-style="banner_short"] {
-  margin-top: var(--regular-margin);
+  margin-top: var(--small-margin);
   border-radius: var(--ion-border-radius-secondary);
   width: 100%;
-  margin-bottom: var(--largest-margin) !important;
+  margin-bottom: var(--small-margin) !important;
   padding: 0 var(--large-padding);
   background: var(--ion-dg-bg-default);
   height: var(--banner-short-height);


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Reduce default margins in banner_short to _small_ (previously was top _regular_ and bottom _largest_). Any further reduction will require authoring fix as described in issue comment

## Git Issues

Closes #1175

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/150853349-d12b6f43-5199-4ded-8dc9-fca57743d5c3.png)

