### PR TITLE
feat: nav_group can receive a data_list as value and extract template names

### DIFF
--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -87,25 +87,25 @@ export class NavGroupComponent extends TemplateLayoutComponent {
   }
 
   modifyRowSetter(row: FlowTypes.TemplateRow) {
-    if (Array.isArray(row?.value)) {
-      // Check if value is an object referring to a whole data_list with a "template" column,
-      // and if so, assign an array of the values of this column to templateNames
-      const templateArray = [];
-      if (row?.value.length === 1) {
-        const dataObject = row?.value[0];
-        if (isObject(dataObject)) {
-          for (const property in dataObject) {
-            if (dataObject[property].hasOwnProperty("template")) {
-              templateArray.push(dataObject[property].template);
-            }
-          }
+    // Check if value is an object referring to a whole data_list with a "template" column,
+    // and if so, assign an array of the values of this column to templateNames
+    const templateArray = [];
+    if (isObject(row?.value)) {
+      const dataListObject = row?.value;
+      for (const property in dataListObject) {
+        if (dataListObject[property].hasOwnProperty("template")) {
+          templateArray.push(dataListObject[property].template);
         }
       }
-      if (templateArray.length > 0) {
-        this.templateNames = templateArray;
-      } else {
+    }
+    if (templateArray.length > 0) {
+      this.templateNames = templateArray;
+    } else {
+      if (Array.isArray(row?.value)) {
         this.templateNames = row.value;
       }
+    }
+    if (this.templateNames.length > 0) {
       row._debug_name = this.templateNames[this.sectionIndex];
       // only set the active section the first time value received
       // (handle via goToSection method internally for other cases)

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -89,7 +89,7 @@ export class NavGroupComponent extends TemplateLayoutComponent {
   modifyRowSetter(row: FlowTypes.TemplateRow) {
     // Check if value is an object referring to a whole data_list with a "template" column,
     // and if so, assign an array of the values of this column to templateNames.
-    // Handle case where object is passed in directly, or where inside a _list local variable
+    // Handle case where object is passed in directly, or where inside a "_list" local variable
     const templateArray = [];
     const dataListObject = isObject(row?.value)
       ? row.value

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -91,7 +91,7 @@ export class NavGroupComponent extends TemplateLayoutComponent {
     // and if so, assign an array of the values of this column to templateNames
     const templateArray = [];
     if (isObject(row?.value)) {
-      const dataListObject = row?.value;
+      const dataListObject = row.value;
       for (const property in dataListObject) {
         if (dataListObject[property].hasOwnProperty("template")) {
           templateArray.push(dataListObject[property].template);

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -3,6 +3,7 @@ import { PLHAnimations } from "src/app/shared/animations";
 import { FlowTypes } from "data-models";
 import { hackAddRowWithDefaultActions } from "../../hacks";
 import { TemplateLayoutComponent } from "./layout";
+import { isObject } from "src/app/shared/utils/utils";
 import { TemplateFieldService } from "../../services/template-field.service";
 
 @Component({
@@ -87,7 +88,24 @@ export class NavGroupComponent extends TemplateLayoutComponent {
 
   modifyRowSetter(row: FlowTypes.TemplateRow) {
     if (Array.isArray(row?.value)) {
-      this.templateNames = row.value;
+      // Check if value is an object referring to a whole data_list with a "template" column,
+      // and if so, assign an array of the values of this column to templateNames
+      const templateArray = [];
+      if (row?.value.length === 1) {
+        const dataObject = row?.value[0];
+        if (isObject(dataObject)) {
+          for (const property in dataObject) {
+            if (dataObject[property].hasOwnProperty("template")) {
+              templateArray.push(dataObject[property].template);
+            }
+          }
+        }
+      }
+      if (templateArray.length > 0) {
+        this.templateNames = templateArray;
+      } else {
+        this.templateNames = row.value;
+      }
       row._debug_name = this.templateNames[this.sectionIndex];
       // only set the active section the first time value received
       // (handle via goToSection method internally for other cases)

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -87,9 +87,7 @@ export class NavGroupComponent extends TemplateLayoutComponent {
   }
 
   modifyRowSetter(row: FlowTypes.TemplateRow) {
-    console.log("modifyRowSetter for " + row.name);
     this.hackPopulateTemplateNames(row);
-    console.log("this.templateNames: ", this.templateNames);
     if (this.templateNames.length > 0) {
       row._debug_name = this.templateNames[this.sectionIndex];
       // only set the active section the first time value received
@@ -112,7 +110,7 @@ export class NavGroupComponent extends TemplateLayoutComponent {
       dataListObject = row.value;
     }
     // Handle case where data list object is inside an array,
-    // e.g. if assigned to a "_list" local variable
+    // e.g. if assigned to a "_list" local variable in authoring
     else if (Array.isArray(row?.value) && isObject(row?.value[0])) {
       dataListObject = row.value[0];
     }

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -87,17 +87,15 @@ export class NavGroupComponent extends TemplateLayoutComponent {
   }
 
   modifyRowSetter(row: FlowTypes.TemplateRow) {
-    console.log(`row.value for ${row.name}`, row.value);
     // Check if value is an object referring to a whole data_list with a "template" column,
-    // and if so, assign an array of the values of this column to templateNames
-    const templateArray = [];
+    // and if so, assign an array of the values of this column to templateNames.
     // Handle case where object is passed in directly, or where inside a _list local variable
+    const templateArray = [];
     const dataListObject = isObject(row?.value)
       ? row.value
       : Array.isArray(row?.value) && isObject(row?.value[0])
       ? row.value[0]
       : null;
-    console.log("dataListObject: ", dataListObject);
     if (dataListObject) {
       for (const property in dataListObject) {
         if (dataListObject[property].hasOwnProperty("template")) {

--- a/src/app/shared/components/template/components/layout/nav_group.ts
+++ b/src/app/shared/components/template/components/layout/nav_group.ts
@@ -87,11 +87,18 @@ export class NavGroupComponent extends TemplateLayoutComponent {
   }
 
   modifyRowSetter(row: FlowTypes.TemplateRow) {
+    console.log(`row.value for ${row.name}`, row.value);
     // Check if value is an object referring to a whole data_list with a "template" column,
     // and if so, assign an array of the values of this column to templateNames
     const templateArray = [];
-    if (isObject(row?.value)) {
-      const dataListObject = row.value;
+    // Handle case where object is passed in directly, or where inside a _list local variable
+    const dataListObject = isObject(row?.value)
+      ? row.value
+      : Array.isArray(row?.value) && isObject(row?.value[0])
+      ? row.value[0]
+      : null;
+    console.log("dataListObject: ", dataListObject);
+    if (dataListObject) {
       for (const property in dataListObject) {
         if (dataListObject[property].hasOwnProperty("template")) {
           templateArray.push(dataListObject[property].template);

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -308,7 +308,7 @@ export function deepMergeObjects(target: any, ...sources: any) {
   return deepMergeObjects(target, ...sources);
 }
 
-function isObject(item: any) {
+export function isObject(item: any) {
   return item && typeof item === "object" && !Array.isArray(item);
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Provides a workaround for Issue #1467, in the case of a `nav_group` component using template names from a data list.

A `nav_group` can now be passed a whole data list as its `value` using `@data`, and if that data list contains a `template` column then the values of that column are used to populate the template array of the `nav_list`.

## Screenshots/Videos

From [example_items_nav](https://docs.google.com/spreadsheets/d/1n82prWaYx-HWKW0ibxv-sO_Vuw9WxvuNLRJ_jI_WXtk/edit#gid=1360411654)
NB: example shows 4 "stepper" steps because the source data list contains a row for the CONCATENATE workaround tested in #1467, but this row could be removed
<img width="381" alt="Screenshot 2022-08-19 at 12 48 08" src="https://user-images.githubusercontent.com/64838927/185612389-9077f5f1-b269-46b5-b42e-c206c957f9d9.png">
<img width="682" alt="Screenshot 2022-08-19 at 12 48 26" src="https://user-images.githubusercontent.com/64838927/185612417-6ec1aba6-0ff3-4d1a-b17b-5e88cfc6fe93.png">
<img width="665" alt="Screenshot 2022-08-19 at 12 06 34" src="https://user-images.githubusercontent.com/64838927/185605791-82e5623b-ff0a-4dec-8319-2637ecd4afd1.png">