### PR TITLE
Update debug radio globals

### DIFF
--- a/packages/app-data/sheets/template/debug/debug_lang_global_1.json
+++ b/packages/app-data/sheets/template/debug/debug_lang_global_1.json
@@ -40,7 +40,9 @@
       "name": "text_2",
       "value": "Text and @global.language_global_1",
       "_translations": {
-        "value": {}
+        "value": {
+          "es_sp": true
+        }
       },
       "_nested_name": "text_2",
       "_dynamicFields": {
@@ -124,6 +126,33 @@
       }
     },
     {
+      "name": "answer_list_4",
+      "value": [
+        "name:happy | text: @local.text_2",
+        "name:ok | text:ok",
+        "name:sad | text:sad"
+      ],
+      "type": "set_variable",
+      "_nested_name": "answer_list_4",
+      "_dynamicFields": {
+        "value": {
+          "0": [
+            {
+              "fullExpression": "name:happy | text: @local.text_2",
+              "matchedExpression": "@local.text_2",
+              "type": "local",
+              "fieldName": "text_2"
+            }
+          ]
+        }
+      },
+      "_dynamicDependencies": {
+        "@local.text_2": [
+          "value.0"
+        ]
+      }
+    },
+    {
       "type": "radio_group",
       "name": "radio_group_1",
       "parameter_list": {
@@ -199,6 +228,31 @@
       }
     },
     {
+      "type": "radio_group",
+      "name": "radio_group_4",
+      "parameter_list": {
+        "answer_list": "@local.answer_list_4"
+      },
+      "_nested_name": "radio_group_4",
+      "_dynamicFields": {
+        "parameter_list": {
+          "answer_list": [
+            {
+              "fullExpression": "@local.answer_list_4",
+              "matchedExpression": "@local.answer_list_4",
+              "type": "local",
+              "fieldName": "answer_list_4"
+            }
+          ]
+        }
+      },
+      "_dynamicDependencies": {
+        "@local.answer_list_4": [
+          "parameter_list.answer_list"
+        ]
+      }
+    },
+    {
       "type": "combo_box",
       "name": "combo_box_1",
       "parameter_list": {
@@ -269,6 +323,31 @@
       },
       "_dynamicDependencies": {
         "@local.answer_list_3": [
+          "parameter_list.answer_list"
+        ]
+      }
+    },
+    {
+      "type": "combo_box",
+      "name": "combo_box_4",
+      "parameter_list": {
+        "answer_list": "@local.answer_list_4"
+      },
+      "_nested_name": "combo_box_4",
+      "_dynamicFields": {
+        "parameter_list": {
+          "answer_list": [
+            {
+              "fullExpression": "@local.answer_list_4",
+              "matchedExpression": "@local.answer_list_4",
+              "type": "local",
+              "fieldName": "answer_list_4"
+            }
+          ]
+        }
+      },
+      "_dynamicDependencies": {
+        "@local.answer_list_4": [
           "parameter_list.answer_list"
         ]
       }

--- a/packages/app-data/translations/es_sp/strings.json
+++ b/packages/app-data/translations/es_sp/strings.json
@@ -46,5 +46,6 @@
   "@global.language_global_1: \"text\"": "@global.language_global_1: \"texto\"",
   "@global.language_global_2: \"text\"": "@global.language_global_2: \"texto\"",
   "@global.language_global_1: text": "@global.language_global_1: texto",
-  "@global.language_global_2: text": "@global.language_global_2: texto"
+  "@global.language_global_2: text": "@global.language_global_2: texto",
+  "Text and @global.language_global_1": "Texto y @global.language_global_1"
 }

--- a/packages/app-data/translations_source/from_translators/translated.es_sp.json
+++ b/packages/app-data/translations_source/from_translators/translated.es_sp.json
@@ -238,5 +238,10 @@
     "SourceText": "@global.language_global_2: text",
     "text": "@global.language_global_2: texto",
     "type": "template"
+  },
+  {
+    "SourceText": "Text and @global.language_global_1",
+    "text": "Texto y @global.language_global_1",
+    "type": "template"
   }
 ]


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Update debug radio globals to show bug more clearly and include authoring workaround

## Additional Info (from slack)
Just as a quick update, I've looked more into the issue and at the core is the fact that the parameter list passed to the radio-group component is stored as strings retaining | characters, i.e.
0: "name:happy | text: Text and @global.language_global_1"
1: "name:ok | text:ok"
2: "name:sad | text:sad"
So everything that can be translated in a generic way is done so before, but the final form that arrives is more like "name:happy | text: Text and @global.language_global_1" , so the translation doesn't match as intended.

The obvious fix is to move all separation of parameters to a higher level where they can be processed in a more general way, e.g. converted to json {"name": "happy", "text": "Text and @global.language_global_1"}  - this in turn can be translated correctly part by part. However this would be a mid-size refactor so I'm not sure if it's worth undertaking unless we need it more urgently than anything else

Otherwise it is a simple authoring fix by defining the text as a local variable instead (which should translate correctly)

I've updated the example template to include the authoring solution (PR 1458). If we're happy with it for now I'd suggest lowering priority and I'll link this message in the PR for future ref, otherwise we can organise priorities on Friday.

## Git Issues

Relates to #1284

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/181135655-5c79f8f8-41c3-45ac-b068-8045098a0e1e.png)

