### PR TITLE
chore: reduce yarn log warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,3 +13,12 @@ yarnPath: .yarn/releases/yarn-3.1.0.cjs
 # Custom script using post-install plugin to compile sources after install
 # NOTE - currently this happens without output to terminal (issue)
 postinstall: yarn precompile
+
+# Ignore some common warnings https://yarnpkg.com/advanced/error-codes
+logFilters:
+  - code: "YN0076" # INCOMPATIBLE_ARCHITECTURE
+    level: "discard"
+  - code: "YN0060" # INCOMPATIBLE_PEER_DEPENDENCY
+    level: "discard"
+  - code: "YN0002" # MISSING_PEER_DEPENDENCY
+    level: "discard"


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add filter to ignore some specific log warnings that appear each time `yarn install` is run. These are pretty verbose and usually not significant nor actionable

"YN0076" INCOMPATIBLE_ARCHITECTURE
This occurs when the package contains scripts for multiple operating systems, and just to say that if running on windows, for example, linux scripts have been skipped

"YN0060" INCOMPATIBLE_PEER_DEPENDENCY
If dependencies a and b both require a third dependency c, only one version of dependency c will by default be installed corresponding to a version number that is marked as compatible with both. If one of the packages is outdated and the version numbers are not compatible (as is often the case), the system will opt to use the more recent version (which usually will have backwards compatibility). The warning has no way of knowing if the backwards compatibility will work or not - instead either we would expect runtime errors that will indicate such.

"YN0002" # MISSING_PEER_DEPENDENCY
Some dependencies assume instead of explicitly stating that certain 3rd party dependencies exist. An example of this is ionic-angular, which assumes you will install angular independent of the package. This results in a missing dependency issue. If the issue is genuine, no action would be possible locally except for filing an issue on the corresponding dependency's github.

## Git Issues

Closes #

## Screenshots/Videos

Previously long lists of warnings
![image](https://user-images.githubusercontent.com/10515065/151418250-8331e9a5-f9e0-4ae2-a478-143215aaf58a.png)

![image](https://user-images.githubusercontent.com/10515065/151418299-a88e9260-3352-4672-908b-7882c29d0755.png)

Now much fewer
![image](https://user-images.githubusercontent.com/10515065/151418442-5d9bc22c-28da-4c9d-9576-6048e06a6f08.png)


