### PR TITLE
bug: fixed text sizing issue on overflow funder on splash_funders template

### DIFF
--- a/packages/app-data/sheets/template/splash_funders.json
+++ b/packages/app-data/sheets/template/splash_funders.json
@@ -147,84 +147,94 @@
       "_nested_name": "global_funders"
     },
     {
-      "type": "items",
-      "name": "loop_funders_description",
-      "value": "@local.funders_data",
+      "type": "display_group",
+      "name": "global_funders_overflow",
+      "parameter_list": {
+        "style": "two_columns_images_overflow grid-spacing-sm"
+      },
       "rows": [
         {
-          "type": "text",
-          "name": "@item.id",
-          "value": "@item.description",
-          "_translations": {
-            "value": {}
-          },
-          "condition": "@item.description",
-          "parameter_list": {
-            "style": "center"
-          },
-          "_nested_name": "loop_funders_description.@item.id",
-          "_dynamicFields": {
-            "name": [
-              {
-                "fullExpression": "@item.id",
-                "matchedExpression": "@item.id",
-                "type": "item",
-                "fieldName": "id"
+          "type": "items",
+          "name": "loop_funders_description",
+          "value": "@local.funders_data",
+          "rows": [
+            {
+              "type": "subtitle",
+              "name": "@item.id",
+              "value": "@item.description",
+              "_translations": {
+                "value": {}
+              },
+              "condition": "@item.description",
+              "parameter_list": {
+                "style": "center small"
+              },
+              "_nested_name": "global_funders_overflow.loop_funders_description.@item.id",
+              "_dynamicFields": {
+                "name": [
+                  {
+                    "fullExpression": "@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ],
+                "value": [
+                  {
+                    "fullExpression": "@item.description",
+                    "matchedExpression": "@item.description",
+                    "type": "item",
+                    "fieldName": "description"
+                  }
+                ],
+                "condition": [
+                  {
+                    "fullExpression": "@item.description",
+                    "matchedExpression": "@item.description",
+                    "type": "item",
+                    "fieldName": "description"
+                  }
+                ],
+                "_nested_name": [
+                  {
+                    "fullExpression": "global_funders_overflow.loop_funders_description.@item.id",
+                    "matchedExpression": "@item.id",
+                    "type": "item",
+                    "fieldName": "id"
+                  }
+                ]
+              },
+              "_dynamicDependencies": {
+                "@item.id": [
+                  "name",
+                  "_nested_name"
+                ],
+                "@item.description": [
+                  "value",
+                  "condition"
+                ]
               }
-            ],
+            }
+          ],
+          "_nested_name": "global_funders_overflow.loop_funders_description",
+          "_dynamicFields": {
             "value": [
               {
-                "fullExpression": "@item.description",
-                "matchedExpression": "@item.description",
-                "type": "item",
-                "fieldName": "description"
-              }
-            ],
-            "condition": [
-              {
-                "fullExpression": "@item.description",
-                "matchedExpression": "@item.description",
-                "type": "item",
-                "fieldName": "description"
-              }
-            ],
-            "_nested_name": [
-              {
-                "fullExpression": "loop_funders_description.@item.id",
-                "matchedExpression": "@item.id",
-                "type": "item",
-                "fieldName": "id"
+                "fullExpression": "@local.funders_data",
+                "matchedExpression": "@local.funders_data",
+                "type": "local",
+                "fieldName": "funders_data"
               }
             ]
           },
           "_dynamicDependencies": {
-            "@item.id": [
-              "name",
-              "_nested_name"
-            ],
-            "@item.description": [
-              "value",
-              "condition"
+            "@local.funders_data": [
+              "value"
             ]
           }
         }
       ],
-      "_nested_name": "loop_funders_description",
-      "_dynamicFields": {
-        "value": [
-          {
-            "fullExpression": "@local.funders_data",
-            "matchedExpression": "@local.funders_data",
-            "type": "local",
-            "fieldName": "funders_data"
-          }
-        ]
-      },
-      "_dynamicDependencies": {
-        "@local.funders_data": [
-          "value"
-        ]
-      }
+      "_nested_name": "global_funders_overflow"
     }
   ],
   "_xlsxPath": "global/core_templates/core_templates_app_launch.xlsx"

--- a/packages/app-data/sheets/template/splash_funders.json
+++ b/packages/app-data/sheets/template/splash_funders.json
@@ -167,7 +167,7 @@
               },
               "condition": "@item.description",
               "parameter_list": {
-                "style": "center small"
+                "style": "center tiny"
               },
               "_nested_name": "global_funders_overflow.loop_funders_description.@item.id",
               "_dynamicFields": {

--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -76,10 +76,9 @@ plh-tmpl-display-group .display-group-wrapper[data-param-style~="parent_point"] 
     display: block;
     max-height: 160px;
     max-width: 160px;
-    padding: 32px 16px 16px 16px;
   }
   .tmpl-image-container {
-    padding: 0 !important;
+    padding: 32px 16px 16px 16px;
   }
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The final funder in the list is represented by text rather than a log. This text needed to be styled to fit with the other funders' logos, but there was no way to do this from the template level.
This PR styles the text correctly by making use of the `display_group` with style `two_columns_images_overflow`.

## Notes

Because the `text` component has the class `large` applied by default, it doesn't seem possible to resize text from the template level, either by using a parameter, e.g. `style: small`, or an explicit style in `style_list`, e.g. `font-size: 50%`. Therefore I used the `subtitle` component, for which the text size can be affected by `style: small`. This seems like a workaround and something that can be addressed with the theming system – I'm not sure why the `large` class is forced on all text, but it means text size can't be affected by parent elements of `text` components, unless I'm missing a way to do it. @chrismclarke we could discuss at some point, probably in the context of theming, and how to apply theme variables relating to text.

## Git Issues

Closes #1443 

## Screenshots/Videos

(The previous styling can be seen in the screenshot in the issue)
<img width="383" alt="Screenshot 2022-07-21 at 12 28 59" src="https://user-images.githubusercontent.com/64838927/180205828-84bd0654-eedc-426a-a94e-9a3c13a3f6aa.png">

