### PR TITLE
feat: allow templates to dynamically reference app version number

### DIFF
--- a/packages/app-data/sheets/template/example_hardcoded/example_hardcoded_fields.json
+++ b/packages/app-data/sheets/template/example_hardcoded/example_hardcoded_fields.json
@@ -119,6 +119,41 @@
           "value"
         ]
       }
+    },
+    {
+      "type": "subtitle",
+      "name": "app_version_label",
+      "value": "_app_version",
+      "_translations": {
+        "value": {}
+      },
+      "exclude_from_translation": true,
+      "_nested_name": "app_version_label"
+    },
+    {
+      "type": "text",
+      "name": "app_version_value",
+      "value": "@fields._app_version",
+      "_translations": {
+        "value": {}
+      },
+      "exclude_from_translation": true,
+      "_nested_name": "app_version_value",
+      "_dynamicFields": {
+        "value": [
+          {
+            "fullExpression": "@fields._app_version",
+            "matchedExpression": "@fields._app_version",
+            "type": "fields",
+            "fieldName": "_app_version"
+          }
+        ]
+      },
+      "_dynamicDependencies": {
+        "@fields._app_version": [
+          "value"
+        ]
+      }
     }
   ],
   "_xlsxPath": "quality_assurance/example_sheets/to_be_sorted/hardcoded_variables.xlsx"

--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -37,6 +37,7 @@ const APP_FIELDS = {
   SERVER_SYNC_LATEST: `${FIELD_PREFIX}._server_sync_latest`,
   APP_LANGUAGE: `${FIELD_PREFIX}._app_language`,
   DEPLOYMENT_NAME: `${FIELD_PREFIX}._deployment_name`,
+  APP_VERSION: `${FIELD_PREFIX}._app_version`,
   APP_AUTH_USER: `${FIELD_PREFIX}._app_auth_user`,
 };
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,6 +81,7 @@ export class AppComponent {
     this.platform.ready().then(async () => {
       // ensure deployment field set correctly for use in any startup services or templates
       localStorage.setItem(APP_FIELDS.DEPLOYMENT_NAME, this.DEPLOYMENT_NAME);
+      localStorage.setItem(APP_FIELDS.APP_VERSION, this.APP_VERSION);
       await this.initialiseCoreServices();
       this.hackSetDeveloperOptions();
       const isDeveloperMode = this.templateFieldService.getField("user_mode") === false;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds `_app_version` to `APP_FIELDS` to be dynamically referenced in templates using `@fields._app_version`

## Screenshots/Videos

<img width="621" alt="Screenshot 2022-06-17 at 11 20 31" src="https://user-images.githubusercontent.com/64838927/174279634-4e5b5c5c-87df-46a0-b504-ec4601535020.png">
<img width="960" alt="Screenshot 2022-06-17 at 11 20 41" src="https://user-images.githubusercontent.com/64838927/174279643-e2cec6e2-53a9-4567-be2d-92189e24214e.png">

