### PR TITLE
Fix/concat multiple steps

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -5,7 +5,7 @@ import { groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
-  public cacheVersion = 20220831.1;
+  public cacheVersion = 20221011.1;
 
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {
     template: new Parsers.TemplateParser(this),

--- a/packages/shared/src/models/dataPipe/operators/concat.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.spec.ts
@@ -31,7 +31,7 @@ describe("Concat Operator", () => {
   it("Throws if concatenating lists with duplicate ids", () => {
     const duplicateDf = new DataFrame([{ id: "id_3", first_name: "Duplicated" }]);
     expect(() => new concat(duplicateDf, ["names"], testPipe).apply()).toThrowError(
-      "Multiple entries exist for index: id_3"
+      "names\nMultiple entries exist for index: id_3"
     );
   });
   it("concatenates multiple lists", () => {

--- a/packages/shared/src/models/dataPipe/operators/concat.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.ts
@@ -6,15 +6,21 @@ import BaseOperator from "./base";
 type ILoadedDatalist = any; // datalist
 
 class ConcatOperator extends BaseOperator {
-  public args_list: string[];
+  public args_list: { data: any; name: string }[];
   private indexColumn = "id";
+  /** When processing arg keep track of active for logging purposes */
+  private activeArg: { data: any; name: string };
   constructor(df: DataFrame, args_list: any, pipe: DataPipe) {
     super(df, args_list, pipe);
   }
 
   // load input data list from arg, populate error object if not exist for use in validation step
   parseArg(arg: any): ILoadedDatalist {
-    return this.pipe.inputSources[arg] ?? { error: `Data list does not exists: ${arg}` };
+    const data = this.pipe.inputSources[arg];
+    if (!data) {
+      return { error: `Data list does not exists: ${arg}` };
+    }
+    return { data, name: arg };
   }
 
   validateArg(datalist: ILoadedDatalist) {
@@ -22,8 +28,9 @@ class ConcatOperator extends BaseOperator {
   }
 
   apply() {
-    for (const dataList of this.args_list) {
-      this.df = this.applyConcat(dataList);
+    for (const arg of this.args_list) {
+      this.activeArg = arg;
+      this.df = this.applyConcat(arg.data);
     }
     return this.df;
   }
@@ -68,11 +75,10 @@ class ConcatOperator extends BaseOperator {
   private checkDuplicateRows(df1: DataFrame, df2: DataFrame) {
     const duplicateIndex = df1.index.find((index) => df2.index.includes(index));
     if (duplicateIndex) {
-      throw new Error("Multiple entries exist for index: " + duplicateIndex);
+      throw new Error(
+        `${this.activeArg.name}\nMultiple entries exist for index: ${duplicateIndex}`
+      );
     }
   }
-
-  /** Concatenate two identically-shaped data frames */
-  private concatDfs(df1: DataFrame, df2: DataFrame) {}
 }
 export default ConcatOperator;

--- a/packages/shared/src/models/dataPipe/pipe.spec.ts
+++ b/packages/shared/src/models/dataPipe/pipe.spec.ts
@@ -72,6 +72,16 @@ describe("Data Pipe", () => {
     const pipe = new DataPipe(operations, testData);
     expect(() => pipe.run()).toThrowError("Input sources missing for data pipe: nationalities");
   });
+  it("Empties input source when specified as FALSE", () => {
+    const operations: IDataPipeOperation[] = [
+      { input_source: "names", operation: "filter", args_list: [], output_target: "names" },
+      { input_source: false as any, operation: "filter", output_target: "empty", args_list: [] },
+    ];
+    const pipe = new DataPipe(operations, testData);
+    pipe.run();
+    expect(pipe.outputTargets.names.length === 2);
+    expect(pipe.outputTargets.empty.length === 0);
+  });
   it("Throw on invalid operation", () => {
     const invalidOp = { operation: "invalid_op" };
     expect(() => new DataPipe([invalidOp as any]).run()).toThrowError(

--- a/packages/shared/src/models/dataPipe/pipe.ts
+++ b/packages/shared/src/models/dataPipe/pipe.ts
@@ -17,10 +17,7 @@ export class DataPipe {
       throw new Error("Input sources missing for data pipe: " + missingInputs);
     }
     for (const step of this.steps) {
-      // assign input if specified (default to previous output)
-      if (step.input_source) {
-        this.setInputSource(step.input_source);
-      }
+      this.setInputSource(step.input_source);
       // validate operator
       const operator = OPERATORS[step.operation] as IBaseOperator;
       if (!operator) {
@@ -47,11 +44,22 @@ export class DataPipe {
     }
   }
 
-  setInputSource(name: string) {
-    if (!this.inputSources.hasOwnProperty(name)) {
-      throw new Error(`Data source not found: ${name}`);
+  /**
+   * Assign input if specified (default to previous output)
+   * @param name if specified will populate from named datalist
+   * @note if FALSE provided will clear current dataframe to empty instead
+   */
+  setInputSource(name?: string | boolean) {
+    if (typeof name === "string") {
+      if (!this.inputSources.hasOwnProperty(name)) {
+        throw new Error(`Data source not found: ${name}`);
+      }
+      this.df = new DataFrame(this.inputSources[name]);
     }
-    this.df = new DataFrame(this.inputSources[name]);
+    // specifying FALSE in name column loads an empty dataset
+    if (name === false) {
+      this.df = new DataFrame([]);
+    }
   }
 
   /** Extract a list of all required input sources and check to see if they already exist or will be generated */


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

When processing data pipes by default the output data of each step will be used as the input for the next, unless another named input_source is provided. A proposal was made to allow passing input_source FALSE to bypass this behaviour and instead start with a blank/empty input source (e.g. concatenating two data lists independent of other operations), however this was never fully implemented. 

This PR should correct the behaviour. 
It also improves the logging to reflect the name of the datalist when error thrown for duplicate row ids

## Review Notes
Recommend testing with the sheets noted in the linked PR

## Git Issues

Closes #1555

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
