### PR TITLE
feat: add parsing of dynamic notification content

### DIFF
--- a/packages/data-models/functions.ts
+++ b/packages/data-models/functions.ts
@@ -19,7 +19,7 @@ const DYNAMIC_STRING_REGEX = /[`!]?@([a-z]+)\.([0-9a-z_]+)([0-9a-z_.]*)/gi;
  * Store these references in a separate object so they can be evaluated at runtime
  */
 export function extractDynamicFields(data: any) {
-  let dynamicFields = {};
+  let dynamicFields: any = {};
   switch (typeof data) {
     case "object":
       // simply convert array to object to handle in next case


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds method to evaluate notification data_list row at the time of scheduling a notification to populate any dynamic content as required.

## Review Notes
I didn't have an example of a notification that contained both translated and dynamic content, so would be good to run as an additional test.

## Git Issues

Closes #1213

## Screenshots/Videos


https://user-images.githubusercontent.com/10515065/152608963-b3a8e494-3337-4af8-a7ec-3c2760e757ba.mp4


