### PR TITLE
fix: concat normalisation

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -54,7 +54,7 @@ export default program
  */
 export class AppDataConverter {
   /** Change version to invalidate all underlying caches */
-  public version = 20220927.0;
+  public version = 20221011.0;
 
   public activeDeployment = getActiveDeployment();
 

--- a/packages/shared/src/models/dataPipe/operators/concat.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.spec.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from "danfojs";
+import { DataFrame, toJSON } from "danfojs";
 import { DataPipe } from "../pipe";
 import testData from "../testData.spec";
 import concat from "./concat";
@@ -40,4 +40,84 @@ describe("Concat Operator", () => {
     const expectedCols = ["id", "first_name", "last_name", "year_of_birth", "additonal_field"];
     expect(output.columns).toEqual(expectedCols);
   });
+  it("concatenates complex example", () => {
+    const { debugData1, debugData2, outputExpected } = DEBUG_TEST_DATA();
+    (testData as any).debugData1 = debugData1;
+    (testData as any).debugData2 = debugData2;
+    const output = new concat(emptyDf, ["debugData1", "debugData2"], testPipe).apply();
+    expect(toJSON(output)).toEqual(outputExpected);
+  });
 });
+
+/** Example concatenating 2 lists containing irregular shaped data */
+function DEBUG_TEST_DATA() {
+  const debugData1 = [
+    {
+      id: "welcome_individual",
+      individual: true,
+      together: false,
+      priority: 1,
+    },
+    {
+      id: "care_together",
+      individual: false,
+      together: true,
+      priority: 2,
+    },
+  ];
+  // Importantly debugData2's first entry does not contain all columns (requires normalising)
+  // and contains columns in different order to debugData1
+  const debugData2 = [
+    {
+      id: "question_1",
+      template: "w_praise_question_1",
+      individual: true,
+      together: false,
+      priority: 11,
+    },
+    {
+      id: "read",
+      subtask_group: "read",
+      template: "w_praise_read",
+      individual: true,
+      together: true,
+      priority: 12,
+    },
+  ];
+  // concatenated data should contain all rows and fill missing values
+  const outputExpected = [
+    {
+      id: "welcome_individual",
+      individual: true,
+      together: false,
+      priority: 1,
+      template: undefined,
+      subtask_group: undefined,
+    },
+    {
+      id: "care_together",
+      individual: false,
+      together: true,
+      priority: 2,
+      template: undefined,
+      subtask_group: undefined,
+    },
+    {
+      id: "question_1",
+      individual: true,
+      together: false,
+      priority: 11,
+      template: "w_praise_question_1",
+      subtask_group: undefined,
+    },
+    {
+      id: "read",
+      individual: true,
+      together: true,
+      priority: 12,
+      template: "w_praise_read",
+      subtask_group: "read",
+    },
+  ];
+  return { debugData1, debugData2, outputExpected };
+}

--- a/packages/shared/src/models/dataPipe/operators/concat.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.ts
@@ -1,4 +1,5 @@
 import { DataFrame, concat } from "danfojs";
+import { normalizeData } from "..";
 import type { DataPipe } from "../pipe";
 import { setIndexColumn } from "../utils";
 import BaseOperator from "./base";
@@ -28,7 +29,7 @@ class ConcatOperator extends BaseOperator {
     return this.df;
   }
   private applyConcat(data: any): DataFrame {
-    let concatDf = new DataFrame(data);
+    let concatDf = new DataFrame(normalizeData(data));
     // empty dataframes throw error on concat, so just return the other (or existing) dataframe instead
     if (this.df.index.length === 0) return concatDf;
     if (concatDf.index.length === 0) return this.df;

--- a/packages/shared/src/models/dataPipe/utils.ts
+++ b/packages/shared/src/models/dataPipe/utils.ts
@@ -37,14 +37,14 @@ export function normalizeData(data: { [key: string]: any }[], missingValueReplac
     }
   }
   const columns = Object.keys(columnsHashmap);
-  // Replace missing values
+  // Replace missing values and order columns consistently
   return data.map((entry) => {
+    const normalised = {};
     for (const column of columns) {
-      if (!entry.hasOwnProperty(column)) {
-        entry[column] = missingValueReplacement;
-      }
+      const value = entry.hasOwnProperty(column) ? entry[column] : missingValueReplacement;
+      normalised[column] = value;
     }
-    return entry;
+    return normalised;
   });
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Fix issue identified where concatenating 2 lists with columns in mixed orders would populate data incorrectly

- Add normalisation step to concat operations to ensure columns aren't accidentally omitted
- Ensure normalisation also enforces consistent column order
- Add additional test data and spec test for local testing

## Review Notes
Recommend testing against the example data. 
I've gone ahead and bumped the parser core version which should invalidate all existing cached data. Syncing locally I can see there are definite changes, so just needs to be cross-checked if the changes are as expected

![image](https://user-images.githubusercontent.com/10515065/195211127-b9831ea3-3161-4a93-ab8c-ab573b899e18.png)


## Git Issues

Closes #1515
Closes #1557

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
