### PR TITLE
Add documentation of two questions

### DIFF
--- a/documentation/docs/questions/images/display_group.png
+++ b/documentation/docs/questions/images/display_group.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ddd3a1d58608377d5936d7a4a619d622dfc331ce3ac4b96cc044c763707ad21
+size 90507

--- a/documentation/docs/questions/parameters_styles.md
+++ b/documentation/docs/questions/parameters_styles.md
@@ -1,0 +1,11 @@
+# Parameters vs styles
+
+**I’m guessing the style_list stuff are specifications that are based on CSS. Although I know of its existence, I’ve never worked my way through CSS stuff. I guess that’s another thing to learn something about. I put `text-align: right` in the `parameter_list` column and it did nothing, but it did what I would have expected in the `style_list` column. Similarly, `style: large center` has an effect in the `parameter_list` column but not the `style_list` column.**
+
+_Asked on 10 February 2022_
+
+The `parameter_list` takes only parameters that are specifically defined by us for every specific component. As such, these are going to be pretty impossible for you to guess without documentation. For what it's worth, [this file](https://github.com/IDEMSInternational/parenting-app-ui/blob/master/documentation/docs/authors/template-component-parameter-list.md) is the closest thing to documentation of those parameters that we have at the moment.  
+
+Instead, the `style_list` does indeed interpret CSS directly. My knowledge of CSS is limited as well so I can't be of much help here, but [this documentation website](https://www.w3schools.com/cssref/default.asp) has proven handy to me in the past. 
+
+_Answered on 14 February 2022_

--- a/documentation/docs/questions/positioning_components.md
+++ b/documentation/docs/questions/positioning_components.md
@@ -1,0 +1,11 @@
+# Positioning components
+
+**Is it possible to do word wrapping around images, or must images be all by themselves on a row?**
+
+_Asked on 14 February 2022_
+
+We don't exactly have a syntax to get text to wrap around an image. The system we use to get something similar (at least to get components to display side-by-side) is based on "display groups". To show you how these work I authored the template `example_dg`([sheet](https://docs.google.com/spreadsheets/d/1i6Th92RAkGfardxSJdJYWVoMtTkaNr-Xn2kIHDvtQoQ/edit#gid=1595229908) / [web preview](https://plh-global.web.app/template/example_dg)), which corresponds to the screenshot below. 
+
+![](images/display_group.png)
+
+_Answered on 14 February 2022_

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -35,6 +35,9 @@ nav:
       - components/round_button.md
       - components/text.md
       - components/simple_checkbox.md
+  - Q & A:
+      - questions/parameters_styles.md
+      - questions/positioning_components.md
 # Enable all extension for authoring as per https://squidfunk.github.io/mkdocs-material/setup/extensions/
 
 markdown_extensions:


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
PR adds Q & A section to the documentation website and adds two questions to this section.

@jfmcquade @chrismclarke I don't think there is _need_ for you to review this, but if you have any suggestions for improvements before I move forward and add more questions let me know.

## Screenshots
<img width="956" alt="image" src="https://user-images.githubusercontent.com/74557272/170099208-2edcd3f7-ab9a-42ad-a83f-58bbcdb25cd5.png">
<img width="956" alt="image" src="https://user-images.githubusercontent.com/74557272/170099290-601306e8-2a67-4739-b6d9-64a59ec8cac1.png">
