### PR TITLE
feat: fix and improve component for copying text to clipboard, and apply to user code screen

### DIFF
--- a/packages/app-data/sheets/template/component_demo/comp_select_text.json
+++ b/packages/app-data/sheets/template/component_demo/comp_select_text.json
@@ -1,8 +1,8 @@
 {
   "flow_type": "template",
-  "flow_name": "feature_select_text",
+  "flow_name": "comp_select_text",
   "status": "released",
-  "flow_subtype": "debug",
+  "flow_subtype": "component_demo",
   "rows": [
     {
       "name": "user_id",
@@ -31,7 +31,7 @@
     },
     {
       "name": "copy_text",
-      "value": "Copy this",
+      "value": "Copy to clipboard",
       "_translations": {
         "value": {}
       },

--- a/packages/app-data/sheets/template/user_code.json
+++ b/packages/app-data/sheets/template/user_code.json
@@ -99,41 +99,32 @@
       },
       "rows": [
         {
-          "type": "display_group",
-          "name": "dg_user_code",
-          "parameter_list": {
-            "style": "dashed_box"
+          "type": "select_text",
+          "name": "user_code",
+          "value": "@local.user_id",
+          "_translations": {
+            "value": {}
           },
-          "rows": [
-            {
-              "type": "subtitle",
-              "name": "code",
-              "value": "@local.user_id",
-              "_translations": {
-                "value": {}
-              },
-              "parameter_list": {
-                "style": "center"
-              },
-              "_nested_name": "has_ever_been_synced.dg_user_code.code",
-              "_dynamicFields": {
-                "value": [
-                  {
-                    "fullExpression": "@local.user_id",
-                    "matchedExpression": "@local.user_id",
-                    "type": "local",
-                    "fieldName": "user_id"
-                  }
-                ]
-              },
-              "_dynamicDependencies": {
-                "@local.user_id": [
-                  "value"
-                ]
+          "parameter_list": {
+            "copy_text": "Copy code",
+            "copied_text": "Copied!"
+          },
+          "_nested_name": "has_ever_been_synced.user_code",
+          "_dynamicFields": {
+            "value": [
+              {
+                "fullExpression": "@local.user_id",
+                "matchedExpression": "@local.user_id",
+                "type": "local",
+                "fieldName": "user_id"
               }
-            }
-          ],
-          "_nested_name": "has_ever_been_synced.dg_user_code"
+            ]
+          },
+          "_dynamicDependencies": {
+            "@local.user_id": [
+              "value"
+            ]
+          }
         },
         {
           "type": "text",

--- a/src/app/shared/components/template/components/select-text/select-text.component.html
+++ b/src/app/shared/components/template/components/select-text/select-text.component.html
@@ -1,48 +1,42 @@
-<div
-  class="bordered-line mt-20 individual-select-text-box"
-  [attr.data-toggled]="toggle"
-  (click)="triggerCopyContent($event, _row)"
->
-  <div class="">
-    <div class="ion-float-left">{{ _row?.name }}</div>
-    <div class="ion-float-right">
-      <ng-container *ngIf="_row?.parameter_list?.copy_text && _row?.parameter_list.copied_text">
-        <ng-container *ngIf="!toggle; else copy_text_replace">{{
-          _row.parameter_list.copy_text
-        }}</ng-container>
-        <ng-template #copy_text_replace>{{ _row.parameter_list.copied_text }}</ng-template>
+<div class="box-wrapper" [attr.data-toggled]="toggle" (click)="triggerCopyContent($event, _row)">
+  <div class="text">{{ _row?.value }}</div>
+  <div class="copy-button">
+    <ng-container *ngIf="_row?.parameter_list?.copy_text && _row?.parameter_list.copied_text">
+      <ng-container *ngIf="!toggle; else copy_text_replace">{{
+        _row.parameter_list.copy_text
+      }}</ng-container>
+      <ng-template #copy_text_replace>{{ _row.parameter_list.copied_text }}</ng-template>
+    </ng-container>
+
+    <ng-container *ngIf="_row.parameter_list?.copy_icon && _row.parameter_list.copied_text">
+      <ng-container *ngIf="!toggle; else copy_icon_replace">
+        <ion-icon name="{{ _row.parameter_list?.copy_icon }}"></ion-icon>
       </ng-container>
 
-      <ng-container *ngIf="_row.parameter_list?.copy_icon && _row.parameter_list.copied_text">
-        <ng-container *ngIf="!toggle; else copy_icon_replace">
-          <ion-icon name="{{ _row.parameter_list?.copy_icon }}"></ion-icon>
-        </ng-container>
+      <ng-template #copy_icon_replace>
+        <span class="copy_text">{{ _row?.parameter_list.copied_text }}</span>
+      </ng-template>
+    </ng-container>
 
-        <ng-template #copy_icon_replace>
-          <span class="copy_text">{{ _row?.parameter_list.copied_text }}</span>
-        </ng-template>
+    <ng-container *ngIf="_row.parameter_list?.copy_text && _row.parameter_list.copied_icon">
+      <ng-container *ngIf="!toggle; else copy_text_replace">
+        {{ _row.parameter_list?.copy_text }}
       </ng-container>
 
-      <ng-container *ngIf="_row.parameter_list?.copy_text && _row.parameter_list.copied_icon">
-        <ng-container *ngIf="!toggle; else copy_text_replace">
-          {{ _row.parameter_list?.copy_text }}
-        </ng-container>
+      <ng-template #copy_text_replace>
+        <ion-icon name="{{ _row.parameter_list?.copied_icon }}"></ion-icon>
+      </ng-template>
+    </ng-container>
 
-        <ng-template #copy_text_replace>
-          <ion-icon name="{{ _row.parameter_list?.copied_icon }}"></ion-icon>
-        </ng-template>
+    <ng-container *ngIf="_row.parameter_list?.copy_icon && _row.parameter_list?.copied_icon">
+      <ng-container *ngIf="!toggle; else copy_img_replace">
+        <ion-icon name="{{ _row.parameter_list?.copy_icon }}"></ion-icon>
       </ng-container>
 
-      <ng-container *ngIf="_row.parameter_list?.copy_icon && _row.parameter_list?.copied_icon">
-        <ng-container *ngIf="!toggle; else copy_img_replace">
-          <ion-icon name="{{ _row.parameter_list?.copy_icon }}"></ion-icon>
-        </ng-container>
-
-        <ng-template #copy_img_replace>
-          <img class="image-based-icon" [src]="_row.parameter_list.copied_icon | plhAsset" />
-        </ng-template>
-      </ng-container>
-    </div>
-    <span></span>
+      <ng-template #copy_img_replace>
+        <img class="image-based-icon" [src]="_row.parameter_list.copied_icon | plhAsset" />
+      </ng-template>
+    </ng-container>
   </div>
+  <span></span>
 </div>

--- a/src/app/shared/components/template/components/select-text/select-text.component.scss
+++ b/src/app/shared/components/template/components/select-text/select-text.component.scss
@@ -1,37 +1,39 @@
-.bordered-line {
-  border: 4px dashed rgba(220, 220, 220);
-  border-radius: 4px;
-  min-height: 40px;
-  margin-bottom: 20px;
+@use "/src/theme/mixins";
+
+.box-wrapper {
+  @include mixins.flex-centered;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  padding: var(--regular-padding);
+  width: 100%;
+  min-height: var(--dashed-box-item-min-height);
+  padding: var(--regular-padding) var(--largest-padding);
+  border: 2px dashed var(--ion-color-primary);
+  background-color: var(--ion-color-primary-contrast);
+  border-radius: var(--ion-border-radius-secondary);
+  position: relative;
   cursor: pointer;
-  background-color: #ffffff;
-}
+  color: var(--ion-color-primary);
 
-.bordered-line.green {
-  color: rgb(255, 255, 255);
-}
+  &[data-toggled="true"] {
+    background-color: var(--ion-color-primary-light);
+    border-color: var(--ion-color-primary-shade);
+  }
 
-.icon-image-contain {
-  max-width: 24px;
-  max-height: 24px;
-}
-
-.mt-20 {
-  margin-top: 20px;
-}
-
-.individual-select-text-box[data-toggled="true"] {
-  background-color: rgba(0, 128, 0, 0.2);
-  border: 4px dashed rgba(0, 128, 0, 0.9);
+  .text {
+    width: 100%;
+    text-align: center;
+    font-size: var(--font-size-text-large);
+    line-height: var(--line-height-text-largest);
+  }
+  .copy-button {
+    margin-top: 1rem;
+  }
 }
 
 .image-based-icon {
   width: 100%;
   max-width: 16px;
   height: auto;
-}
-
-.individual-select-text-box {
-  display: grid;
-  padding: 10px 15px;
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Addresses [this](https://github.com/IDEMSInternational/parenting-app-ui/issues/1006#issuecomment-1187596203) comment on reopened issue #1006, regarding the copy-to-clipboard component, namely:
1. The component now displays the `value` instead of the `name`
2. The text within the component now wraps properly (see images below)
3. The component is now styled in keeping with the rest of the app 

Currently this component reuses some of the styling from the `dashed_box` `display_group`, but the components are unrelated. In the future, the styling of both components could be coupled together.

## Git Issues

Closes #1006 

## Screenshots/Videos

The select text component, available at `template/comp_select_text`. Showing proper text wrapping
<img width="399" alt="Screenshot 2022-07-20 at 10 15 29" src="https://user-images.githubusercontent.com/64838927/179946926-167f1cd0-3b6e-4c16-b0af-8ee2eabcb95c.png">
<img width="204" alt="Screenshot 2022-07-20 at 10 16 00" src="https://user-images.githubusercontent.com/64838927/179946935-98203268-a914-48f0-a6c8-fa93ee16dbb0.png">

The `user_code` page making use of the component:
<img width="387" alt="Screenshot 2022-07-20 at 10 15 43" src="https://user-images.githubusercontent.com/64838927/179947258-c32c6d94-7a63-4bc5-953f-5ce1baed1fec.png">
<img width="381" alt="Screenshot 2022-07-20 at 10 24 23" src="https://user-images.githubusercontent.com/64838927/179947500-e6060093-1b93-47e2-897f-6c6668f49972.png">

