### PR TITLE
Bug: Fix bug where template post-processing was not being properly applied

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/template.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/template.parser.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../utils";
 
 export class TemplateParser extends DefaultParser {
-  postProcess(row: FlowTypes.TemplateRow, nestedPath?: string) {
+  postProcessRow(row: FlowTypes.TemplateRow, nestedPath?: string) {
     // remove empty rows
     if (Object.keys(row).length === 0) {
       return;
@@ -59,7 +59,7 @@ export class TemplateParser extends DefaultParser {
 
     // handle nested rows in same way
     if (row.rows) {
-      row.rows = row.rows.map((r) => this.postProcess(r, row._nested_name));
+      row.rows = row.rows.map((r) => this.postProcessRow(r, row._nested_name));
     }
 
     if (row.exclude_from_translation) {

--- a/src/app/shared/components/template/services/instance/template-row.service.ts
+++ b/src/app/shared/components/template/services/instance/template-row.service.ts
@@ -261,10 +261,7 @@ export class TemplateRowService extends TemplateInstanceService {
     // Instead of returning themselves items looped child rows
     if (type === "items") {
       // extract raw parameter list
-      let itemDataList: { [id: string]: any } = row.value;
-      if (typeof itemDataList === "string") {
-        itemDataList = await this.templateVariablesService.evaluateConditionString(itemDataList);
-      }
+      const itemDataList: { [id: string]: any } = row.value;
       const parameterList = this.hackUnparseItemParameterList(row);
       const parsedItemDataList = await this.parseDataList(itemDataList);
       const itemRows = new ItemProcessor(parsedItemDataList, parameterList).process(row.rows);

--- a/src/app/shared/components/template/services/instance/template-row.service.ts
+++ b/src/app/shared/components/template/services/instance/template-row.service.ts
@@ -261,7 +261,10 @@ export class TemplateRowService extends TemplateInstanceService {
     // Instead of returning themselves items looped child rows
     if (type === "items") {
       // extract raw parameter list
-      const itemDataList: { [id: string]: any } = row.value;
+      let itemDataList: { [id: string]: any } = row.value;
+      if (typeof itemDataList === "string") {
+        itemDataList = await this.templateVariablesService.evaluateConditionString(itemDataList);
+      }
       const parameterList = this.hackUnparseItemParameterList(row);
       const parsedItemDataList = await this.parseDataList(itemDataList);
       const itemRows = new ItemProcessor(parsedItemDataList, parameterList).process(row.rows);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes bug where template post-processing was not being applied, meaning that variables were not being evaluated and items loops were broken.

## Testing

Checkout this feature branch, then run `yarn workflow clear_workflow_cache` followed by `yarn workflow sync_sheets` to process all sheets with the updated parser. In Source Control, the only file differences should be genuine changes made since the last content sync. I suggest testing extensively on this branch, perhaps authoring sheets to test the new data-pipe functionalities.

## Further steps

Further investigation is required to look into the source of the issue: as far as I understand it, templates parsed since PR #1490 should have been parsed incorrectly, not receiving post-processing. This didn't seem to be the case. Potentially an issue related to caching? It's possible that nobody cleared their workflow cache since that PR was merged, although in that case newly authored or edited templates should still have failed to be parsed correctly, according to my current diagnosis.

## Git Issues

Closes #1508 

## Screenshots/Videos

The template `example_items_generated` now displays as expected:
<img width="422" alt="Screenshot 2022-09-23 at 10 30 38" src="https://user-images.githubusercontent.com/64838927/191933213-c0c22d9e-12db-4cef-93b0-1b897de7215e.png">

