### PR TITLE
fix: add standalone popup dismiss on nav

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -2,6 +2,7 @@ import { Location } from "@angular/common";
 import { Injectable } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ModalController } from "@ionic/angular";
+import { first } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
 import { arrayToHashmapArray } from "src/app/shared/utils";
 import { ITemplatePopupComponentProps, TemplatePopupComponent } from "../components/layout/popup";
@@ -182,9 +183,10 @@ export class TemplateNavService {
     container?: TemplateContainerComponent
   ) {
     const templatename = action.args[0];
-    // handle case when triggered outside of templating system
+    // if triggered outside templating system (e.g. via notification action) still enable
+    // popup creation and dismiss on nav changes
     if (!container) {
-      console.log("handling popup without container");
+      this.router.events.pipe(first()).subscribe(() => this.dismissPopup(templatename));
       return this.createPopupAndWaitForDismiss(templatename, null);
     }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

When popups are launched the template that created them are in charge of knowing when to close/reopen. When a popup is opened from a notification action there is no default template, so the popup stays open regardless of what is happening with any newly created templates that sit under it.

This PR adds a small workaround so that any popups triggered outside the templating system automatically close on page navigation.

## Author Notes
This means that following navigation, if the user presses the back button whatever page they are on will no longer have the popup open (unlike normal popups, which automatically re-open on page back)

## Git Issues

Closes #1214

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/152617224-848ad36d-732d-45c4-8239-065ccaa7a146.mp4



