### PR TITLE
feat: add info button to 'parent point box' component

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -338,7 +338,8 @@ export namespace FlowTypes {
     | "audio_end"
     | "audio_first_start"
     | "nav_resume" // return to template after navigation or popup close;
-    | "sent"; // notification sent
+    | "sent" // notification sent
+    | "info_click";
 
   export interface TemplateRowAction {
     /** actions have an associated trigger */

--- a/packages/scripts/src/commands/app-data/convert/utils/app-data-action.utils.ts
+++ b/packages/scripts/src/commands/app-data/convert/utils/app-data-action.utils.ts
@@ -30,6 +30,7 @@ export function parseAppDataActionString(actionString: string): FlowTypes.Templa
     uncompleted: true,
     nav_resume: true,
     sent: true,
+    info_click: true,
   };
   if (!Object.keys(actionTriggers).find((t) => actionString.startsWith(t))) {
     actionString = `click | ${actionString}`;

--- a/src/app/shared/components/template/components/points-item/points-item.component.html
+++ b/src/app/shared/components/template/components/points-item/points-item.component.html
@@ -9,6 +9,9 @@
         {{ _row.value }}
       </div>
     </div>
+    <div *ngIf="info_icon_src" class="info-button" (click)="clickInfo($event)">
+      <img [src]="info_icon_src | plhAsset" alt="" />
+    </div>
     <div class="image">
       <!-- order of preference - video, lottie, img -->
       <video

--- a/src/app/shared/components/template/components/points-item/points-item.component.scss
+++ b/src/app/shared/components/template/components/points-item/points-item.component.scss
@@ -20,7 +20,7 @@ $item-background: var(--points-item-background, var(--ion-color-primary-200));
     .star {
       @include mixins.flex-centered;
       position: absolute;
-      right: -12px;
+      left: -12px;
       top: -16px;
       .star-value {
         padding-top: 4px;
@@ -32,6 +32,16 @@ $item-background: var(--points-item-background, var(--ion-color-primary-200));
       img {
         width: calc(47px * var(--scale-factor--point));
         height: calc(47px * var(--scale-factor--point));
+      }
+    }
+    .info-button {
+      // @include mixins.flex-centered;
+      position: absolute;
+      right: 6px;
+      top: 6px;
+      img {
+        width: calc(28px * var(--scale-factor--point));
+        height: calc(28px * var(--scale-factor--point));
       }
     }
     .image {

--- a/src/app/shared/components/template/components/points-item/points-item.component.scss
+++ b/src/app/shared/components/template/components/points-item/points-item.component.scss
@@ -35,7 +35,6 @@ $item-background: var(--points-item-background, var(--ion-color-primary-200));
       }
     }
     .info-button {
-      // @include mixins.flex-centered;
       position: absolute;
       right: 6px;
       top: 6px;

--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -27,6 +27,7 @@ export class TmplParentPointBoxComponent
   @ViewChild("star", { static: false }) star: ElementRef;
   @ViewChild("item", { static: false }) item: ElementRef;
   icon_src: string | null;
+  info_icon_src: string | null;
   lottie_src: string | null;
   video_src: string | null;
   windowWidth: number;
@@ -80,6 +81,7 @@ export class TmplParentPointBoxComponent
   getParams() {
     this.video_src = getStringParamFromTemplateRow(this._row, "video_src", null);
     this.icon_src = getStringParamFromTemplateRow(this._row, "icon_src", null);
+    this.info_icon_src = getStringParamFromTemplateRow(this._row, "info_icon_src", null);
     this.lottie_src = getStringParamFromTemplateRow(this._row, "lottie_src", null);
     this.play_celebration = getBooleanParamFromTemplateRow(this._row, "play_celebration", true);
     this.text = getStringParamFromTemplateRow(this._row, "text", null);
@@ -110,6 +112,11 @@ export class TmplParentPointBoxComponent
     await this.setValue(this.value);
     await this.triggerActions("click");
     await this.triggerActions("changed");
+  }
+
+  async clickInfo(event) {
+    await this.triggerActions("info_click");
+    event.stopPropagation();
   }
 
   getScaleFactor(): number {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds an optional "info" button to the top right of the `parent_point_box` component. The button is present iff an `info_icon_src` is provided to the component. The actions triggered on click of this icon are set at the template level, via the new `info_click` trigger in the action list of the `parent_point_box` component.
See [example_parent_point_box](https://docs.google.com/spreadsheets/d/1OzJtUnbn8b4km7x7eYmCajOugn9syQhdzWEUzuILIkc/edit#gid=63099847).

The star containing the counter is shifted to the left of the box in order to put the info button in its most natural place (even when there is no info button).

Adding a new type of action trigger, in this case `info_click`, is generally not desirable, but I think it is potentially justified here – it offers a very efficient way to achieve our current use case, and could be useful if we want to extend this functionality to other components. For example, if we want to move away from using ionic, then we may want to implement custom "info" tooltips and move away from ionic's in-built functionality (as currently in use, for example, on the slider component – see `comp_slider`).

## Git Issues

Closes #1529 

## Screenshots/Videos

[example_parent_point_box](https://docs.google.com/spreadsheets/d/1OzJtUnbn8b4km7x7eYmCajOugn9syQhdzWEUzuILIkc/edit#gid=63099847)

https://user-images.githubusercontent.com/64838927/193871589-b9b616a7-decf-4453-9f4e-5f3fee44ac5b.mov

<img width="1282" alt="Screenshot 2022-10-04 at 17 13 14" src="https://user-images.githubusercontent.com/64838927/193871145-e37f6452-098d-4912-8b41-379e85d9c0d2.png">

