### PR TITLE
Fix/shared configs

### DIFF
--- a/.idems_app/deployments/early_family_math/config.ts
+++ b/.idems_app/deployments/early_family_math/config.ts
@@ -1,6 +1,5 @@
 import { IDeploymentConfig } from "data-models";
-import { DEFAULT_CONSTANTS } from "data-models";
-
+import { getDefaultAppConstants } from "data-models";
 /**
  * The default config should ideally be a superset of any extended configs
  * to allow for easier post-processing
@@ -17,7 +16,7 @@ const config: IDeploymentConfig = {
     translated_strings_path: "packages/app-data/translations_source/from_translators",
     source_strings_path: "packages/app-data/translations_source/to_translate",
   },
-  app_constants: DEFAULT_CONSTANTS,
+  app_constants: getDefaultAppConstants(),
 };
 // Override constants
 config.app_constants.APP_LANGUAGES.default = "us_en";

--- a/.idems_app/deployments/plh/global.config.ts
+++ b/.idems_app/deployments/plh/global.config.ts
@@ -1,7 +1,7 @@
 import { IDeploymentConfig } from "data-models";
-import { DEFAULT_CONSTANTS } from "data-models";
+import { getDefaultAppConstants } from "data-models/constants";
 
-const app_constants = DEFAULT_CONSTANTS;
+const app_constants = getDefaultAppConstants();
 /** Define default startup actions for plh app */
 app_constants.APP_INITIALISATION_DEFAULTS.app_first_launch_actions = [
   {
@@ -32,7 +32,7 @@ app_constants.APP_INITIALISATION_DEFAULTS.app_first_launch_actions = [
  */
 const config: IDeploymentConfig = {
   name: "plh_global",
-  app_constants: DEFAULT_CONSTANTS,
+  app_constants,
   google_drive: {
     sheets_folder_id: "1n221Zv9LYuwxmjhiboq8vhQg67_K9L5f",
     assets_folder_id: "1dp9QAQ84m8pm0IBQTSPXe1ramyynKPNn",

--- a/.idems_app/deployments/plh/tz.config.ts
+++ b/.idems_app/deployments/plh/tz.config.ts
@@ -1,8 +1,9 @@
+import { cloneConfig } from "data-models/deployment.model";
 import DEFAULT_CONFIG from "./global.config";
 
 /** TZ config extends the default config **/
 
-const config = DEFAULT_CONFIG;
+const config = cloneConfig(DEFAULT_CONFIG);
 config.name = "plh_tz";
 config.app_data.sheets_filter_function = (flow) =>
   !["debug", "component_demo", "example_hardcoded", "campaign_rows_debug"].includes(

--- a/.idems_app/deployments/plh/za.config.ts
+++ b/.idems_app/deployments/plh/za.config.ts
@@ -1,8 +1,9 @@
+import { cloneConfig } from "data-models/deployment.model";
 import DEFAULT_CONFIG from "./global.config";
 
 /** ZA config extends the default config **/
 
-const config = DEFAULT_CONFIG;
+const config = cloneConfig(DEFAULT_CONFIG);
 config.name = "plh_za";
 config.app_data.sheets_filter_function = (flow) =>
   !["debug", "component_demo", "example_hardcoded", "campaign_rows_debug"].includes(

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import APP_CONFIG_GLOBALS from "./app-config/globals";
+import clone from "clone";
 /*********************************************************************************************
  *  Constants used throughout the app
  *
@@ -144,7 +145,7 @@ const FEEDBACK_MODULE_DEFAULTS = {
   selected_text_field: "_feedback_selected_text",
 };
 
-export const DEFAULT_APP_CONSTANTS = {
+const APP_CONSTANTS = {
   APP_FIELDS,
   APP_HEADER_DEFAULTS,
   APP_INITIALISATION_DEFAULTS,
@@ -160,5 +161,6 @@ export const DEFAULT_APP_CONSTANTS = {
   NOTIFICATION_DEFAULTS,
   SERVER_SYNC_FREQUENCY_MS,
 };
-
-export type IAppConstants = typeof DEFAULT_APP_CONSTANTS;
+// Export as a clone to avoid risk one import could alter another
+export const getDefaultAppConstants = () => clone(APP_CONSTANTS);
+export type IAppConstants = typeof APP_CONSTANTS;

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -144,7 +144,7 @@ const FEEDBACK_MODULE_DEFAULTS = {
   selected_text_field: "_feedback_selected_text",
 };
 
-const APP_CONSTANTS = {
+export const DEFAULT_APP_CONSTANTS = {
   APP_FIELDS,
   APP_HEADER_DEFAULTS,
   APP_INITIALISATION_DEFAULTS,
@@ -161,4 +161,4 @@ const APP_CONSTANTS = {
   SERVER_SYNC_FREQUENCY_MS,
 };
 
-export default APP_CONSTANTS;
+export type IAppConstants = typeof DEFAULT_APP_CONSTANTS;

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -1,4 +1,5 @@
-import type APP_CONSTANTS from "./constants";
+import clone from "clone";
+import type { IAppConstants } from "./constants";
 
 export interface IDeploymentConfig {
   /** Friendly name used to identify the deployment name */
@@ -18,7 +19,7 @@ export interface IDeploymentConfig {
     assets_filter_function?: (gdriveEntry: IGdriveEntry) => boolean;
   };
   /** Optional override of any provided constants from data-models/constants */
-  app_constants?: Partial<typeof APP_CONSTANTS>;
+  app_constants?: Partial<IAppConstants>;
   app_data?: {
     /** processed sheets for use in app. Default `packages/app-data/sheets` */
     sheets_output_path?: string;
@@ -52,6 +53,9 @@ export interface IDeploymentConfig {
   /** optional version number to force recompile */
   _version?: number;
 }
+
+/** When extending a config it is usually better to clone to avoid accidentally altering original */
+export const cloneConfig = (config: IDeploymentConfig): IDeploymentConfig => clone(config);
 
 /** Minimal example of just required config */
 export const DEPLOYMENT_CONFIG_EXAMPLE_MIN: IDeploymentConfig = {

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -1,4 +1,4 @@
-import APP_CONSTANTS from "./constants";
+import type { IAppConstants } from "./constants";
 
 /*********************************************************************************************
  *  Base flow types
@@ -295,7 +295,7 @@ export namespace FlowTypes {
   }
   export type IDynamicField = { [key: string]: TemplateRowDynamicEvaluator[] | IDynamicField };
 
-  type IDynamicPrefix = typeof APP_CONSTANTS.DYNAMIC_PREFIXES[number];
+  type IDynamicPrefix = IAppConstants["DYNAMIC_PREFIXES"][number];
 
   /** Data passed back from regex match, e.g. expression @local.someField => type:local, fieldName: someField */
   export interface TemplateRowDynamicEvaluator {

--- a/packages/data-models/functions.ts
+++ b/packages/data-models/functions.ts
@@ -1,6 +1,6 @@
 // import const from app-data directly as typings can sometimes break otherwise
+import { getDefaultAppConstants } from "./constants";
 import { FlowTypes } from "./flowTypes";
-import APP_CONSTANTS from "./constants";
 
 /**
  * Regex used to match dynamic strings. Specific keypoints:
@@ -87,7 +87,7 @@ export function extractDynamicEvaluators(
           type = "raw";
         }
         // cross-check to ensure lookup matches one of the pre-defined dynamic field types (e.g. not email@domain.com)
-        if (!APP_CONSTANTS.DYNAMIC_PREFIXES.includes(type)) {
+        if (!getDefaultAppConstants().DYNAMIC_PREFIXES.includes(type)) {
           return undefined;
         }
         return { fullExpression, matchedExpression, type, fieldName };

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -3,5 +3,5 @@ export * from "./functions";
 export { IDeploymentWorkflows, IWorkflow, IWorkflowContext, WORKFLOW_DEFAULTS } from "./workflows";
 export { IDeploymentConfig, DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS } from "./deployment.model";
 
-export { DEFAULT_APP_CONSTANTS } from "./constants";
+export { getDefaultAppConstants } from "./constants";
 export type { IAppConstants } from "./constants";

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -3,6 +3,5 @@ export * from "./functions";
 export { IDeploymentWorkflows, IWorkflow, IWorkflowContext, WORKFLOW_DEFAULTS } from "./workflows";
 export { IDeploymentConfig, DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS } from "./deployment.model";
 
-// Constants are not designed to be consumed directly, but rather following merge with deployment config
-import CONSTANTS from "./constants";
-export const DEFAULT_CONSTANTS = CONSTANTS;
+export { DEFAULT_APP_CONSTANTS } from "./constants";
+export type { IAppConstants } from "./constants";

--- a/packages/data-models/package.json
+++ b/packages/data-models/package.json
@@ -8,8 +8,12 @@
     "serve": "tsc -w"
   },
   "devDependencies": {
+    "@types/clone": "^2.1.1",
     "@types/node": "^15.12.4",
     "scripts": "workspace:*",
     "typescript": "~4.2.4"
+  },
+  "dependencies": {
+    "clone": "^2.1.2"
   }
 }

--- a/src/app/data/constants.ts
+++ b/src/app/data/constants.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_APP_CONSTANTS, IAppConstants } from "data-models";
+import { getDefaultAppConstants, IAppConstants } from "data-models";
 import { environment } from "src/environments/environment";
 import { deepMergeObjects } from "../shared/utils";
 
@@ -6,6 +6,6 @@ const app_constant_overrides = (environment.deploymentConfig as any).app_constan
 
 /** List of constants provided by data-models combined with deployment-specific overrides */
 export const APP_CONSTANTS: IAppConstants = deepMergeObjects(
-  DEFAULT_APP_CONSTANTS,
+  getDefaultAppConstants(),
   app_constant_overrides
 );

--- a/src/app/data/constants.ts
+++ b/src/app/data/constants.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_CONSTANTS } from "data-models";
+import { DEFAULT_APP_CONSTANTS, IAppConstants } from "data-models";
 import { environment } from "src/environments/environment";
 import { deepMergeObjects } from "../shared/utils";
 
 const app_constant_overrides = (environment.deploymentConfig as any).app_constants || {};
 
 /** List of constants provided by data-models combined with deployment-specific overrides */
-export const APP_CONSTANTS: typeof DEFAULT_CONSTANTS = deepMergeObjects(
-  DEFAULT_CONSTANTS,
+export const APP_CONSTANTS: IAppConstants = deepMergeObjects(
+  DEFAULT_APP_CONSTANTS,
   app_constant_overrides
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5108,6 +5108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/clone@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@types/clone@npm:2.1.1"
+  checksum: bda9668b9d6e0875d64bbe00763676f566e8647bc224333a03ac7fd66655dfed56a98a9f8304d0145c4411b964649c84c4d1a03adbdb6547eafb9ab8f303d254
+  languageName: node
+  linkType: hard
+
 "@types/component-emitter@npm:^1.2.10":
   version: 1.2.11
   resolution: "@types/component-emitter@npm:1.2.11"
@@ -9942,7 +9949,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "data-models@workspace:packages/data-models"
   dependencies:
+    "@types/clone": ^2.1.1
     "@types/node": ^15.12.4
+    clone: ^2.1.2
     scripts: "workspace:*"
     typescript: ~4.2.4
   languageName: unknown


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
When setting the login page defaults for plh_tz the same change was also appearing on plh_za. This is due to a quirk with how javascript handles deeply nested objects. 

When we set the deployment the scripts first process all available configs to check the config name which is specified in the .ts file, and because some config files may extend others (e.g. plh_tz and plh_za both derive from plh_global). If plh_tz changes a property on itself (e.g. `APP_AUTHENTICATION_DEFAULTS.enforceLogin`), the change isn't actually made on the singular plh_tz configuration json object, but instead on another reference object that javascript holds for deeply nested json which is still linked to plh_global. This same reference object is used when populating plh_za inherits from plh_global, and hence the change made is accidentally passed on.

To fix this new methods have been added for both retrieving the default list of app constants and extending a common config configuration which force javascript to deeply clone objects first (and force new reference allocations). This should therefore avoid the accidental spillover of changes from one object to another

## Review Notes
Run `yarn scripts deployment set` for different configs and check nested json appears as expected in the output (namely the APP_AUTHENTICATION_DEFAULTS, or if set a deeper nested item could be  NOTIFICATION_DEFAULTS.time.hour).

As configs are processed in alphabetical order the main check would be that za.config.ts does not inherit from tz.config.ts

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
