### PR TITLE
feat: add support for skins

### DIFF
--- a/packages/data-models/constants.ts
+++ b/packages/data-models/constants.ts
@@ -39,6 +39,7 @@ const APP_FIELDS = {
   DEPLOYMENT_NAME: `${FIELD_PREFIX}._deployment_name`,
   APP_VERSION: `${FIELD_PREFIX}._app_version`,
   APP_AUTH_USER: `${FIELD_PREFIX}._app_auth_user`,
+  APP_SKIN: `${FIELD_PREFIX}._app_skin`,
 };
 
 const APP_LANGUAGES = {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { Capacitor } from "@capacitor/core";
 import { SplashScreen } from "@capacitor/splash-screen";
 import { App } from "@capacitor/app";
 import { DbService } from "./shared/services/db/db.service";
+import { SkinService } from "./shared/services/skin/skin.service";
 import { ThemeService } from "./feature/theme/services/theme.service";
 import { environment } from "src/environments/environment";
 import { TaskActionService } from "./shared/services/task/task-action.service";
@@ -51,7 +52,8 @@ export class AppComponent {
     private dbService: DbService,
     private dbSyncService: DBSyncService,
     private userMetaService: UserMetaService,
-    public themeService: ThemeService,
+    private themeService: ThemeService,
+    private skinService: SkinService,
     private tourService: TourService,
     private templateService: TemplateService,
     private templateFieldService: TemplateFieldService,
@@ -131,6 +133,7 @@ export class AppComponent {
     await this.dbService.init();
     await this.userMetaService.init();
     this.themeService.init();
+    this.skinService.init();
     /** CC 2021-05-14 - disabling reminders service until decide on full implementation (ideally not requiring evaluation of all reminders on init) */
     // this.remindersService.init();
     await this.appEventService.init();

--- a/src/app/feature/theme/services/theme.service.ts
+++ b/src/app/feature/theme/services/theme.service.ts
@@ -23,6 +23,7 @@ export class ThemeService {
 
   public setTheme(themeName: string) {
     if (this.availableThemes.includes(themeName)) {
+      console.log("[SET THEME]", themeName);
       document.body.dataset.theme = themeName;
       this.currentTheme$.next(themeName);
       // Use local storage so that the current theme persists across app launches

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -16,6 +16,8 @@ import { TemplateFieldService } from "../template-field.service";
 import { EventService } from "src/app/shared/services/event/event.service";
 import { DBSyncService } from "src/app/shared/services/db/db-sync.service";
 import { AuthService } from "src/app/shared/services/auth/auth.service";
+import { SkinService } from "src/app/shared/services/skin/skin.service";
+import { ThemeService } from "src/app/feature/theme/services/theme.service";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -42,6 +44,8 @@ export class TemplateActionService extends TemplateInstanceService {
   private eventService: EventService;
   private dbSyncService: DBSyncService;
   private authService: AuthService;
+  private skinService: SkinService;
+  private themeService: ThemeService;
 
   constructor(injector: Injector, public container?: TemplateContainerComponent) {
     super(injector);
@@ -56,6 +60,8 @@ export class TemplateActionService extends TemplateInstanceService {
     this.eventService = this.getGlobalService(EventService);
     this.dbSyncService = this.getGlobalService(DBSyncService);
     this.authService = this.getGlobalService(AuthService);
+    this.skinService = this.getGlobalService(SkinService);
+    this.themeService = this.getGlobalService(ThemeService);
   }
 
   /** Public method to add actions to processing queue and process */
@@ -212,6 +218,12 @@ export class TemplateActionService extends TemplateInstanceService {
         }
         if (emit_value === "set_language") {
           this.templateTranslateService.setLanguage(args[1]);
+        }
+        if (emit_value === "set_skin") {
+          this.skinService.setSkin(args[1]);
+        }
+        if (emit_value === "set_theme") {
+          this.themeService.setTheme(args[1]);
         }
         if (emit_value === "server_sync") {
           await this.serverService.syncUserData();

--- a/src/app/shared/services/skin/skin.service.spec.ts
+++ b/src/app/shared/services/skin/skin.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { SkinService } from "./skin.service";
+
+describe("SkinService", () => {
+  let service: SkinService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SkinService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/skin/skin.service.ts
+++ b/src/app/shared/services/skin/skin.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from "@angular/core";
+import { BehaviorSubject } from "rxjs";
+import { LocalStorageService } from "src/app/shared/services/local-storage/local-storage.service";
+import { APP_CONSTANTS } from "src/app/data";
+
+const { APP_FIELDS } = APP_CONSTANTS;
+
+// TODO - Where should these live and be added to? Should ultimately come from sheets?
+// Could live at deployment level, e.g. app_constants.compatible_skins
+const SKINS = ["default", "modular"];
+
+@Injectable({
+  providedIn: "root",
+})
+export class SkinService {
+  currentSkin$ = new BehaviorSubject<string>(null);
+  availableSkins = SKINS;
+
+  constructor(private localStorageService: LocalStorageService) {}
+
+  init() {
+    const currentSkinName = this.getCurrentSkin();
+    if (currentSkinName) {
+      this.setSkin(currentSkinName);
+    } else {
+      this.setSkin("default");
+    }
+  }
+
+  public setSkin(skinName: string) {
+    if (this.availableSkins.includes(skinName)) {
+      console.log("[SET SKIN]", skinName);
+      this.currentSkin$.next(skinName);
+      // Use local storage so that the current skin persists across app launches
+      this.localStorageService.setString(APP_FIELDS.APP_SKIN, skinName);
+    } else {
+      console.error(`No skin found with name "${skinName}"`);
+    }
+  }
+
+  public getCurrentSkin() {
+    return this.localStorageService.getString(APP_FIELDS.APP_SKIN);
+  }
+
+  public getAllSkins() {
+    return this.availableSkins;
+  }
+}


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds support for skins. The current skin is tracked in the value of an app field: `_app_skin`. This value can be referred to in templates in order to apply template overrides that are conditional on the current app skin, as exemplified in [example overrides](https://docs.google.com/spreadsheets/d/1MpoH3BxhECZRmYM10HZ0pTOoe69FJ-fEW9FwzK-Q6yw/edit#gid=1745157248) (last 3 sheets).

Also exposes `_app_skin` (and `_app_theme`) to be updated via the `set_skin` (and `set_theme`) emit. As these are reserved app fields, they should be treated as readonly and no template action is offered to alter them

## Git Issues

Closes #

## Screenshots/Videos

Example of skin switching and overrides being applied. Template: [example_skin_override_default](https://docs.google.com/spreadsheets/d/1MpoH3BxhECZRmYM10HZ0pTOoe69FJ-fEW9FwzK-Q6yw/edit#gid=1226561114)

https://user-images.githubusercontent.com/64838927/193626580-cd2e89ea-5215-494d-901b-60294beef0ef.mov


