### PR TITLE
fix: force use of largeBody notification text style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": "IDEMS International",
   "homepage": "https://idems.international/",
   "description": "",

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -239,7 +239,7 @@ export class CampaignService {
     text = text || NOTIFICATION_DEFAULTS.text;
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
-      body: text,
+      body: null, // Force use of largeBody
       largeBody: text,
       title,
       extra: { ...row, campaign_id },

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -239,8 +239,10 @@ export class CampaignService {
     text = text || NOTIFICATION_DEFAULTS.text;
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
-      body: null, // Force use of largeBody
+      body: text,
+      // Expandable notification shown when largeBody and summaryText present
       largeBody: text,
+      summaryText: text,
       title,
       extra: { ...row, campaign_id },
       id: stringToIntegerHash(row.id),

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -234,14 +234,12 @@ export class CampaignService {
     if (!notification_schedule) return;
     let { _schedule_at } = notification_schedule;
 
-    const title = row.title || NOTIFICATION_DEFAULTS.title;
-    const body = row.text || NOTIFICATION_DEFAULTS.text;
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
-      body,
-      largeBody: `${body}`,
+      body: row.text || NOTIFICATION_DEFAULTS.text,
+      largeBody: row.text || NOTIFICATION_DEFAULTS.text,
       summaryText: "",
-      title,
+      title: row.title || NOTIFICATION_DEFAULTS.title,
       extra: { ...row, campaign_id },
       id: stringToIntegerHash(row.id),
     };

--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -232,17 +232,15 @@ export class CampaignService {
     const notification_schedule = this.evaluateSchedule(schedule, earliestStart);
     // may return null if schedule would be outside permitted timeframe, in which case do not schedule
     if (!notification_schedule) return;
-    let { title, text } = row;
     let { _schedule_at } = notification_schedule;
 
-    title = title || NOTIFICATION_DEFAULTS.title;
-    text = text || NOTIFICATION_DEFAULTS.text;
+    const title = row.title || NOTIFICATION_DEFAULTS.title;
+    const body = row.text || NOTIFICATION_DEFAULTS.text;
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
-      body: text,
-      // Expandable notification shown when largeBody and summaryText present
-      largeBody: text,
-      summaryText: text,
+      body,
+      largeBody: `${body}`,
+      summaryText: "",
       title,
       extra: { ...row, campaign_id },
       id: stringToIntegerHash(row.id),

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -175,14 +175,16 @@ export class LocalNotificationService {
    * see full scheduling options in type interface
    * see named actions below for configurations
    */
-  public async scheduleNotification(options: ILocalNotification, reloadNotifications = true) {
+  public async scheduleNotification(notification: ILocalNotification, reloadNotifications = true) {
     if (!this.permissionGranted) return;
-    options.extra = { ...options.extra };
-    const notifications = [{ ...LOCAL_NOTIFICATION_DEFAULTS, ...options }];
-    await LocalNotifications.schedule({ notifications });
-    // ensure extra field populated (TODO - could make stronger requirement elsewhere)
-    options.extra = { ...options.extra };
-    await this.addDBNotification(options as ILocalNotification);
+    // add default values
+    Object.entries(LOCAL_NOTIFICATION_DEFAULTS).forEach(([key, value]) => {
+      if (!notification.hasOwnProperty(key)) {
+        notification[key] = value;
+      }
+    });
+    await LocalNotifications.schedule({ notifications: [notification] });
+    await this.addDBNotification(notification as ILocalNotification);
     if (reloadNotifications) {
       await this.loadNotifications();
     }

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -183,6 +183,8 @@ export class LocalNotificationService {
         notification[key] = value;
       }
     });
+    // HACK - for some reason largebody not always passed (possibly from schedule immediate) so reassign
+    notification.largeBody = notification.largeBody || notification.body;
     await LocalNotifications.schedule({ notifications: [notification] });
     await this.addDBNotification(notification as ILocalNotification);
     if (reloadNotifications) {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add extra code to try and force notifications to use expandable format

## Review Notes
There's a few minor refactoring points that have small potential for knock-ons, so would be good to have a quick functional test of a few different notifications (e.g. including dynamic/translated content). Testing for content can be done in the web preview, testing for expandable text in the appetize preview (as desktop notifications work a bit differently to android)

## Git Issues

Closes #1297

## Screenshots/Videos

https://user-images.githubusercontent.com/10515065/160260109-7ff90e62-2a11-49c8-b1a3-5e67baf7bc81.mp4


