### PR TITLE
fix: gdrive watch files and modified user

### DIFF
--- a/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
+++ b/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
@@ -103,7 +103,7 @@ export class GDriveDownloader {
    */
   public async updateFileEntry(serverEntry: drive_v3.Schema$File) {
     await this.setupGdrive();
-    const cachedEntry = this.contentsData.find((cached) => cached.id === serverEntry.id);
+    const cachedEntry = this.getCachedEntry(serverEntry);
     if (!cachedEntry) {
       console.log(chalk.red("Full sync required before updating file", serverEntry.name));
       return;
@@ -119,6 +119,10 @@ export class GDriveDownloader {
     actions.updated.push(entryWithFolderPath);
     await this.processSyncActions(actions);
     this.updateCacheContentsFile(entryWithFolderPath);
+  }
+
+  public getCachedEntry(serverEntry: drive_v3.Schema$File) {
+    return this.contentsData.find((cached) => cached.id === serverEntry.id);
   }
 
   private async setupGdrive() {

--- a/packages/@idemsInternational/gdrive-tools/src/commands/watch.ts
+++ b/packages/@idemsInternational/gdrive-tools/src/commands/watch.ts
@@ -194,12 +194,15 @@ class GDriveWatcher {
 
   private async handleFileChange(change: drive_v3.Schema$Change) {
     const { file } = change;
-    // TODO - see if way to check file used by app
     // filter only files modified by me
-    const { modifiedByMe, name } = file;
-    if (modifiedByMe) {
-      console.log(chalk.blue(`${formatTimestamp()} [Change] ${name}`));
-      await new GDriveDownloader(this.options).updateFileEntry(file);
+    const { name, lastModifyingUser } = file;
+    if (lastModifyingUser?.me) {
+      const gdriveDownloader = new GDriveDownloader(this.options);
+      // Filter only app cached entries (gdrive has full user drive scope)
+      if (gdriveDownloader.getCachedEntry(file)) {
+        console.log(chalk.blue(`${formatTimestamp()} [Change] ${name}`));
+        await new GDriveDownloader(this.options).updateFileEntry(file);
+      }
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add filter to limit gdrive watch files to only those currently used by the app and last modified by user

## Review Notes
- Run sync watch `yarn workflow sync --content-watch`
- Make changes to files in drive both inside and outside app sheet folder
- Only changes recorded should be for the files inside the app sheet folder

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
