### PR TITLE
fix: strip bold markdown from notifications

### DIFF
--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -235,6 +235,10 @@ export class CampaignService {
     if (!notification_schedule) return;
     let { _schedule_at } = notification_schedule;
 
+    // HACK - remove markdown form title and text as not currently supported in capacitor notifications
+    row.text = this.hackStripNotificationMarkdown(row.text);
+    row.title = this.hackStripNotificationMarkdown(row.title);
+
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },
       body: row.text || NOTIFICATION_DEFAULTS.text,
@@ -460,5 +464,14 @@ export class CampaignService {
       .map(([_, value]) => shuffleArray(value));
     const shuffleSortedRows: FlowTypes.Campaign_listRow[] = [].concat(...shuffleSortedGroups);
     return shuffleSortedRows;
+  }
+
+  /**
+   * Rough function to strip some commonly used markdown from strings, specifically
+   * `**` - bold text
+   * NOTE - comprehensive extraction could be carried out using something like strip-markdown or mdast
+   */
+  private hackStripNotificationMarkdown(str = "") {
+    return str.replace(/\*\*/g, "");
   }
 }

--- a/src/app/feature/campaign/pages/campaign-debug/components/campaign-debug-row.ts
+++ b/src/app/feature/campaign/pages/campaign-debug/components/campaign-debug-row.ts
@@ -11,6 +11,8 @@ import { FlowTypes } from "src/app/shared/model";
       <div class="row-content">
         <!-- Info -->
         <div style="flex:1">
+          <!-- Text -->
+          <div>{{ row.text }}</div>
           <!-- Click Action List -->
           <div *ngIf="row.action_list && row.action_list.length > 0">
             <div class="divider"></div>


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Strips any markdown `**` from notifications as this does not show correctly
Small workaround to #1219

## Author Notes
As we need to manually specify what markdown to strip I've just focused on bold text (the only example I could see). Are there any others we need to remove for now? I'm aware of not being too heavy-handed in case another author wants to use markdown characters as text (e.g. hashtags and underscores)

## Git Issues

Closes #1314

## Screenshots/Videos

Scheduling bold-markdown text shows the text that gets modified before sending

https://user-images.githubusercontent.com/10515065/165499396-6eaea873-e3c1-4155-832e-e7cc0354f466.mp4

Here is the message that arrived on my local device (ignore the bold heading, that isn't due to markdown just because the notification title and text are the same)

![image](https://user-images.githubusercontent.com/10515065/165499459-6bd55278-65a3-45b4-82da-019dc4f0fc91.png)



