### PR TITLE
feat: add force_restart emit action

### DIFF
--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -183,7 +183,14 @@ export class TemplateActionService extends TemplateInstanceService {
         // TODO - trigger emit in shared service to allow individual services/components to subscribe
         // themselves instead of relying on hardcoded calls here
 
-        // Handle a forced rerender
+        /* Emit actions
+            emit:force_restart    // reload app window to home page
+            emit:force_reload     // full re-render of all templates in current page
+            emit:force_reprocess   // recalculate existing rows (not set_variable/set_nested)
+        */
+        if (emit_value === "force_restart") {
+          location.href = "/";
+        }
         if (emit_value === "force_reload") {
           await this.container?.forceRerender(true);
         }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

We have 2 (confusingly named) actions `force_reload` and `force_reprocess` that both trigger re-evaluation of templates (with reload re-evaluating fully and reprocess just checking for variable changes). Neither, however re-evaluate content that is sat outside the current template page, such as the app menu.

As an interim solution I've added a `force_restart` action that does a more heavy-handed full page reload and redirect to the home page (like when running app reset).

I've also updated the authoring to perform a restart when changing between dev and user mode from the settings screen.

## Review Notes
There's no easy way to review the changes, because when running locally the app is forced into dev mode regardless. So we will need to sync the latest content with the authoring changes and deploy to the web version to test. 

But by temporarily blocking the local app overrides all behaves as expected in video below

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/152440306-b304171b-8794-4b4c-b5aa-e1ac1b58ee22.mp4


