### PR TITLE
Fix: Notifications now properly scheduled on initial app launch

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -140,13 +140,13 @@ export class AppComponent {
     await this.appDataService.init();
     await this.templateService.init();
     await this.templateProcessService.init();
-    await this.campaignService.init();
     await this.tourService.init();
 
     // Initialise additional services in a non-blocking way
     setTimeout(async () => {
       await this.localNotificationInteractionService.init();
       await this.localNotificationService.init();
+      await this.campaignService.init();
       await this.dbSyncService.init();
       await this.analyticsService.init();
       /** CC 2022-04-01 - Disable service as not currently in use */


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes a bug where notifications were not properly scheduled on initial app launch, see Issue #1496. 

This was due to the fact that the "local notifications" service is required by the "campaign" service to schedule notifications, but the latter was being initialised before the former. Switching the order of these initialisations doesn't seem to have any negative effects from a quick functional test, but perhaps @chrismclarke could assess whether we would expect any knock-on effects relating to changing the order of initialisation of the various core services.

(The fact that the services need to be initialised in this order is actually mentioned in the function description for `initialiseCoreServices`)

## Explanation of the behaviour in the issue

As outlined in Issue #1496, no notifications were initially scheduled when launching the app, but manually "forcing" a notification to be sent via the campaigns list did prompt the "pending notifications" to be populated. I think this can be explained by the fact that the method used to schedule a notification includes a trigger to reload all notifications (including "rescheduling any notifications that have been listed in the DB but do not appear as pending"). So any campaign notification being scheduled, whether through a manual trigger or not, should have properly populated the list of pending notifications.

## Git Issues

Closes #1496 