### PR TITLE
fix: ensure deployment name field populated

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -74,6 +74,8 @@ export class AppComponent {
   async initializeApp() {
     this.themeService.init();
     this.platform.ready().then(async () => {
+      // ensure deployment field set correctly for use in any startup services or templates
+      localStorage.setItem(APP_FIELDS.DEPLOYMENT_NAME, this.DEPLOYMENT_NAME);
       await this.initialiseCoreServices();
       this.hackSetDeveloperOptions();
       const isDeveloperMode = this.templateFieldService.getField("user_mode") === false;
@@ -210,8 +212,6 @@ export class AppComponent {
    * temporary workaround for setting unlocked content
    */
   private async hackSetAppOpenFields(user: IUserMeta) {
-    localStorage.setItem(APP_FIELDS.DEPLOYMENT_NAME, this.DEPLOYMENT_NAME);
-
     // TODO CC 2021-07-23 - Review if methods below still required
     let old_date = this.userMetaService.getUserMeta("current_date");
     await this.userMetaService.setUserMeta({ current_date: new Date().toISOString() });


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fix minor bug where the deployment name field was only being set after initial startup slides, and so unable to be used in overrides

## Git Issues

Closes #1267

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/159816893-b2870b01-8d39-4511-a297-284ed32eeca8.mp4



