### PR TITLE
Decrease grid gap in parent_centre

### DIFF
--- a/src/theme/deployment/_templates.scss
+++ b/src/theme/deployment/_templates.scss
@@ -19,7 +19,7 @@ plh-template-container[data-templatename="parent_centre"] {
   plh-tmpl-display-group .display-group-wrapper[data-param-style~="parent_point"] {
     // ensure tiles are at least 200px and provide a larger gap between icons
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    grid-gap: 32px;
+    grid-gap: 20px;
   }
 }
 


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
Set the hard-coded grid gap on the parent centre from 32px to 20px.
