### PR TITLE
refactor: Theming – introduce 50-900 colour variants

### DIFF
--- a/packages/app-data/sheets/index.ts
+++ b/packages/app-data/sheets/index.ts
@@ -1108,6 +1108,12 @@ export const SHEETS_CONTENT_LIST: ISheetContents = {
       flow_subtype: "component_demo",
       _xlsxPath: "quality_assurance/component_sheets/component_simple_checkbox .xlsx",
     },
+    comp_colour_palette: {
+      flow_type: "template",
+      flow_name: "comp_colour_palette",
+      flow_subtype: "component_demo",
+      _xlsxPath: "quality_assurance/component_sheets/comp_colour_palette.xlsx",
+    },
     comp_combo_box: {
       flow_type: "template",
       flow_name: "comp_combo_box",

--- a/packages/app-data/sheets/template/component_demo/comp_colour_palette.json
+++ b/packages/app-data/sheets/template/component_demo/comp_colour_palette.json
@@ -1,0 +1,14 @@
+{
+  "flow_type": "template",
+  "flow_name": "comp_colour_palette",
+  "status": "released",
+  "flow_subtype": "component_demo",
+  "rows": [
+    {
+      "type": "colour_palette",
+      "name": "colour_palette",
+      "_nested_name": "colour_palette"
+    }
+  ],
+  "_xlsxPath": "quality_assurance/component_sheets/component_colour_palette.xlsx"
+}

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -273,7 +273,8 @@ export namespace FlowTypes {
     | "select_text"
     | "html"
     | "latex"
-    | "animated_slides";
+    | "animated_slides"
+    | "colour_palette";
 
   export interface TemplateRow extends Row_with_translations {
     type: TemplateRowType;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<ion-app *ngIf="renderAppTemplates" [ngClass]="'theme-' + themeService.currentTheme.name">
+<ion-app *ngIf="renderAppTemplates">
   <ion-menu #menu side="start" menuId="main-side-menu" contentId="main-content">
     <ion-header>
       <ion-toolbar color="primary">

--- a/src/app/feature/theme/theme-service/theme.service.ts
+++ b/src/app/feature/theme/theme-service/theme.service.ts
@@ -28,6 +28,17 @@ export class ThemeService {
 
     this.currentTheme = this.getCurrentTheme();
     this.applyCSSVariablesForTheme(this.currentTheme);
+    this.applyTheme(this.currentTheme.name);
+  }
+
+  public applyTheme(themeName: string) {
+    document.body.classList.add("theme-" + themeName);
+    // remove other "theme-" classes from document.body, only after adding
+    // new theme- class to avoid no theme- class being applied momentarily
+    const classes = document.body.className.split(" ").filter((c) => {
+      return !c.startsWith("theme-") || c === "theme-" + themeName;
+    });
+    document.body.className = classes.join(" ").trim();
   }
 
   private getThemeMap(): { [themeName: string]: AppTheme } {
@@ -65,6 +76,7 @@ export class ThemeService {
     } else {
       this.currentTheme = BASE_THEME;
     }
+    this.applyTheme(this.currentTheme.name);
     this.localStorageService.setString("currentThemeName", this.currentTheme.name);
     this.ipcService.send(ThemeService.THEME_UPDATE_CHANNEL, themeName);
   }

--- a/src/app/feature/theme/theme-service/theme.service.ts
+++ b/src/app/feature/theme/theme-service/theme.service.ts
@@ -32,13 +32,7 @@ export class ThemeService {
   }
 
   public applyTheme(themeName: string) {
-    document.body.classList.add("theme-" + themeName);
-    // remove other "theme-" classes from document.body, only after adding
-    // new theme- class to avoid no theme- class being applied momentarily
-    const classes = document.body.className.split(" ").filter((c) => {
-      return !c.startsWith("theme-") || c === "theme-" + themeName;
-    });
-    document.body.className = classes.join(" ").trim();
+    document.body.dataset.theme = themeName;
   }
 
   private getThemeMap(): { [themeName: string]: AppTheme } {

--- a/src/app/shared/components/template/components/colour-palette/colour-palette.component.html
+++ b/src/app/shared/components/template/components/colour-palette/colour-palette.component.html
@@ -1,0 +1,6 @@
+<div class="palette-container" *ngFor="let colour of themeColours">
+  <div class="swatch-container" *ngFor="let weight of colourWeights">
+    <div [ngClass]="'swatch color-' + colour + '-' + weight"></div>
+    <div class="label">color-{{ colour }}-{{ weight }}</div>
+  </div>
+</div>

--- a/src/app/shared/components/template/components/colour-palette/colour-palette.component.scss
+++ b/src/app/shared/components/template/components/colour-palette/colour-palette.component.scss
@@ -1,0 +1,32 @@
+@use "/src/theme/mixins";
+
+$colors: primary, secondary;
+$colorWeights: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
+
+.palette-container {
+  background-color: white;
+  margin: 20px;
+  padding: 20px;
+}
+
+.swatch-container {
+  @include mixins.flex-centered;
+}
+
+.swatch {
+  width: 100px;
+  height: 30px;
+}
+
+.label {
+  width: 170px;
+  padding-left: 10px;
+}
+
+@each $color in $colors {
+  @each $weight in $colorWeights {
+    .color-#{$color}-#{$weight} {
+      background-color: var(--ion-color-#{$color}-#{$weight});
+    }
+  }
+}

--- a/src/app/shared/components/template/components/colour-palette/colour-palette.component.spec.ts
+++ b/src/app/shared/components/template/components/colour-palette/colour-palette.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { IonicModule } from "@ionic/angular";
+
+import { ColourPaletteComponent } from "./colour-palette.component";
+
+describe("ColourPaletteComponent", () => {
+  let component: ColourPaletteComponent;
+  let fixture: ComponentFixture<ColourPaletteComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ColourPaletteComponent],
+        imports: [IonicModule.forRoot()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ColourPaletteComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/template/components/colour-palette/colour-palette.component.ts
+++ b/src/app/shared/components/template/components/colour-palette/colour-palette.component.ts
@@ -1,0 +1,12 @@
+import { Component } from "@angular/core";
+import { TemplateBaseComponent } from "../base";
+
+@Component({
+  selector: "plh-colour-palette",
+  templateUrl: "./colour-palette.component.html",
+  styleUrls: ["./colour-palette.component.scss"],
+})
+export class TmplColourPaletteComponent extends TemplateBaseComponent {
+  themeColours = ["primary", "secondary"];
+  colourWeights = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
+}

--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -49,6 +49,7 @@ import { TemplateHTMLComponent } from "./html/html.component";
 import { TmplAccordionComponent } from "./accordion/accordion.component";
 import { TmplLatexComponent } from "./latex/latex.component";
 import { TmplAnimatedSlidesComponent } from "./animated-slides/animated-slides.component";
+import { TmplColourPaletteComponent } from "./colour-palette/colour-palette.component";
 
 /** All components should be exported as a single array for easy module import */
 export const TEMPLATE_COMPONENTS = [
@@ -95,6 +96,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplAccordionComponent,
   TmplLatexComponent,
   TmplAnimatedSlidesComponent,
+  TmplColourPaletteComponent,
 ];
 
 /***************************************************************************************
@@ -157,4 +159,5 @@ export const TEMPLATE_COMPONENT_MAPPING: Record<
   html: TemplateHTMLComponent,
   latex: TmplLatexComponent,
   animated_slides: TmplAnimatedSlidesComponent,
+  colour_palette: TmplColourPaletteComponent,
 };

--- a/src/app/shared/components/template/components/select-text/select-text.component.scss
+++ b/src/app/shared/components/template/components/select-text/select-text.component.scss
@@ -17,7 +17,7 @@
   color: var(--ion-color-primary);
 
   &[data-toggled="true"] {
-    background-color: var(--ion-color-primary-light);
+    background-color: var(--ion-color-primary-200);
     border-color: var(--ion-color-primary-shade);
   }
 

--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -2,7 +2,7 @@ ion-content.background-secondary {
   --background: var(--ion-color-secondary);
 }
 ion-content.background-primary-lighter {
-  --background: var(--ion-color-primary-lighter);
+  --background: var(--ion-color-primary-50);
 }
 ion-content.background-white {
   --background: white;
@@ -11,7 +11,7 @@ ion-content.background-white {
   background: var(--ion-color-secondary);
 }
 .background-primary-lighter {
-  background: var(--ion-color-primary-lighter);
+  background: var(--ion-color-primary-50);
 }
 .background-white {
   background: white;

--- a/src/theme/themes/default.scss
+++ b/src/theme/themes/default.scss
@@ -5,7 +5,7 @@ $color-primary: hsl(203, 76%, 21%);
 $color-secondary: hsl(31, 95%, 57%);
 
 @mixin theme-default {
-  .theme-default {
+  [data-theme="default"] {
     @include utils.generateTheme($color-primary, $color-secondary);
   }
 }

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -4,33 +4,18 @@
 
 // Returns a map of colours based partly on Material Design's colour system
 // https://material.io/design/color/the-color-system.html
-@function getColorPalette($primary, $secondary, $page-background: null) {
+@function getColorPalette(
+  $primary,
+  $secondary,
+  $page-background: null,
+  $weights: (50, 100, 200, 300, 400, 500, 600, 700, 800, 900)
+) {
   $result: (
     "color-primary": $primary,
-    "color-primary-50": color.change($primary, $lightness: 95%),
-    "color-primary-100": color.change($primary, $lightness: 90%),
-    "color-primary-200": color.change($primary, $lightness: 80%),
-    "color-primary-300": color.change($primary, $lightness: 70%),
-    "color-primary-400": color.change($primary, $lightness: 60%),
-    "color-primary-500": color.change($primary, $lightness: 50%),
-    "color-primary-600": color.change($primary, $lightness: 40%),
-    "color-primary-700": color.change($primary, $lightness: 30%),
-    "color-primary-800": color.change($primary, $lightness: 20%),
-    "color-primary-900": color.change($primary, $lightness: 10%),
     "color-primary-contrast": contrast-colour.choose-contrast-color($primary),
     "color-secondary": $secondary,
-    "color-secondary-50": color.change($secondary, $lightness: 95%),
-    "color-secondary-100": color.change($secondary, $lightness: 90%),
-    "color-secondary-200": color.change($secondary, $lightness: 80%),
-    "color-secondary-300": color.change($secondary, $lightness: 70%),
-    "color-secondary-400": color.change($secondary, $lightness: 60%),
-    "color-secondary-500": color.change($secondary, $lightness: 50%),
-    "color-secondary-600": color.change($secondary, $lightness: 40%),
-    "color-secondary-700": color.change($secondary, $lightness: 30%),
-    "color-secondary-800": color.change($secondary, $lightness: 20%),
-    "color-secondary-900": color.change($secondary, $lightness: 10%),
     "color-secondary-contrast": contrast-colour.choose-contrast-color($secondary),
-    "color-page-background": color.change($primary, $lightness: 95%),
+    "background-color": color.change($primary, $lightness: 95%),
     //  GRADIENTS
     // primary-gradient
     "gradient-primary-start": color.adjust($primary, $lightness: 33%),
@@ -39,11 +24,27 @@
     "gradient-secondary-start": color.adjust($secondary, $saturation: 4%),
     "gradient-secondary-end": color.adjust($secondary, $saturation: 5%, $lightness: -19%),
   );
+
+  // Generate variants of base colours based on given weights and add to map
+  // E.g. '"color-primary-400": color.change($primary, $lightness: 60%)'
+  $result: map.merge($result, generateColourVariants($primary, "primary", $weights));
+  $result: map.merge($result, generateColourVariants($secondary, "secondary", $weights));
+
   @if ($page-background != null) {
-    $result: map.set($result, "color-page-background", $page-background);
+    $result: map.set($result, "background-color", $page-background);
   }
   @return $result;
 }
+
+@function generateColourVariants($base, $baseName, $weights) {
+  $variants-map: ();
+  @each $weight in $weights {
+    $map: (color-#{$baseName}-#{$weight}: color.change($base, $lightness: 100 - ($weight / 10)));
+    $variants-map: map.merge($variants-map, $map);
+  }
+  @return $variants-map;
+}
+
 @mixin generateTheme($p, $s, $bg: null) {
   $colorPalette: getColorPalette($p, $s, $bg);
   @include colorVariables($colorPalette);
@@ -52,33 +53,11 @@
 @mixin colorVariables($sourceColorPalette) {
   $colorPalette: $sourceColorPalette;
 
-  --ion-color-primary: #{map.get($colorPalette, "color-primary")};
-  --ion-color-primary-50: #{map.get($colorPalette, "color-primary-50")};
-  --ion-color-primary-100: #{map.get($colorPalette, "color-primary-100")};
-  --ion-color-primary-200: #{map.get($colorPalette, "color-primary-200")};
-  --ion-color-primary-300: #{map.get($colorPalette, "color-primary-300")};
-  --ion-color-primary-400: #{map.get($colorPalette, "color-primary-400")};
-  --ion-color-primary-500: #{map.get($colorPalette, "color-primary-500")};
-  --ion-color-primary-600: #{map.get($colorPalette, "color-primary-600")};
-  --ion-color-primary-700: #{map.get($colorPalette, "color-primary-700")};
-  --ion-color-primary-800: #{map.get($colorPalette, "color-primary-800")};
-  --ion-color-primary-900: #{map.get($colorPalette, "color-primary-900")};
-  --ion-color-primary-contrast: #{map.get($colorPalette, "color-primary-contrast")};
-
-  --ion-color-secondary: #{map.get($colorPalette, "color-secondary")};
-  --ion-color-secondary-50: #{map.get($colorPalette, "color-secondary-50")};
-  --ion-color-secondary-100: #{map.get($colorPalette, "color-secondary-100")};
-  --ion-color-secondary-200: #{map.get($colorPalette, "color-secondary-200")};
-  --ion-color-secondary-300: #{map.get($colorPalette, "color-secondary-300")};
-  --ion-color-secondary-400: #{map.get($colorPalette, "color-secondary-400")};
-  --ion-color-secondary-500: #{map.get($colorPalette, "color-secondary-500")};
-  --ion-color-secondary-600: #{map.get($colorPalette, "color-secondary-600")};
-  --ion-color-secondary-700: #{map.get($colorPalette, "color-secondary-700")};
-  --ion-color-secondary-800: #{map.get($colorPalette, "color-secondary-800")};
-  --ion-color-secondary-900: #{map.get($colorPalette, "color-secondary-900")};
-  --ion-color-secondary-contrast: #{map.get($colorPalette, "color-secondary-contrast")};
-
-  --ion-background-color: #{map.get($colorPalette, "color-page-background")};
+  // Generate variants of base colours based on given weights and add to map
+  // E.g. equivalent to '--ion-color-primary-400: #{map.get($colorPalette, "color-primary-400")}'
+  @each $label, $color in $colorPalette {
+    --ion-#{$label}: #{$color};
+  }
 
   // BORDERS
   --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -5,12 +5,30 @@
 @function getColorPalette($primary, $secondary, $page-background: null) {
   $result: (
     "color-primary": $primary,
-    "color-primary-light": color.change($primary, $lightness: 80%),
-    "color-primary-lighter": color.change($primary, $lightness: 95%),
+    "color-primary-50": color.change($primary, $lightness: 95%),
+    "color-primary-100": color.change($primary, $lightness: 90%),
+    "color-primary-200": color.change($primary, $lightness: 80%),
+    "color-primary-300": color.change($primary, $lightness: 70%),
+    "color-primary-400": color.change($primary, $lightness: 60%),
+    "color-primary-500": color.change($primary, $lightness: 50%),
+    "color-primary-600": color.change($primary, $lightness: 40%),
+    "color-primary-700": color.change($primary, $lightness: 30%),
+    "color-primary-800": color.change($primary, $lightness: 20%),
+    "color-primary-900": color.change($primary, $lightness: 10%),
     "color-primary-contrast": contrast-colour.choose-contrast-color($primary),
     "color-secondary": $secondary,
     "color-secondary-light": color.change($secondary, $lightness: 80%),
     "color-secondary-lighter": color.change($secondary, $lightness: 95%),
+    "color-secondary-50": color.change($secondary, $lightness: 95%),
+    "color-secondary-100": color.change($secondary, $lightness: 90%),
+    "color-secondary-200": color.change($secondary, $lightness: 80%),
+    "color-secondary-300": color.change($secondary, $lightness: 70%),
+    "color-secondary-400": color.change($secondary, $lightness: 60%),
+    "color-secondary-500": color.change($secondary, $lightness: 50%),
+    "color-secondary-600": color.change($secondary, $lightness: 40%),
+    "color-secondary-700": color.change($secondary, $lightness: 30%),
+    "color-secondary-800": color.change($secondary, $lightness: 20%),
+    "color-secondary-900": color.change($secondary, $lightness: 10%),
     "color-secondary-contrast": contrast-colour.choose-contrast-color($secondary),
     "color-page-background": color.change($primary, $lightness: 95%),
     //  GRADIENTS
@@ -35,13 +53,13 @@
   $colorPalette: $sourceColorPalette;
 
   --ion-color-primary: #{map.get($colorPalette, "color-primary")};
-  --ion-color-primary-light: #{map.get($colorPalette, "color-primary-light")};
-  --ion-color-primary-lighter: #{map.get($colorPalette, "color-primary-lighter")};
+  --ion-color-primary-light: #{map.get($colorPalette, "color-primary-200")};
+  --ion-color-primary-lighter: #{map.get($colorPalette, "color-primary-50")};
   --ion-color-primary-contrast: #{map.get($colorPalette, "color-primary-contrast")};
 
   --ion-color-secondary: #{map.get($colorPalette, "color-secondary")};
-  --ion-color-secondary-light: #{map.get($colorPalette, "color-secondary-light")};
-  --ion-color-secondary-lighter: #{map.get($colorPalette, "color-secondary-lighter")};
+  --ion-color-secondary-light: #{map.get($colorPalette, "color-secondary-200")};
+  --ion-color-secondary-lighter: #{map.get($colorPalette, "color-secondary-50")};
   --ion-color-secondary-contrast: #{map.get($colorPalette, "color-secondary-contrast")};
 
   --ion-background-color: #{map.get($colorPalette, "color-page-background")};

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -2,6 +2,8 @@
 @use "sass:map";
 @use "./contrast-colour.scss";
 
+// Returns a map of colours based partly on Material Design's colour system
+// https://material.io/design/color/the-color-system.html
 @function getColorPalette($primary, $secondary, $page-background: null) {
   $result: (
     "color-primary": $primary,
@@ -17,8 +19,6 @@
     "color-primary-900": color.change($primary, $lightness: 10%),
     "color-primary-contrast": contrast-colour.choose-contrast-color($primary),
     "color-secondary": $secondary,
-    "color-secondary-light": color.change($secondary, $lightness: 80%),
-    "color-secondary-lighter": color.change($secondary, $lightness: 95%),
     "color-secondary-50": color.change($secondary, $lightness: 95%),
     "color-secondary-100": color.change($secondary, $lightness: 90%),
     "color-secondary-200": color.change($secondary, $lightness: 80%),
@@ -64,16 +64,18 @@
 
   --ion-background-color: #{map.get($colorPalette, "color-page-background")};
 
+  // BORDERS
+  --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
+  --ion-border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
+  --ion-border-color-secondary: 2px solid #{map.get($colorPalette, "color-secondary")};
+  --ion-border-light: 1px solid #{map.get($colorPalette, "light")};
+  --ion-border-light-thicker: 2px solid #{map.get($colorPalette, "light")};
+  --border-dashed: 2px dashed #{map.get($colorPalette, "color-primary")};
+
   //  GRADIENTS
   //Gradient direction
   $vertical: 180deg;
   $horizontal: 90deg;
-  // primary-gradient
-  --ion-gradient-primary-start: #{map.get($colorPalette, "gradient-primary-start")};
-  --ion-gradient-primary-end: #{map.get($colorPalette, "gradient-primary-end")};
-  // secondary-gradient
-  --ion-gradient-secondary-start: #{map.get($colorPalette, "gradient-secondary-start")};
-  --ion-gradient-secondary-end: #{map.get($colorPalette, "gradient-secondary-end")};
 
   // COMPONENTS
   // Buttons
@@ -93,12 +95,4 @@
       $saturation: 3%,
       $lightness: 25%
     )};
-
-  //  Borders
-  --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
-  --ion-border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
-  --ion-border-color-secondary: 2px solid #{map.get($colorPalette, "color-secondary")};
-  --ion-border-light: 1px solid #{map.get($colorPalette, "light")};
-  --ion-border-light-thicker: 2px solid #{map.get($colorPalette, "light")};
-  --border-dashed: 2px dashed #{map.get($colorPalette, "color-primary")};
 }

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -53,13 +53,29 @@
   $colorPalette: $sourceColorPalette;
 
   --ion-color-primary: #{map.get($colorPalette, "color-primary")};
-  --ion-color-primary-light: #{map.get($colorPalette, "color-primary-200")};
-  --ion-color-primary-lighter: #{map.get($colorPalette, "color-primary-50")};
+  --ion-color-primary-50: #{map.get($colorPalette, "color-primary-50")};
+  --ion-color-primary-100: #{map.get($colorPalette, "color-primary-100")};
+  --ion-color-primary-200: #{map.get($colorPalette, "color-primary-200")};
+  --ion-color-primary-300: #{map.get($colorPalette, "color-primary-300")};
+  --ion-color-primary-400: #{map.get($colorPalette, "color-primary-400")};
+  --ion-color-primary-500: #{map.get($colorPalette, "color-primary-500")};
+  --ion-color-primary-600: #{map.get($colorPalette, "color-primary-600")};
+  --ion-color-primary-700: #{map.get($colorPalette, "color-primary-700")};
+  --ion-color-primary-800: #{map.get($colorPalette, "color-primary-800")};
+  --ion-color-primary-900: #{map.get($colorPalette, "color-primary-900")};
   --ion-color-primary-contrast: #{map.get($colorPalette, "color-primary-contrast")};
 
   --ion-color-secondary: #{map.get($colorPalette, "color-secondary")};
-  --ion-color-secondary-light: #{map.get($colorPalette, "color-secondary-200")};
-  --ion-color-secondary-lighter: #{map.get($colorPalette, "color-secondary-50")};
+  --ion-color-secondary-50: #{map.get($colorPalette, "color-secondary-50")};
+  --ion-color-secondary-100: #{map.get($colorPalette, "color-secondary-100")};
+  --ion-color-secondary-200: #{map.get($colorPalette, "color-secondary-200")};
+  --ion-color-secondary-300: #{map.get($colorPalette, "color-secondary-300")};
+  --ion-color-secondary-400: #{map.get($colorPalette, "color-secondary-400")};
+  --ion-color-secondary-500: #{map.get($colorPalette, "color-secondary-500")};
+  --ion-color-secondary-600: #{map.get($colorPalette, "color-secondary-600")};
+  --ion-color-secondary-700: #{map.get($colorPalette, "color-secondary-700")};
+  --ion-color-secondary-800: #{map.get($colorPalette, "color-secondary-800")};
+  --ion-color-secondary-900: #{map.get($colorPalette, "color-secondary-900")};
   --ion-color-secondary-contrast: #{map.get($colorPalette, "color-secondary-contrast")};
 
   --ion-background-color: #{map.get($colorPalette, "color-page-background")};

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -1,7 +1,8 @@
 @use "sass:color";
+@use "sass:map";
 @use "./contrast-colour.scss";
 
-@function getColorPalette($primary, $secondary) {
+@function getColorPalette($primary, $secondary, $page-background: null) {
   $result: (
     "color-primary": $primary,
     "color-primary-light": color.change($primary, $lightness: 80%),
@@ -11,6 +12,7 @@
     "color-secondary-light": color.change($secondary, $lightness: 80%),
     "color-secondary-lighter": color.change($secondary, $lightness: 95%),
     "color-secondary-contrast": contrast-colour.choose-contrast-color($secondary),
+    "color-page-background": color.change($primary, $lightness: 95%),
     //  GRADIENTS
     // primary-gradient
     "gradient-primary-start": color.adjust($primary, $lightness: 33%),
@@ -19,61 +21,66 @@
     "gradient-secondary-start": color.adjust($secondary, $saturation: 4%),
     "gradient-secondary-end": color.adjust($secondary, $saturation: 5%, $lightness: -19%),
   );
+  @if ($page-background != null) {
+    $result: map.set($result, "color-page-background", $page-background);
+  }
   @return $result;
 }
-@mixin generateTheme($p, $s) {
-  $colorPalette: getColorPalette($p, $s);
+@mixin generateTheme($p, $s, $bg: null) {
+  $colorPalette: getColorPalette($p, $s, $bg);
   @include colorVariables($colorPalette);
 }
 
 @mixin colorVariables($sourceColorPalette) {
   $colorPalette: $sourceColorPalette;
 
-  --ion-color-primary: #{map-get($colorPalette, "color-primary")};
-  --ion-color-primary-light: #{map-get($colorPalette, "color-primary-light")};
-  --ion-color-primary-lighter: #{map-get($colorPalette, "color-primary-lighter")};
-  --ion-color-primary-contrast: #{map-get($colorPalette, "color-primary-contrast")};
+  --ion-color-primary: #{map.get($colorPalette, "color-primary")};
+  --ion-color-primary-light: #{map.get($colorPalette, "color-primary-light")};
+  --ion-color-primary-lighter: #{map.get($colorPalette, "color-primary-lighter")};
+  --ion-color-primary-contrast: #{map.get($colorPalette, "color-primary-contrast")};
 
-  --ion-color-secondary: #{map-get($colorPalette, "color-secondary")};
-  --ion-color-secondary-light: #{map-get($colorPalette, "color-secondary-light")};
-  --ion-color-secondary-lighter: #{map-get($colorPalette, "color-secondary-lighter")};
-  --ion-color-secondary-contrast: #{map-get($colorPalette, "color-secondary-contrast")};
+  --ion-color-secondary: #{map.get($colorPalette, "color-secondary")};
+  --ion-color-secondary-light: #{map.get($colorPalette, "color-secondary-light")};
+  --ion-color-secondary-lighter: #{map.get($colorPalette, "color-secondary-lighter")};
+  --ion-color-secondary-contrast: #{map.get($colorPalette, "color-secondary-contrast")};
+
+  --ion-background-color: #{map.get($colorPalette, "color-page-background")};
 
   //  GRADIENTS
   //Gradient direction
   $vertical: 180deg;
   $horizontal: 90deg;
   // primary-gradient
-  --ion-gradient-primary-start: #{map-get($colorPalette, "gradient-primary-start")};
-  --ion-gradient-primary-end: #{map-get($colorPalette, "gradient-primary-end")};
+  --ion-gradient-primary-start: #{map.get($colorPalette, "gradient-primary-start")};
+  --ion-gradient-primary-end: #{map.get($colorPalette, "gradient-primary-end")};
   // secondary-gradient
-  --ion-gradient-secondary-start: #{map-get($colorPalette, "gradient-secondary-start")};
-  --ion-gradient-secondary-end: #{map-get($colorPalette, "gradient-secondary-end")};
+  --ion-gradient-secondary-start: #{map.get($colorPalette, "gradient-secondary-start")};
+  --ion-gradient-secondary-end: #{map.get($colorPalette, "gradient-secondary-end")};
 
   // COMPONENTS
   // Buttons
   --ion-btn-primary: linear-gradient(
     #{$vertical},
-    #{map-get($colorPalette, "gradient-primary-start")} 0.43%,
-    #{map-get($colorPalette, "gradient-primary-end")} 74.07%
+    #{map.get($colorPalette, "gradient-primary-start")} 0.43%,
+    #{map.get($colorPalette, "gradient-primary-end")} 74.07%
   );
   --ion-btn-secondary: linear-gradient(
     #{$vertical},
-    #{map-get($colorPalette, "gradient-secondary-start")} 28.12%,
-    #{map-get($colorPalette, "gradient-secondary-end")} 100%
+    #{map.get($colorPalette, "gradient-secondary-start")} 28.12%,
+    #{map.get($colorPalette, "gradient-secondary-end")} 100%
   );
   --ion-btn-control-bg: #{color.adjust(
-      map-get($colorPalette, "color-primary"),
+      map.get($colorPalette, "color-primary"),
       $hue: 3.6deg,
       $saturation: 3%,
       $lightness: 25%
     )};
 
   //  Borders
-  --ion-border-standard: 2px solid #{map-get($colorPalette, "color-primary")};
-  --ion-border-thin-standard: 1px solid #{map-get($colorPalette, "color-primary")};
-  --ion-border-color-secondary: 2px solid #{map-get($colorPalette, "color-secondary")};
-  --ion-border-light: 1px solid #{map-get($colorPalette, "light")};
-  --ion-border-light-thicker: 2px solid #{map-get($colorPalette, "light")};
-  --border-dashed: 2px dashed #{map-get($colorPalette, "color-primary")};
+  --ion-border-standard: 2px solid #{map.get($colorPalette, "color-primary")};
+  --ion-border-thin-standard: 1px solid #{map.get($colorPalette, "color-primary")};
+  --ion-border-color-secondary: 2px solid #{map.get($colorPalette, "color-secondary")};
+  --ion-border-light: 1px solid #{map.get($colorPalette, "light")};
+  --ion-border-light-thicker: 2px solid #{map.get($colorPalette, "light")};
+  --border-dashed: 2px dashed #{map.get($colorPalette, "color-primary")};
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -11,16 +11,13 @@
 @include default.theme-default;
 
 // WiP - system to generate colours from base colour
-$primary: hsl(203, 76%, 21%);
+$primary: hsl(203, 76%, 21%); // 0d3f5e
 $primary-light: color.change($primary, $lightness: 80%);
-$primary-lighter: color.change($primary, $lightness: 95%);
+$primary-lighter: color.change($primary, $lightness: 95%); // #e9f5fc
 
-$secondary: hsl(31, 95%, 57%);
+$secondary: hsl(31, 95%, 57%); // #e5943e
 
-$tertiary: hsl(47, 100%, 92%);
-$quaternary: hsl(204, 88%, 94%);
-$light: #ffffff;
-$dark: #00000040;
+$tertiary: hsl(47, 100%, 92%); // #fff6d6
 
 /** Gradient direction **/
 $vertical: 180deg;
@@ -147,33 +144,14 @@ $horizontal: 90deg;
   --timer-counter-height: 73px;
   --timer-counter-font-size: 40px;
   --timer-title-width: 80%;
-  --timer-buttons-color: #{color.adjust($primary, $hue: 1%, $saturation: 3%, $lightness: 25%)};
 
   // Combo box //
-  --combo-box-placeholder-primary: rgba(13, 64, 96, 0.5);
   --combo-box-font-size-standard: 20px;
   --combo-box-min-height: 55px;
   --combo-box-min-width: 260px;
   --combo-box-passive-no-answer-bg: transparent;
   --combo-box-no-answer-bg: transparent;
   --combo-box-with-answer-bg: transparent;
-
-  --combo-box-gradient-active-start: #{color.adjust($tertiary, $lightness: -13%)};
-  --combo-box-gradient-active-end: #{color.adjust($tertiary, $saturation: -3%, $lightness: -40%)};
-
-  --combo-box-gradient-passive-start: #{color.adjust($quaternary, $saturation: 12%, $lightness: -8%)};
-  --combo-box-gradient-passive-end: #{color.adjust($quaternary, $saturation: 12%, $lightness: -44%)};
-
-  --combo-box-active-with-answer-bg: linear-gradient(
-    #{$vertical},
-    var(--combo-box-gradient-active-start) 34.6%,
-    var(--combo-box-gradient-active-end) 105.68%
-  );
-  --combo-box-passive-with-answer-bg: linear-gradient(
-    #{$vertical},
-    var(--combo-box-gradient-passive-start) 34.6%,
-    var(--combo-box-gradient-passive-end) 105.68%
-  );
 
   // Points iten //
   --points-item-height: 152px;
@@ -183,13 +161,6 @@ $horizontal: 90deg;
   --help-icon-standard-size: 35px;
   --help-icon-small-size: 30px;
 
-  //TOOLS
-  --tool-one-bg: #{color.adjust($secondary, $hue: -2%)}; // #FA8E29
-  --tool-two-bg: #{color.adjust($secondary, $hue: -2%, $saturation: 5%, $lightness: -7%)}; // #FF7B00
-  --tool-three-bg: #{color.adjust($primary, $hue: -8%, $saturation: 8%, $lightness: 17%)}; // #108AB2
-  --tool-four-bg: #{color.adjust($primary, $hue: -8%, $saturation: 12%, $lightness: 8%)}; //#096A8B
-  --tool-five-bg: #{$primary};
-
   //BUTTONS
   --buttons-min-height: 71px;
   --buttons-short-height: 50px;
@@ -198,16 +169,6 @@ $horizontal: 90deg;
   --buttons-font-size-small: 20px;
   --buttons-font-size: 25px;
   --buttons-size: 64px;
-
-  //OPTION BUTTONS
-  --ion-gradient-primary-option-start: #{color.adjust($primary, $saturation: 8%, $lightness: 17%)}; //#0F8AB2
-  --ion-gradient-primary-option-end: #{$primary};
-
-  --ion-gradient-option-btn: linear-gradient(
-    #{$vertical},
-    var(--ion-gradient-primary-option-start) 28.12%,
-    var(--ion-gradient-primary-option-end) 100%
-  );
 
   // Round button //
   --round-button-min-height: 58px;
@@ -227,40 +188,180 @@ $horizontal: 90deg;
   --square-button-navigation-min-height: 50px;
   --square-button-min-width: 60px;
 
-  //BANNER
-  --ion-banner-gradient-secondary-start: #{color.adjust(
-      $secondary,
-      $hue: 17%,
-      $saturation: 5%,
-      $lightness: 14%
-    )}; //#FFE16A
-  --ion-banner-gradient-secondary-end: #{color.adjust(
-      $secondary,
-      $hue: 8%,
-      $saturation: 5%,
-      $lightness: 3%
-    )}; //#FFB833
-
-  --ion-banner-gradient-primary-start: #{color.adjust($primary, $saturation: 19%, $lightness: 64%)}; //#B3EDFD
-  --ion-banner-gradient-primary-middle: #{color.adjust($primary, $saturation: 24%, $lightness: 48%)}; //#60DDFF
-  --ion-banner-gradient-primary-end: #{color.adjust($primary, $saturation: 17%, $lightness: 26%)}; //#09B9E9
-
-  --ion-banner-secondary: linear-gradient(
-    #{$vertical},
-    var(--ion-banner-gradient-secondary-start) 34.6%,
-    var(--ion-banner-gradient-secondary-end) 105.68%
-  );
-  --ion-banner-primary: linear-gradient(
-    #{$vertical},
-    var(--ion-banner-gradient-primary-start) 34.6%,
-    var(--ion-banner-gradient-primary-middle) 65.78%,
-    var(--ion-banner-gradient-primary-end) 105.68%
-  );
-
   //ACCORDION
   --accordion-section-padding: 0 10px;
   --accordion-section-open-height: 400px;
   --accordion-section-width: 85%;
+
+  // TILES
+  --tile-default-height: 104px;
+  --tile-button-height: 73px;
+  --tile-button-width: 73px;
+  --tile-workshop-page-height: 132px;
+  --tile-workshop-page-width: 111px;
+  --tile-workshop-page-button-height: 55px;
+  --tile-workshop-page-button-width: 100%;
+  --tile-parent-point-width: 200px;
+  --tile-parent-point-height: 104px;
+  --tile-image-text-width: 176px;
+  --tile-button-style-height: 60px;
+
+  // ***********************
+  // LEGACY COLOUR VARIABLES
+  // ***********************
+  // TODO: Migrate these variables to use the new theming system and replace their references
+
+  // Tiles
+  --tile-button-background: #{color.adjust($primary, $saturation: 14%, $lightness: 60%)};
+  --tile-primary-light-gradient-start: #{color.adjust(
+      $primary-lighter,
+      $saturation: 6%,
+      $lightness: -15%
+    )}; // #97d5fc
+  --tile-primary-light-gradient-end: #{color.adjust(
+      $primary-lighter,
+      $saturation: 12%,
+      $lightness: -44%
+    )}; // #009dff;
+  --tile-primary-light-gradient: linear-gradient(
+    179.77deg,
+    var(--tile-primary-light-gradient-start) 34.6%,
+    var(--tile-primary-light-gradient-end) 105.68%
+  );
+  --tile-primary-gradient-start: #{color.adjust($primary, $saturation: 17%, $lightness: 39%)}; // #3aaff8
+  --tile-primary-gradient-end: #{color.adjust($primary, $saturation: 2%, $lightness: 13%)}; // #13669a
+  --tile-primary-gradient: linear-gradient(
+    170.54deg,
+    var(--tile-primary-gradient-start) 0.43%,
+    var(--tile-primary-gradient-end) 74.07%
+  );
+  --tile-secondary-light-gradient-start: #{color.adjust(
+      $tertiary,
+      $saturation: -1%,
+      $lightness: -27%
+    )}; // #fed84d
+  --tile-secondary-light-gradient-end: #{color.adjust($tertiary, $lightness: -47%)}; // #e6b400
+  --tile-secondary-light-gradient: linear-gradient(
+    168.87deg,
+    var(--tile-secondary-light-gradient-start) 28.12%,
+    var(--tile-secondary-light-gradient-end) 100%
+  );
+  --tile-secondary-gradient-start: #{color.adjust($secondary, $saturation: 4%)}; // #fe9525
+  --tile-secondary-gradient-end: #{color.adjust($secondary, $saturation: 5%, $lightness: -19%)}; // #c26400
+  --tile-secondary-gradient: linear-gradient(
+    168.87deg,
+    var(--tile-secondary-gradient-start) 28.12%,
+    var(--tile-secondary-gradient-end) 100%
+  );
+
+  //PARENT CENTRE
+  --parent-centre-primary-light-gradient-start: #{color.adjust(
+      $primary-lighter,
+      $saturation: 6%,
+      $lightness: -15%
+    )}; // #97d5fc
+  --parent-centre-primary-light-gradient-end: #{color.adjust(
+      $primary-lighter,
+      $saturation: 12%,
+      $lightness: -44%
+    )}; // #009dff;
+  --parent-centre-primary-light-gradient: linear-gradient(
+    179.77deg,
+    var(--parent-centre-primary-light-gradient-start) 34.6%,
+    var(--parent-centre-primary-light-gradient-end) 105.68%
+  );
+  --parent-centre-primary-gradient-start: #{color.adjust(
+      $primary,
+      $saturation: 17%,
+      $lightness: 39%
+    )}; // #3aaff8
+  --parent-centre-primary-gradient-end: #{color.adjust($primary, $saturation: 2%, $lightness: 13%)}; // #13669a
+  --parent-centre-primary-gradient: linear-gradient(
+    170.54deg,
+    var(--parent-centre-primary-gradient-start) 0.43%,
+    var(--parent-centre-primary-gradient-end) 74.07%
+  );
+  --parent-centre-secondary-light-gradient-start: #{color.adjust(
+      $tertiary,
+      $saturation: -1%,
+      $lightness: -27%
+    )}; // #fed84d
+  --parent-centre-secondary-light-gradient-end: #{color.adjust($tertiary, $lightness: -47%)}; // #e6b400
+  --parent-centre-secondary-light-gradient: linear-gradient(
+    168.87deg,
+    var(--parent-centre-secondary-light-gradient-start) 28.12%,
+    var(--parent-centre-secondary-light-gradient-end) 100%
+  );
+  --parent-centre-secondary-gradient-start: #{color.adjust($secondary, $saturation: 4%)}; // #fe9525
+  --parent-centre-secondary-gradient-end: #{color.adjust(
+      $secondary,
+      $saturation: 5%,
+      $lightness: -19%
+    )}; // #c26400
+  --parent-centre-secondary-gradient: linear-gradient(
+    168.87deg,
+    var(--parent-centre-secondary-gradient-start) 28.12%,
+    var(--parent-centre-secondary-gradient-end) 100%
+  );
+
+  // ROUND ICON BUTTON
+  --round-icon-button-light: #{color.adjust($tertiary, $lightness: -42%)}; //#FFCA41
+  --round-icon-button: #{$secondary}; //#F49D04
+  --round-icon-button-dark: #{color.adjust($secondary, $lightness: -7%)}; //#F87023
+
+  // POINTS ITEM
+  --points-item-bg: #{color.adjust($primary-lighter, $saturation: 12%, $lightness: -9%)}; //#B2E2FF
+
+  // RADIO GROUP
+  --radio-group-gradient-active-start: #{color.adjust($tertiary, $lightness: -13%)};
+  --radio-group-gradient-active-end: #{color.adjust($tertiary, $saturation: -3%, $lightness: -40%)};
+  --radio-group-gradient-passive-start: #{color.adjust(
+      $primary-lighter,
+      $saturation: 12%,
+      $lightness: -8%
+    )};
+  --radio-group-gradient-passive-end: #{color.adjust(
+      $primary-lighter,
+      $saturation: 12%,
+      $lightness: -44%
+    )};
+  --radio-group-gradient-secondary: linear-gradient(
+    #{$vertical},
+    var(--radio-group-gradient-active-start) 34.6%,
+    var(--radio-group-gradient-active-end) 105.68%
+  );
+  --radio-group-gradient-primary: linear-gradient(
+    #{$vertical},
+    var(--radio-group-gradient-passive-start) 34.6%,
+    var(--radio-group-gradient-passive-end) 105.68%
+  );
+  --radio-group-active-bg: var(--radio-group-gradient-secondary);
+  --radio-group-passive-bg: var(--radio-group-gradient-primary);
+
+  //HOME SCREEN
+  --home-screen-light-gradient-start: #{color.adjust($primary, $saturation: 12%, $lightness: 62%)}; //#ABDEFE
+  --home-screen-light-gradient-end: #{color.adjust($primary, $saturation: 12%, $lightness: 17%)}; //#0277C0
+  --home-screen-shade-gradient-start: #{color.adjust($primary, $saturation: 17%, $lightness: 24%)}; //#088BDD
+  --home-screen-shade-gradient-end: #{color.adjust($primary, $saturation: 17%, $lightness: 3%)}; //#044974
+  --home-screen-dark-gradient-start: #{color.adjust($primary, $saturation: 16%, $lightness: 9%)}; //#065E95
+  --home-screen-dark-gradient-end: #{color.adjust($primary, $saturation: 14%, $lightness: -9%)}; //#00263E
+  --home-screen-light-bg: linear-gradient(
+    to right,
+    var(--home-screen-light-gradient-start),
+    var(--home-screen-light-gradient-end)
+  );
+  --home-screen-shade-bg: linear-gradient(
+    #{$horizontal},
+    var(--home-screen-shade-gradient-start) 36%,
+    var(--home-screen-shade-gradient-end) 111.65%
+  );
+  --home-screen-dark-bg: linear-gradient(
+    #{$horizontal},
+    var(--home-screen-dark-gradient-start) 20.92%,
+    var(--home-screen-dark-gradient-end) 96.06%
+  );
+
+  // Accordian
   --ion-accordion-status-bg-start: #{color.adjust($primary, $lightness: 33%)}; //#309EE3
   --ion-accordion-status-bg-end: #{color.adjust($primary, $saturation: 2%, $lightness: 13%)}; //#136E9C
   --ion-accrodion-status-gradient: linear-gradient(
@@ -300,182 +401,91 @@ $horizontal: 90deg;
     var(--ion-accordion-progress-gradient-secondary-end) 102.14%
   );
 
-  //HOME SCREEN
-  --home-screen-light-gradient-start: #{color.adjust($primary, $saturation: 12%, $lightness: 62%)}; //#ABDEFE
-  --home-screen-light-gradient-end: #{color.adjust($primary, $saturation: 12%, $lightness: 17%)}; //#0277C0
-  --home-screen-shade-gradient-start: #{color.adjust($primary, $saturation: 17%, $lightness: 24%)}; //#088BDD
-  --home-screen-shade-gradient-end: #{color.adjust($primary, $saturation: 17%, $lightness: 3%)}; //#044974
-  --home-screen-dark-gradient-start: #{color.adjust($primary, $saturation: 16%, $lightness: 9%)}; //#065E95
-  --home-screen-dark-gradient-end: #{color.adjust($primary, $saturation: 14%, $lightness: -9%)}; //#00263E
-  --home-screen-light-bg: linear-gradient(
-    to right,
-    var(--home-screen-light-gradient-start),
-    var(--home-screen-light-gradient-end)
+  //BANNER
+  --ion-banner-gradient-secondary-start: #{color.adjust(
+      $secondary,
+      $hue: 17%,
+      $saturation: 5%,
+      $lightness: 14%
+    )}; //#FFE16A
+  --ion-banner-gradient-secondary-end: #{color.adjust(
+      $secondary,
+      $hue: 8%,
+      $saturation: 5%,
+      $lightness: 3%
+    )}; //#FFB833
+
+  --ion-banner-gradient-primary-start: #{color.adjust($primary, $saturation: 19%, $lightness: 64%)}; //#B3EDFD
+  --ion-banner-gradient-primary-middle: #{color.adjust($primary, $saturation: 24%, $lightness: 48%)}; //#60DDFF
+  --ion-banner-gradient-primary-end: #{color.adjust($primary, $saturation: 17%, $lightness: 26%)}; //#09B9E9
+
+  --ion-banner-secondary: linear-gradient(
+    #{$vertical},
+    var(--ion-banner-gradient-secondary-start) 34.6%,
+    var(--ion-banner-gradient-secondary-end) 105.68%
   );
-  --home-screen-shade-bg: linear-gradient(
-    #{$horizontal},
-    var(--home-screen-shade-gradient-start) 36%,
-    var(--home-screen-shade-gradient-end) 111.65%
-  );
-  --home-screen-dark-bg: linear-gradient(
-    #{$horizontal},
-    var(--home-screen-dark-gradient-start) 20.92%,
-    var(--home-screen-dark-gradient-end) 96.06%
+  --ion-banner-primary: linear-gradient(
+    #{$vertical},
+    var(--ion-banner-gradient-primary-start) 34.6%,
+    var(--ion-banner-gradient-primary-middle) 65.78%,
+    var(--ion-banner-gradient-primary-end) 105.68%
   );
 
-  //RADIO GROUP
-  --radio-group-gradient-active-start: #{color.adjust($tertiary, $lightness: -13%)};
-  --radio-group-gradient-active-end: #{color.adjust($tertiary, $saturation: -3%, $lightness: -40%)};
+  // Option buttons
+  --ion-gradient-primary-option-start: #{color.adjust($primary, $saturation: 8%, $lightness: 17%)}; //#0F8AB2
+  --ion-gradient-primary-option-end: #{$primary};
 
-  --radio-group-gradient-passive-start: #{color.adjust(
-      $quaternary,
+  --ion-gradient-option-btn: linear-gradient(
+    #{$vertical},
+    var(--ion-gradient-primary-option-start) 28.12%,
+    var(--ion-gradient-primary-option-end) 100%
+  );
+
+  // Tools
+  --tool-one-bg: #{color.adjust($secondary, $hue: -2%)}; // #FA8E29
+  --tool-two-bg: #{color.adjust($secondary, $hue: -2%, $saturation: 5%, $lightness: -7%)}; // #FF7B00
+  --tool-three-bg: #{color.adjust($primary, $hue: -8%, $saturation: 8%, $lightness: 17%)}; // #108AB2
+  --tool-four-bg: #{color.adjust($primary, $hue: -8%, $saturation: 12%, $lightness: 8%)}; //#096A8B
+  --tool-five-bg: #{$primary};
+
+  // Timer
+  --timer-buttons-color: #{color.adjust($primary, $hue: 1%, $saturation: 3%, $lightness: 25%)};
+
+  // Combo box
+  --combo-box-placeholder-primary: rgba(13, 64, 96, 0.5);
+  --combo-box-gradient-active-start: #{color.adjust($tertiary, $lightness: -13%)};
+  --combo-box-gradient-active-end: #{color.adjust($tertiary, $saturation: -3%, $lightness: -40%)};
+  --combo-box-gradient-passive-start: #{color.adjust(
+      $primary-lighter,
       $saturation: 12%,
       $lightness: -8%
     )};
-  --radio-group-gradient-passive-end: #{color.adjust(
-      $quaternary,
+  --combo-box-gradient-passive-end: #{color.adjust(
+      $primary-lighter,
       $saturation: 12%,
       $lightness: -44%
     )};
-
-  --radio-group-gradient-secondary: linear-gradient(
+  --combo-box-active-with-answer-bg: linear-gradient(
     #{$vertical},
-    var(--radio-group-gradient-active-start) 34.6%,
-    var(--radio-group-gradient-active-end) 105.68%
+    var(--combo-box-gradient-active-start) 34.6%,
+    var(--combo-box-gradient-active-end) 105.68%
   );
-  --radio-group-gradient-primary: linear-gradient(
+  --combo-box-passive-with-answer-bg: linear-gradient(
     #{$vertical},
-    var(--radio-group-gradient-passive-start) 34.6%,
-    var(--radio-group-gradient-passive-end) 105.68%
-  );
-  --radio-group-active-bg: var(--radio-group-gradient-secondary);
-  --radio-group-passive-bg: var(--radio-group-gradient-primary);
-
-  // ROUND ICON BUTTON
-  --round-icon-button-light: #{color.adjust($tertiary, $lightness: -42%)}; //#FFCA41
-  --round-icon-button: #{$secondary}; //#F49D04
-  --round-icon-button-dark: #{color.adjust($secondary, $lightness: -7%)}; //#F87023
-
-  // POINTS ITEM
-  --points-item-bg: #{color.adjust($quaternary, $saturation: 12%, $lightness: -9%)}; //#B2E2FF
-
-  // TILES
-  --tile-default-height: 104px;
-  --tile-button-height: 73px;
-  --tile-button-width: 73px;
-  --tile-workshop-page-height: 132px;
-  --tile-workshop-page-width: 111px;
-  --tile-workshop-page-button-height: 55px;
-  --tile-workshop-page-button-width: 100%;
-  --tile-parent-point-width: 200px;
-  --tile-parent-point-height: 104px;
-  --tile-image-text-width: 176px;
-  --tile-button-style-height: 60px;
-
-  --tile-button-background: #{color.adjust($primary, $saturation: 14%, $lightness: 60%)};
-
-  --tile-primary-light-gradient-start: #{color.adjust(
-      $quaternary,
-      $saturation: 6%,
-      $lightness: -15%
-    )}; // #97d5fc
-  --tile-primary-light-gradient-end: #{color.adjust($quaternary, $saturation: 12%, $lightness: -44%)}; // #009dff;
-  --tile-primary-light-gradient: linear-gradient(
-    179.77deg,
-    var(--tile-primary-light-gradient-start) 34.6%,
-    var(--tile-primary-light-gradient-end) 105.68%
-  );
-
-  --tile-primary-gradient-start: #{color.adjust($primary, $saturation: 17%, $lightness: 39%)}; // #3aaff8
-  --tile-primary-gradient-end: #{color.adjust($primary, $saturation: 2%, $lightness: 13%)}; // #13669a
-  --tile-primary-gradient: linear-gradient(
-    170.54deg,
-    var(--tile-primary-gradient-start) 0.43%,
-    var(--tile-primary-gradient-end) 74.07%
-  );
-
-  --tile-secondary-light-gradient-start: #{color.adjust(
-      $tertiary,
-      $saturation: -1%,
-      $lightness: -27%
-    )}; // #fed84d
-  --tile-secondary-light-gradient-end: #{color.adjust($tertiary, $lightness: -47%)}; // #e6b400
-  --tile-secondary-light-gradient: linear-gradient(
-    168.87deg,
-    var(--tile-secondary-light-gradient-start) 28.12%,
-    var(--tile-secondary-light-gradient-end) 100%
-  );
-  --tile-secondary-gradient-start: #{color.adjust($secondary, $saturation: 4%)}; // #fe9525
-  --tile-secondary-gradient-end: #{color.adjust($secondary, $saturation: 5%, $lightness: -19%)}; // #c26400
-  --tile-secondary-gradient: linear-gradient(
-    168.87deg,
-    var(--tile-secondary-gradient-start) 28.12%,
-    var(--tile-secondary-gradient-end) 100%
-  );
-
-  //PARENT CENTRE
-  --parent-centre-primary-light-gradient-start: #{color.adjust(
-      $quaternary,
-      $saturation: 6%,
-      $lightness: -15%
-    )}; // #97d5fc
-  --parent-centre-primary-light-gradient-end: #{color.adjust(
-      $quaternary,
-      $saturation: 12%,
-      $lightness: -44%
-    )}; // #009dff;
-  --parent-centre-primary-light-gradient: linear-gradient(
-    179.77deg,
-    var(--parent-centre-primary-light-gradient-start) 34.6%,
-    var(--parent-centre-primary-light-gradient-end) 105.68%
-  );
-
-  --parent-centre-primary-gradient-start: #{color.adjust(
-      $primary,
-      $saturation: 17%,
-      $lightness: 39%
-    )}; // #3aaff8
-  --parent-centre-primary-gradient-end: #{color.adjust($primary, $saturation: 2%, $lightness: 13%)}; // #13669a
-  --parent-centre-primary-gradient: linear-gradient(
-    170.54deg,
-    var(--parent-centre-primary-gradient-start) 0.43%,
-    var(--parent-centre-primary-gradient-end) 74.07%
-  );
-
-  --parent-centre-secondary-light-gradient-start: #{color.adjust(
-      $tertiary,
-      $saturation: -1%,
-      $lightness: -27%
-    )}; // #fed84d
-  --parent-centre-secondary-light-gradient-end: #{color.adjust($tertiary, $lightness: -47%)}; // #e6b400
-  --parent-centre-secondary-light-gradient: linear-gradient(
-    168.87deg,
-    var(--parent-centre-secondary-light-gradient-start) 28.12%,
-    var(--parent-centre-secondary-light-gradient-end) 100%
-  );
-
-  --parent-centre-secondary-gradient-start: #{color.adjust($secondary, $saturation: 4%)}; // #fe9525
-  --parent-centre-secondary-gradient-end: #{color.adjust(
-      $secondary,
-      $saturation: 5%,
-      $lightness: -19%
-    )}; // #c26400
-  --parent-centre-secondary-gradient: linear-gradient(
-    168.87deg,
-    var(--parent-centre-secondary-gradient-start) 28.12%,
-    var(--parent-centre-secondary-gradient-end) 100%
+    var(--combo-box-gradient-passive-start) 34.6%,
+    var(--combo-box-gradient-passive-end) 105.68%
   );
 
   --ion-color-help-tooltip: #{color.adjust($primary, $hue: -8%, $saturation: 12%, $lightness: 9%)};
   --ion-color-slider: #{color.adjust($primary, $hue: -8%, $saturation: 12%, $lightness: 9%)};
-  --ion-btn-dark-box-shadow: 0px 4px 4px #{$dark};
+  --ion-btn-dark-box-shadow: 0px 4px 4px #00000040;
   --ion-dg-bg-default: var(--ion-banner-primary);
 
   // Used for .background-primary-lighter in _layout.scss
   --ion-color-primary-lighter: #{$primary-lighter};
 
   // Used for background of .home_screen_wrapper in round-icon-button.component.scss
-  --ion-color-quaternary: #{$quaternary};
+  --ion-color-quaternary: #{$primary-lighter};
 
   // Used on .alert-delete-button in _layout.scss
   --ion-color-danger: #eb445a;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -481,9 +481,6 @@ $horizontal: 90deg;
   --ion-btn-dark-box-shadow: 0px 4px 4px #00000040;
   --ion-dg-bg-default: var(--ion-banner-primary);
 
-  // Used for .background-primary-lighter in _layout.scss
-  --ion-color-primary-lighter: #{$primary-lighter};
-
   // Used for background of .home_screen_wrapper in round-icon-button.component.scss
   --ion-color-quaternary: #{$primary-lighter};
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Continues work to generate and apply theme variables – introduces incremented colour variant system using 50-900 weights, and deprecates previous `-light` and `-lighter` colour variants. 
Deprecates `$light`, `$dark` and `$quaternary` – `$tertiary` is extant for now but will be deprecated.

Also adds support for overriding background colour at the theme definition level.

There should be no visual changes to the app, other than some very minor colour changes, almost undetectable. This is confirmed by the visual tests, which I have manually checked and look good, accounting for the usual false positives.

## Git Issues

Closes #

## Screenshots/Videos

#### Generated colour variants from our pre-existing primary theme colour:
<img width="475" alt="primary colour variations" src="https://user-images.githubusercontent.com/64838927/182838719-c36c9aa6-dae2-40f1-ae37-1c7ebfe4f89d.png">

