### PR TITLE
fix: app services init order

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -139,14 +139,16 @@ export class AppComponent {
     await this.templateTranslateService.init();
     await this.appDataService.init();
     await this.templateService.init();
+    // ensure local notifications service available for campaigns service
+    await this.localNotificationService.init();
+    // ensure campaigns initialised before template_process which processes templates on startup
+    await this.campaignService.init();
     await this.templateProcessService.init();
     await this.tourService.init();
 
     // Initialise additional services in a non-blocking way
     setTimeout(async () => {
       await this.localNotificationInteractionService.init();
-      await this.localNotificationService.init();
-      await this.campaignService.init();
       await this.dbSyncService.init();
       await this.analyticsService.init();
       /** CC 2022-04-01 - Disable service as not currently in use */


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

Fix regression bug created in #1498. A lot of confusing dependency management going on, we had deferred campaign service evaluation to after local notifications, but realise that the campaigns can be called during the templateProcessService which is used to process some standalone (non-rendered) templates at startup with rows `@campaign.some_campaign`.

Longer term it would be better to ensure some sort of ready$ observable on services that can track if a service is initialisings or has been initialised on demand, so that the exact order the the app.component.ts file is not so important.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
