### PR TITLE
fix: prevent data pipes replacing @row self refs

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
@@ -256,6 +256,9 @@ class RowProcessor {
 
   /** replace any self references, i.e "hello @row.id" => "hello some_id"   */
   private replaceRowSelfReferences() {
+    // Hack - avoid replacing @row statements in data pipes as they refer to row on data source instead
+    if (this.parent.flow.flow_type === "data_pipe") return this.row;
+    // Handle replacements
     const context = { row: this.row };
     return new TemplatedData({ context, initialValue: this.row }).parse();
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
When appending columns using data pipes, references to `@row` are evaluated too early (against their original sheet) instead of the context of the row that the column is being appended to. This PR omits `@row` default parsing step for all data_pipe, instead evaluating in the context of the full row when processing in the data pipeline

A weird side-issue emerged during this where actually it's only rows with `{@row.some_column}` are lost, so an original example of `hello: @row.id` was still working but not `hello: prefix_{@row.id}_suffix` - I can't quite pinpoint why this is the case so for now will just proceed with the fix above and can revisit if the issue emerges again

## Git Issues

Closes #

## Screenshots/Videos
Updated sheets looks like fields should be populated correctly
![image](https://user-images.githubusercontent.com/10515065/195667941-c583bdac-1672-4966-a06a-c47271c3a5fc.png)
