### PR TITLE
fix: hosting preview

### DIFF
--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -54,6 +54,6 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_PLH_TEENS_APP1 }}"
           projectId: plh-teens-app1
-          target: $DEPLOYMENT_NAME
+          target: "${{env.DEPLOYMENT_NAME}}"
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fix issue where deploy preview action no longer correctly interpreting deployment name variable. 
The issue does not appear to be related to any of our own code changes, so assume just down to some core updates within how git processes actions

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
