### PR TITLE
Feat/campaign batch notifications

### DIFF
--- a/documentation/docs/authors/notifications.md
+++ b/documentation/docs/authors/notifications.md
@@ -22,6 +22,7 @@ Here is an example of two rows added to a `==content_list==` for creating notifi
 | schedule.start_date           | Date of earliest notification. If in past will be ignored |
 | schedule.end_date             | Date of latest notification. If in past will be ignored |
 | schedule.day_of_week          | Send notifications weekly on a given day of the week (numbered from 1 - Monday, to 7 - Sunday) |
+| schedule.batch_size           | Maximum number of notifications to schedule, e.g. if scheduling weekly specify number of weeks to preschedule |
 | time.hour                     | Hour of day to send notificaitons on, in 24h format       |
 | time.minute                   | Minute of day to send notification on |
 | delay.days                    | Offset to schedule notfication a given number of days from today |

--- a/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/campaign-debug.page.ts
@@ -70,10 +70,7 @@ export class CampaignDebugPage implements OnInit {
   /**
    * TODO - duplicate code from notifications-debug.page should be merged */
   public async sendNotification(row: FlowTypes.Campaign_listRow) {
-    const notification = await this.campaignService.scheduleCampaignNotification(
-      row,
-      this.debugCampaignId
-    );
+    const notification = await this.campaignService.scheduleNotification(row, this.debugCampaignId);
     const delaySeconds = 3;
     await this.localNotificationService.scheduleImmediateNotification(
       notification,

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-schedule-debug-row.ts
@@ -15,10 +15,10 @@ import { CampaignService } from "../../../campaign.service";
             campaignService.scheduledNotifications[row.id] | objectValues as scheduledNotifications
           "
         >
-          <span class="next-notification" *ngIf="scheduledNotifications[0] as nextNotification">
-            {{ nextNotification.schedule.at | date: "MMM d h:mm a" }}
+          <div class="next-notification" *ngFor="let notification of scheduledNotifications">
+            {{ notification.schedule.at | date: "MMM d h:mm a" }}
             <ion-icon name="notifications"></ion-icon>
-          </span>
+          </div>
         </div>
 
         <span class="tag activated" *ngIf="row._active">Active</span>

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -335,7 +335,7 @@ export class TemplateVariablesService {
       // TODO - ideally campaign lookup should be merged into data list lookup with additional query/params
       // e.g. evaluate conditions, take first etc.
       case "campaign":
-        parsedValue = await this.campaignService.getNextCampaignRow(fieldName);
+        parsedValue = (await this.campaignService.getNextCampaignRows(fieldName))[0];
         break;
       case "calc":
         const expression = fieldName.replace(/@/gi, "this.");

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -110,8 +110,6 @@ export class LocalNotificationService {
    * Use to resolve list of upcoming notifications and any been sent but not triggered in the app.
    */
   private async loadNotifications() {
-    console.group("[Notifications] load");
-
     await this.rescheduleMissingNotifications();
 
     await this.handleUnprocessedNotifications();
@@ -124,7 +122,6 @@ export class LocalNotificationService {
 
     const pendingNotifications = await this.getAPINotifications();
     this.pendingNotifications$.next(this._sortBySchedule(pendingNotifications));
-    console.groupEnd();
   }
 
   private _sortBySchedule(notifications: ILocalNotification[]) {

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -92,6 +92,14 @@ export function randomElementFromArray<T>(arr: T[] = null) {
   }
 }
 
+/** https://stackoverflow.com/a/46545530 */
+export function shuffleArray(arr: any[]) {
+  return arr
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
 /**
  * Retrieve a nested property from a json object
  * using a single path string accessor


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add campaign schedule support for `schedule.batch_size` as a means to schedule multiple notifications for a campaign. This allows daily notifications to be scheduled for a set number of days to ensure they will trigger without need to re-open the app and re-evaluate conditions.

## Author notes
By default, only notifications that satisfy activation/deactivation conditions will be scheduled. So if `notification_2` requires `notification_1.sent` it will not be scheduled even if `batch_size` set to 2. Instead, the recommended approach is to omit activation conditions and instead use a combination of batch_size, priority, deactivation criteria to schedule both and deactivate as required.

## Review notes
I've updated the debug-daily notifications to include `schedule.batch_size` which should demo the functionality. I also updated the campaign debug page to list multiple pending notifications. I think things look as expected, although I haven't tested receiving notifications across multiple days (might be one for beta-testers to try on device next release)

## Git Issues

Closes #1227

## Screenshots/Videos

Debug_daily notifications schedule with `batch_size: 5`
![image](https://user-images.githubusercontent.com/10515065/153687683-e43c0339-94a7-458d-ad90-9583fc6cfb74.png)

