### PR TITLE
bug: fix template overrides

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -54,7 +54,7 @@ export default program
  */
 export class AppDataConverter {
   /** Change version to invalidate all underlying caches */
-  public version = 20220823.0;
+  public version = 20220927.0;
 
   public activeDeployment = getActiveDeployment();
 

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -68,7 +68,9 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
   public async postProcess(flows: FlowTypes.FlowTypeWithData[]): Promise<IParsedWorkbookData> {
     const flowsByType: IParsedWorkbookData = groupJsonByKey(flows, "flow_type");
     for (const [flowType, parser] of Object.entries(this.parsers)) {
-      flowsByType[flowType] = parser.postProcessFlows(flowsByType[flowType]);
+      if (flowsByType[flowType]) {
+        flowsByType[flowType] = parser.postProcessFlows(flowsByType[flowType]);
+      }
     }
     const flowTypesWithGenerated: IParsedWorkbookData =
       this.populateDataPipeGeneratedFlows(flowsByType);

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -67,6 +67,9 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
    */
   public async postProcess(flows: FlowTypes.FlowTypeWithData[]): Promise<IParsedWorkbookData> {
     const flowsByType: IParsedWorkbookData = groupJsonByKey(flows, "flow_type");
+    for (const [flowType, parser] of Object.entries(this.parsers)) {
+      flowsByType[flowType] = parser.postProcessFlows(flowsByType[flowType]);
+    }
     const flowTypesWithGenerated: IParsedWorkbookData =
       this.populateDataPipeGeneratedFlows(flowsByType);
     return flowTypesWithGenerated;

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
@@ -69,21 +69,6 @@ export class DefaultParser<
     return this.flow;
   }
 
-  /** If extending the class add additional postprocess pipeline here */
-  public postProcessRow(row: any) {
-    return row;
-  }
-
-  /** Postprocess an individual flow */
-  public postProcessFlow(flow: FlowType) {
-    return flow;
-  }
-
-  /** Postprocess an array of flows */
-  public postProcessFlows(flows: FlowType[]) {
-    return flows;
-  }
-
   /** If any flows have a first row that starts `@default` return values */
   private extractRowDefaultValues(flow: FlowType) {
     const firstRow = flow.rows?.[0] || {};
@@ -92,6 +77,30 @@ export class DefaultParser<
       delete firstRow[defaultKey];
       return firstRow;
     }
+  }
+
+  /***************************************************************************************
+   * Postprocess Pipeline
+   * If extending the class, override these default methods to add additional
+   * postprocess pipeline. By default, each method just returns its input.
+   **************************************************************************************/
+
+  /** Overridable method called by parser to apply any additional processing
+   * on each individual row. By default the original row is simply returned */
+  public postProcessRow(row: any) {
+    return row;
+  }
+
+  /** Overridable method called by parser to apply any additional processing
+   * on each individual flow. By default the original flow is simply returned */
+  public postProcessFlow(flow: FlowType) {
+    return flow;
+  }
+
+  /** Overridable method called by parser to apply any additional processing on the
+   * array of all processed flows. By default the original list is simply returned */
+  public postProcessFlows(flows: FlowType[]) {
+    return flows;
   }
 }
 

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
@@ -79,6 +79,11 @@ export class DefaultParser<
     return flow;
   }
 
+  /** Postprocess an array of flows */
+  public postProcessFlows(flows: FlowType[]) {
+    return flows;
+  }
+
   /** If any flows have a first row that starts `@default` return values */
   private extractRowDefaultValues(flow: FlowType) {
     const firstRow = flow.rows?.[0] || {};


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

A further bug fix following on from PR #1514.

The method used to assign template overrides was not being called by the sheets processor, since PR #1490. 
This PR makes the `postProcessFlows()` method for each parser explicitly called within `flowParser.postProcess()` to ensure that `templateParser.postProcessFlows()`, which handles assigning the template overrides, is called. There may be a more idiomatic way to achieve this, in the context of our parsers, but I believe this approach meets our current needs.

This PR also updates the version code for the `AppDataConverter` in order to invalidate any author's previous caches and force all the sheets to be reprocessed using the updated parser.

## Testing

Because the `AppDataConverter` version number is updated, you shouldn't need to manually clear the workflow cache: just checkout out this branch, sync the sheets and manually check that the changes look correct. In particular, ensure that the overrides are present and correct.

## Git Issues

Closes #1516 