### PR TITLE
style: add 1024px max template width

### DIFF
--- a/src/app/shared/components/template/template-component.scss
+++ b/src/app/shared/components/template/template-component.scss
@@ -14,6 +14,12 @@ plh-template-component[data-hidden="true"] {
   display: none !important;
   flex: 0 !important;
 }
+plh-template-container {
+  width: 100%;
+  max-width: 1024px;
+  margin: auto;
+}
+
 /// Ensure all directly nested template rows have spacing between elements,
 /// except in case where only one row (e.g. deep-nested)
 plh-template-container > plh-template-component:not([data-hidden="true"]) {

--- a/src/app/shared/components/template/template-component.scss
+++ b/src/app/shared/components/template/template-component.scss
@@ -16,7 +16,7 @@ plh-template-component[data-hidden="true"] {
 }
 plh-template-container {
   width: 100%;
-  max-width: 1024px;
+  max-width: var(--content-max-width, 100%);
   margin: auto;
 }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -90,7 +90,8 @@
 .tooltipClass {
   border-radius: var(--ion-border-radius-standard);
   color: var(--ion-color-primary);
-  min-width: 90vw;
+  // targets width slightly smaller than max content
+  min-width: calc(min(var(--content-max-width), 100vw) - 2rem); // slightly smaller than content
   font-size: var(--font-size-text-medium);
   right: 0;
   @media (max-width: 320px) {

--- a/src/theme/_breakpoints.scss
+++ b/src/theme/_breakpoints.scss
@@ -1,0 +1,19 @@
+/** Content Sizes - defined as multidimensional map **/
+$breakpoints: (
+  // phone: 640px,
+  // tablet: 768px,
+  desktop: 500px
+);
+
+/** 
+Provide quick access to desktop breakpoint, e.g.
+max-width: 100vw
+@include desktop {
+  max-width: 1024px
+}
+ */
+@mixin desktop() {
+  @media (min-width: map-get($breakpoints,"desktop")) {
+    @content;
+  }
+}

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "./breakpoints";
 // Ionic Variables and Theming. For more info, please see:
 // http://ionicframework.com/docs/theming/
 
@@ -45,6 +46,12 @@ $horizontal: 90deg;
   --largest-padding: 30px;
   --huge-padding: 40px;
   --main-container-padding: 0 var(--large-margin);
+
+  // Content Width
+  --content-max-width: 100vw;
+  @include breakpoints.desktop {
+    --content-max-width: map-get($breakpoints, "desktop");
+  }
 
   // Box shadow //
   --ion-default-box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
@@ -557,150 +564,3 @@ $horizontal: 90deg;
   --ion-color-light-shade: #d7d8da;
   --ion-color-light-tint: #f5f6f9;
 }
-// TODO CC 2022-03-26 - dark theme requires redesign
-// @media (prefers-color-scheme: dark) {
-//   /*
-//    * Dark Colors
-//    * -------------------------------------------
-//    */
-
-//   body {
-//     --ion-color-primary: #0d4060;
-//     --ion-color-primary-rgb: 13, 64, 96;
-//     --ion-color-primary-contrast: #ffffff;
-//     --ion-color-primary-contrast-rgb: 255, 255, 255;
-//     --ion-color-primary-shade: #0b3854;
-//     --ion-color-primary-tint: #255370;
-
-//     --ion-color-secondary: #f3d668;
-//     --ion-color-secondary-rgb: 243, 214, 104;
-//     --ion-color-secondary-contrast: #000000;
-//     --ion-color-secondary-contrast-rgb: 0, 0, 0;
-//     --ion-color-secondary-shade: #d6bc5c;
-//     --ion-color-secondary-tint: #f4da77;
-
-//     --ion-color-tertiary: #00a1cd;
-//     --ion-color-tertiary-rgb: 0, 161, 205;
-//     --ion-color-tertiary-contrast: #ffffff;
-//     --ion-color-tertiary-contrast-rgb: 255, 255, 255;
-//     --ion-color-tertiary-shade: #008eb4;
-//     --ion-color-tertiary-tint: #1aaad2;
-
-//     --ion-color-success: #2dd36f;
-//     --ion-color-success-rgb: 45, 211, 111;
-//     --ion-color-success-contrast: #ffffff;
-//     --ion-color-success-contrast-rgb: 255, 255, 255;
-//     --ion-color-success-shade: #28ba62;
-//     --ion-color-success-tint: #42d77d;
-
-//     --ion-color-warning: #ffc409;
-//     --ion-color-warning-rgb: 255, 196, 9;
-//     --ion-color-warning-contrast: #000000;
-//     --ion-color-warning-contrast-rgb: 0, 0, 0;
-//     --ion-color-warning-shade: #e0ac08;
-//     --ion-color-warning-tint: #ffca22;
-
-//     --ion-color-danger: #eb445a;
-//     --ion-color-danger-rgb: 235, 68, 90;
-//     --ion-color-danger-contrast: #ffffff;
-//     --ion-color-danger-contrast-rgb: 255, 255, 255;
-//     --ion-color-danger-shade: #cf3c4f;
-//     --ion-color-danger-tint: #ed576b;
-
-//     --ion-color-dark: #f4f5f8;
-//     --ion-color-dark-rgb: 244, 245, 248;
-//     --ion-color-dark-contrast: #000000;
-//     --ion-color-dark-contrast-rgb: 0, 0, 0;
-//     --ion-color-dark-shade: #d7d8da;
-//     --ion-color-dark-tint: #f5f6f9;
-
-//     --ion-color-medium: #989aa2;
-//     --ion-color-medium-rgb: 152, 154, 162;
-//     --ion-color-medium-contrast: #000000;
-//     --ion-color-medium-contrast-rgb: 0, 0, 0;
-//     --ion-color-medium-shade: #86888f;
-//     --ion-color-medium-tint: #a2a4ab;
-
-//     --ion-color-light: #222428;
-//     --ion-color-light-rgb: 34, 36, 40;
-//     --ion-color-light-contrast: #ffffff;
-//     --ion-color-light-contrast-rgb: 255, 255, 255;
-//     --ion-color-light-shade: #1e2023;
-//     --ion-color-light-tint: #383a3e;
-//   }
-
-//   /*
-//    * iOS Dark Theme
-//    * -------------------------------------------
-//    */
-
-//   .ios body {
-//     --ion-background-color: #000000;
-//     --ion-background-color-rgb: 0, 0, 0;
-
-//     --ion-text-color: #ffffff;
-//     --ion-text-color-rgb: 255, 255, 255;
-
-//     --ion-color-step-50: #0d0d0d;
-//     --ion-color-step-100: #1a1a1a;
-//     --ion-color-step-150: #262626;
-//     --ion-color-step-200: #333333;
-//     --ion-color-step-250: #404040;
-//     --ion-color-step-300: #4d4d4d;
-//     --ion-color-step-350: #595959;
-//     --ion-color-step-400: #666666;
-//     --ion-color-step-450: #737373;
-//     --ion-color-step-500: #808080;
-//     --ion-color-step-550: #8c8c8c;
-//     --ion-color-step-600: #999999;
-//     --ion-color-step-650: #a6a6a6;
-//     --ion-color-step-700: #b3b3b3;
-//     --ion-color-step-750: #bfbfbf;
-//     --ion-color-step-800: #cccccc;
-//     --ion-color-step-850: #d9d9d9;
-//     --ion-color-step-900: #e6e6e6;
-//     --ion-color-step-950: #f2f2f2;
-
-//     --ion-toolbar-background: #0d0d0d;
-
-//     --ion-item-background: #000000;
-//   }
-
-//   /*
-
-//   .md body {
-//     --ion-background-color: #121212;
-//     --ion-background-color-rgb: 18, 18, 18;
-
-//     --ion-text-color: #ffffff;
-//     --ion-text-color-rgb: 255, 255, 255;
-
-//     --ion-border-color: #222222;
-
-//     --ion-color-step-50: #1e1e1e;
-//     --ion-color-step-100: #2a2a2a;
-//     --ion-color-step-150: #363636;
-//     --ion-color-step-200: #414141;
-//     --ion-color-step-250: #4d4d4d;
-//     --ion-color-step-300: #595959;
-//     --ion-color-step-350: #656565;
-//     --ion-color-step-400: #717171;
-//     --ion-color-step-450: #7d7d7d;
-//     --ion-color-step-500: #898989;
-//     --ion-color-step-550: #949494;
-//     --ion-color-step-600: #a0a0a0;
-//     --ion-color-step-650: #acacac;
-//     --ion-color-step-700: #b8b8b8;
-//     --ion-color-step-750: #c4c4c4;
-//     --ion-color-step-800: #d0d0d0;
-//     --ion-color-step-850: #dbdbdb;
-//     --ion-color-step-900: #e7e7e7;
-//     --ion-color-step-950: #f3f3f3;
-
-//     --ion-item-background: #1e1e1e;
-
-//     --ion-toolbar-background: #1f1f1f;
-
-//     --ion-tab-bar-background: #1f1f1f;
-//   }
-// }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add a max-width of 1024px so that content fits a bit nicer on large screens (desktop).
Whilst this is still probably a bit on the large side, recommend keeping as a reasonable default for now and can refine individual templates in the future for fitting different screen sizes

## Review Notes
I don't expect this to have knock-ons as most of our work is focused on devices with smaller screens, however as I did change a bit of the styles that handle templates filling space it would be good to test via visual test that there are no accidental regressions (e.g. things suddenly becoming much wider or thinner in some template contexts)

Note - this only applies to custom templates, so some of the existing dev screens will still fit full page (this is to allow things like the header bar to stay full width and keep scroll bars on the outer edge of the page)

## Git Issues

Closes #

## Screenshots/Videos
E.g. on my desktop (1920px screen)

Before
![image](https://user-images.githubusercontent.com/10515065/165744580-808f2062-aff6-4a5e-b3d6-af42c7de7aa5.png)

After
![image](https://user-images.githubusercontent.com/10515065/165744490-0a1d06a8-4923-489d-bb8e-6fdedd48a5cd.png)

