### PR TITLE
refactor: add app default language to constants

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -35,6 +35,11 @@ export const APP_FIELDS = {
   DEPLOYMENT_NAME: `${FIELD_PREFIX}._deployment_name`,
 };
 
+export const APP_LANGUAGES = {
+  /** Language used during first load. If translations do not exist will default to source strings (en) */
+  default: "en",
+};
+
 /**
  * Some specific strings are currently hardcoded into the app
  * TODO - not all strings included, should add to when required

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -37,7 +37,7 @@ export const APP_FIELDS = {
 
 export const APP_LANGUAGES = {
   /** Language used during first load. If translations do not exist will default to source strings (gb_en) */
-  default: "en",
+  default: "gb_en",
 };
 
 /**

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -36,7 +36,7 @@ export const APP_FIELDS = {
 };
 
 export const APP_LANGUAGES = {
-  /** Language used during first load. If translations do not exist will default to source strings (en) */
+  /** Language used during first load. If translations do not exist will default to source strings (gb_en) */
   default: "en",
 };
 

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -1,13 +1,10 @@
 import { Injectable } from "@angular/core";
 import { TRANSLATION_STRINGS } from "app-data";
+import { APP_FIELDS } from "packages/data-models";
+import { APP_LANGUAGES } from "packages/data-models/constants";
 import { BehaviorSubject } from "rxjs";
 import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
 import { FlowTypes } from "../models";
-
-// assign a local storage field that also matches lookup for use in @fields._app_language
-// (might be changed in future to better indicate read-only field)
-const APP_LANGUAGE_FIELD = "rp-contact-field._app_language";
-const DEFAULT_LANGUAGE = "za_en";
 
 @Injectable({ providedIn: "root" })
 /**
@@ -25,11 +22,11 @@ export class TemplateTranslateService {
   translation_strings = {};
 
   constructor(private localStorageService: LocalStorageService) {
-    const currentLanguage = localStorageService.getString(APP_LANGUAGE_FIELD);
+    const currentLanguage = localStorageService.getString(APP_FIELDS.APP_LANGUAGE);
     if (currentLanguage) {
       this.setLanguage(currentLanguage, false);
     } else {
-      this.setLanguage(DEFAULT_LANGUAGE, true);
+      this.setLanguage(APP_LANGUAGES.default, true);
     }
   }
   // Init handled in constructor, but kept here as reminder to import/call from main app component
@@ -43,7 +40,7 @@ export class TemplateTranslateService {
   setLanguage(code: string, updateDB = true) {
     if (code) {
       if (updateDB) {
-        this.localStorageService.setString(APP_LANGUAGE_FIELD, code);
+        this.localStorageService.setString(APP_FIELDS.APP_LANGUAGE, code);
       }
       this.translation_strings = TRANSLATION_STRINGS[code] || {};
       // update observable for subscribers


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Refactor app to allow default language to be specified from constants

## Author Notes
The default language can now be changed from the `packages\data-models\constants.ts` file. This will only affect users that have not already specified a language. The default value has currently just been set as `en` which does not exist as a translation, and so defaults to the source strings (which are in generic English)

## Git Issues

Closes #

## Screenshots/Videos
Example loading app for first time with `tz_sw` specified as the default language
```
export const APP_LANGUAGES = {
  /** Language used during first load. If translations do not exist will default to source strings (en) */
  default: "tz_sw",
};
```

https://user-images.githubusercontent.com/10515065/155628336-21b3b73f-8727-4b5f-adae-7439cba63af4.mp4


