### PR TITLE
bug: removed excess top padding from slider component

### DIFF
--- a/src/app/shared/components/template/components/slider/slider.component.html
+++ b/src/app/shared/components/template/components/slider/slider.component.html
@@ -1,4 +1,4 @@
-<div class="slider-wrapper margin-t-huge">
+<div class="slider-wrapper">
   <div class="title-slider">
     {{ title }}
   </div>


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The slider component previously included a large blank space above the slider element itself. This has been removed.
It could be worth considering any particular examples in the current templates that this styling update might negatively effect – presumably the class `margin-t-huge`, which added the whitespace above the slider, was originally applied here for reason.

## Git Issues

Closes #1423 

## Screenshots/Videos

### Component demo before and after
<img width="931" alt="Screenshot 2022-06-21 at 12 17 50" src="https://user-images.githubusercontent.com/64838927/174787219-d27c1cd3-d0e5-4004-b66b-c58edd47c2ae.png">

### In situ before and after (`survey_final_q_1` template)
<img width="929" alt="Screenshot 2022-06-21 at 12 16 53" src="https://user-images.githubusercontent.com/64838927/174787331-dc4b8381-0f2d-45d0-95f5-047068908bf3.png">

