### PR TITLE
fix: use device ids and not temp

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,7 +79,7 @@ export class AppComponent {
       await this.initialiseCoreServices();
       this.hackSetDeveloperOptions();
       const isDeveloperMode = this.templateFieldService.getField("user_mode") === false;
-      const user = await this.userMetaService.init();
+      const user = this.userMetaService.userMeta;
       if (!user.first_app_open) {
         await this.surveyService.runSurvey("introSplash");
         await this.userMetaService.setUserMeta({ first_app_open: new Date().toISOString() });
@@ -110,6 +110,7 @@ export class AppComponent {
    **/
   async initialiseCoreServices() {
     await this.dbService.init();
+    await this.userMetaService.init();
     // CC 2021-05-14 - disabling reminders service until decide on full implementation
     // (ideally not requiring evaluation of all reminders on init)
     // this.remindersService.init();

--- a/src/app/shared/services/userMeta/userMeta.service.ts
+++ b/src/app/shared/services/userMeta/userMeta.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@angular/core";
-import { generateRandomId } from "../../utils";
+import { Device } from "@capacitor/device";
 import { MODULE_LIST } from "../data/data.service";
 import { DbService } from "../db/db.service";
 
 @Injectable({ providedIn: "root" })
 export class UserMetaService {
   /** keep an in-memory copy of user to provide synchronously */
-  private userMeta: IUserMeta;
+  public userMeta: IUserMeta;
   constructor(private dbService: DbService) {}
 
   /** When first initialising ensure a default profile created and any newer defaults are merged with older user profiles */
@@ -16,11 +16,8 @@ export class UserMetaService {
     userMetaValues.forEach((v) => {
       userMeta[v.key] = v.value;
     });
-    if (!userMeta.uuid) {
-      console.log("initialising new user");
-      await this.setUserMeta({ ...userMeta, uuid: `temp_${generateRandomId()}` });
-    }
-    console.log("user initialised", userMeta);
+    const { uuid } = await Device.getId();
+    userMeta.uuid = uuid;
     this.userMeta = userMeta;
     return userMeta;
   }

--- a/src/app/shared/services/userMeta/userMeta.service.ts
+++ b/src/app/shared/services/userMeta/userMeta.service.ts
@@ -17,9 +17,12 @@ export class UserMetaService {
       userMeta[v.key] = v.value;
     });
     const { uuid } = await Device.getId();
+    // fix legacy user IDs - note this can likely be removed after v0.16
+    if (userMeta.uuid && userMeta.uuid !== uuid) {
+      await this.setUserMeta({ uuid, uuid_temp: userMeta.uuid });
+    }
     userMeta.uuid = uuid;
     this.userMeta = userMeta;
-    return userMeta;
   }
 
   getUserMeta(key: keyof IUserMeta) {
@@ -40,6 +43,7 @@ interface IUserMetaEntry {
 
 export interface IUserMeta {
   uuid: string;
+  uuid_temp?: string; // legacy id that previously may have been set
   first_app_open: isostring;
   current_date: isostring;
   app_skin: "MODULE_FOCUS_SKIN" | "BLOBS" | "BUTTONS";


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Remove legacy method that assigned temp user ids to `app_feedback` and `app_notification_interaction` tables when synced to the database. 

## Review Notes
This should mean moving forward everything synced to the database should have consistent user ids, however as it will replace the temp ids with correct ones it will mean that any app feedback or app notification interaction data received up won't match up. I've added an extra field to track users who have had their temp id changed, although this is not synced to the server (assume not required as very little app_feedback or app_notification_interaction data has been sent, and this table is mostly legacy at this stage and will likely be removed in the future)

I've included a short video showing changes in the database that the app_notification_interaction and app_feedback tables pick the user id from so assume should all work correctly, although as a functional test you could also just try use the preview URL and check that a correct id is synced to the database following either a notification interaction or feedback submission.

## Git Issues

Closes #1286

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/160052053-99f3643a-d52c-4916-998d-55d8b6568657.mp4