### PR TITLE
chore: add authorize workflow

### DIFF
--- a/documentation/docs/authors/quickstart.md
+++ b/documentation/docs/authors/quickstart.md
@@ -33,7 +33,7 @@ All users need to connect to their personal Google Drive account to access files
 To connect to your Google account you must run:
 
 ```
-yarn scripts app-data download --authorize
+yarn workflow sync_authorize
 ```
 
 You will be prompted to sign into your Google account in a browser window and grant the app access. You may see a warning message to connect the unverified app. Use the advanced dropdown to accept.

--- a/packages/data-models/workflows/sync.workflows.ts
+++ b/packages/data-models/workflows/sync.workflows.ts
@@ -125,6 +125,18 @@ const workflows: IDeploymentWorkflows = {
       },
     ],
   },
+  sync_authorize: {
+    label: "Authorize Google Drive for content sync",
+    steps: [
+      {
+        name: "authorize",
+        function: async ({ tasks }) => {
+          tasks.gdrive.authorize();
+          process.exit(0);
+        },
+      },
+    ],
+  },
 };
 
 export default workflows;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Just running a belated re-review of #1519, all looks good to me although I've previously been trying to deprecate some of the `yarn scripts` commands in favour of workflows so added a quick PR here to migrate the code a little.

Namely
- add a `sync_authorize` workflow and update getting started readme accordingly (note, I don't think this actually needs to be explicit as first run will prompt if auth does not exist, although probably good to keep for reference if we ever want people to manually re-authenticate)

- update the authorize command to also remove existing auth (I found I wasn't being prompted to create new credentials but the old kept failing)

- code tidying on the `gdrive` tasks to add authorize command (to call from task instead of app-data), and refactor a bit of duplicate code for generating common args passed to the gdrive tools executable

## Review Notes
run `yarn workflow sync_authorize`, check that this prompts creation of a new auth token that works with sync

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
