### PR TITLE
bug: fixed splash screen styling on small screens

### DIFF
--- a/packages/app-data/sheets/template/splash_screens.json
+++ b/packages/app-data/sheets/template/splash_screens.json
@@ -65,6 +65,9 @@
                   "tz_sw": true
                 }
               },
+              "parameter_list": {
+                "text_align": "center"
+              },
               "_nested_name": "animated_slides.animated_section.slogan_1"
             }
           ],
@@ -294,7 +297,7 @@
             {
               "type": "display_group",
               "parameter_list": {
-                "style": "two_columns_images tight"
+                "style": "two_columns_images grid-spacing-sm"
               },
               "rows": [
                 {

--- a/src/app/shared/components/template/components/animated-slides/animated-slides.component.scss
+++ b/src/app/shared/components/template/components/animated-slides/animated-slides.component.scss
@@ -4,7 +4,7 @@
   }
   .section-container {
     position: relative;
-    width: 300px;
+    max-width: 300px;
     max-height: 85%;
     margin-top: 15%;
     margin-left: auto;

--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -50,11 +50,18 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style~="parent_point"] 
     max-width: 160px;
     padding: 16px;
   }
-  &[data-param-style~="tight"] {
+  @media (max-width: 375px) {
     plh-template-component {
-      display: block;
-      max-height: 70px;
-      max-width: 160px;
+      padding: 4px;
+    }
+  }
+  &[data-param-style~="grid-spacing-sm"] {
+    grid-gap: 16px;
+    @media (max-width: 375px) {
+      grid-gap: 8px;
+    }
+    plh-template-component {
+      max-height: 80px;
       padding: 0px;
     }
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes but where splash screen slideshow didn't display properly on small screens, with some content being cut off (see issue #1384).
Also makes `display-group` with the style `two_columns_images` change its padding responsively, making the grid spacing smaller for screens less than 375px in width. Also renames 

## Git Issues

Closes #1384 

## Screenshots/Videos

The splash screens resizing responsively, displaying adequately on screens as small as 320px (the smallest size we support)

https://user-images.githubusercontent.com/64838927/174628349-d1d36cb3-7512-427a-abf8-615fa7d7fdd7.mov


