### PR TITLE
fix: prevent info button sometimes triggering click on box below

### DIFF
--- a/src/app/shared/components/template/components/points-item/points-item.component.ts
+++ b/src/app/shared/components/template/components/points-item/points-item.component.ts
@@ -115,8 +115,8 @@ export class TmplParentPointBoxComponent
   }
 
   async clickInfo(event) {
-    await this.triggerActions("info_click");
     event.stopPropagation();
+    await this.triggerActions("info_click");
   }
 
   getScaleFactor(): number {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Clicking on the info button on the `parent_point_box` component sometimes undesirably caused the box itself to be click also. See issue #1536.

## Git Issues

Closes #1536 

## Screenshots/Videos

Video showing the component in [example_parent_point_box](https://docs.google.com/spreadsheets/d/1OzJtUnbn8b4km7x7eYmCajOugn9syQhdzWEUzuILIkc/edit#gid=63099847) working as expected. The output of the `info_click` `set_field` action can be seen in the console log. 

https://user-images.githubusercontent.com/64838927/194067033-3ae551dd-65d0-4338-b8b9-06c04eb89d77.mov

