### PR TITLE
fix: add db sync to server_sync action

### DIFF
--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -14,6 +14,7 @@ import { TourService } from "src/app/shared/services/tour/tour.service";
 import { TemplateTranslateService } from "../template-translate.service";
 import { TemplateFieldService } from "../template-field.service";
 import { EventService } from "src/app/shared/services/event/event.service";
+import { DBSyncService } from "src/app/shared/services/db/db-sync.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -38,6 +39,7 @@ export class TemplateActionService extends TemplateInstanceService {
   private templateTranslateService: TemplateTranslateService;
   private templateFieldService: TemplateFieldService;
   private eventService: EventService;
+  private dbSyncService: DBSyncService;
 
   constructor(injector: Injector, public container?: TemplateContainerComponent) {
     super(injector);
@@ -50,6 +52,7 @@ export class TemplateActionService extends TemplateInstanceService {
     this.templateFieldService = this.getGlobalService(TemplateFieldService);
     this.templateTranslateService = this.getGlobalService(TemplateTranslateService);
     this.eventService = this.getGlobalService(EventService);
+    this.dbSyncService = this.getGlobalService(DBSyncService);
   }
 
   /** Public method to add actions to processing queue and process */
@@ -202,6 +205,7 @@ export class TemplateActionService extends TemplateInstanceService {
         }
         if (emit_value === "server_sync") {
           await this.serverService.syncUserData();
+          await this.dbSyncService.syncToServer();
         }
         if (parent) {
           const msg = ` from ${row?.name || "(no row)"} to parent ${parent?.name || "(no parent)"}`;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

There are two different mechanisms in the app for syncing user data. A hardcoded/standalone system used to sync app user data (created to sync device info and contact fields), and a more generic system for syncing the database more generally (used for app_feedback).

This PR adds the second db sync to the action that manages the other user data sync (`emit:server_sync`). 

## Review Notes
Will require adding feedback and checking if sync successful from setting sync button. If working could also consider additing the `emit: server_sync` action to be triggered after submitting feedback for instant upload.

## Dev Notes
At some point in the future it would make sense to combine, but considered lower priority for now

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/153935321-f163b976-d456-43ee-9de8-4bdb8cdf0f55.mp4


