### PR TITLE
chore: improve error logging during data pipe ops

### DIFF
--- a/packages/shared/src/models/dataPipe/operators/concat.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.spec.ts
@@ -31,7 +31,7 @@ describe("Concat Operator", () => {
   it("Throws if concatenating lists with duplicate ids", () => {
     const duplicateDf = new DataFrame([{ id: "id_3", first_name: "Duplicated" }]);
     expect(() => new concat(duplicateDf, ["names"], testPipe).apply()).toThrowError(
-      "names\nMultiple entries exist for index: id_3"
+      "[names] Multiple entries exist for index: id_3"
     );
   });
   it("concatenates multiple lists", () => {

--- a/packages/shared/src/models/dataPipe/operators/concat.ts
+++ b/packages/shared/src/models/dataPipe/operators/concat.ts
@@ -77,7 +77,7 @@ class ConcatOperator extends BaseOperator {
     const duplicateIndex = df1.index.find((index) => df2.index.includes(index));
     if (duplicateIndex) {
       throw new Error(
-        `${this.activeArg.name}\nMultiple entries exist for index: ${duplicateIndex}`
+        `[${this.activeArg.name}] Multiple entries exist for index: ${duplicateIndex}`
       );
     }
   }

--- a/packages/shared/src/models/dataPipe/pipe.spec.ts
+++ b/packages/shared/src/models/dataPipe/pipe.spec.ts
@@ -88,4 +88,16 @@ describe("Data Pipe", () => {
       `No pipeline operator exists: ${invalidOp.operation}`
     );
   });
+  it("Provides step context when throwing on error", () => {
+    // concatenating a list with itself should throw error due to duplicate ids
+    const operations: IDataPipeOperation[] = [
+      { input_source: "names", operation: "concat", args_list: ["names"], output_target: "names" },
+    ];
+    try {
+      new DataPipe(operations, testData).run();
+    } catch (error) {
+      const { step } = JSON.parse(error.message);
+      expect(step).toEqual(operations[0]);
+    }
+  });
 });

--- a/packages/shared/src/models/dataPipe/pipe.ts
+++ b/packages/shared/src/models/dataPipe/pipe.ts
@@ -25,11 +25,16 @@ export class DataPipe {
       }
       // apply operation
       const instance = new operator(this.df, step.args_list, this);
-      const output = instance.apply();
-      // Assign output as next input. Populate as named input/output if specified
-      this.df = output;
-      if (step.output_target) {
-        this.setOutputTarget(step.output_target);
+      try {
+        const output = instance.apply();
+        // Assign output as next input. Populate as named input/output if specified
+        this.df = output;
+        if (step.output_target) {
+          this.setOutputTarget(step.output_target);
+        }
+      } catch (error) {
+        error.message = JSON.stringify({ message: error.message, step }, null, 2);
+        throw error;
       }
     }
     return this.outputTargets;

--- a/packages/shared/src/models/dataPipe/pipe.ts
+++ b/packages/shared/src/models/dataPipe/pipe.ts
@@ -33,6 +33,7 @@ export class DataPipe {
           this.setOutputTarget(step.output_target);
         }
       } catch (error) {
+        // add additional step context to error message when thrown
         error.message = JSON.stringify({ message: error.message, step }, null, 2);
         throw error;
       }

--- a/packages/shared/src/models/dataPipe/utils.spec.ts
+++ b/packages/shared/src/models/dataPipe/utils.spec.ts
@@ -38,4 +38,10 @@ describe("DataPipe Utils: Set Index Column", () => {
     const errMsg = "Column [missing_col] does not exist in data\nColumns: id, value";
     expect(() => DataPipeUtils.setIndexColumn(df, "missing_col")).toThrowError(errMsg);
   });
+  const nonUniqueDf = new DataFrame([...input, ...input]);
+  it("Throws on non-unique index values", () => {
+    expect(() => DataPipeUtils.setIndexColumn(nonUniqueDf, "id")).toThrowError(
+      `Duplicate ids found for entries: id_2, id_1`
+    );
+  });
 });

--- a/packages/shared/src/models/dataPipe/utils.ts
+++ b/packages/shared/src/models/dataPipe/utils.ts
@@ -1,4 +1,4 @@
-import { DataFrame, Series } from "danfojs";
+import { DataFrame } from "danfojs";
 
 /**
  * Replace NaN values with replacement value. Similar to danfo.js replace method except

--- a/packages/shared/src/models/dataPipe/utils.ts
+++ b/packages/shared/src/models/dataPipe/utils.ts
@@ -1,4 +1,4 @@
-import { DataFrame } from "danfojs";
+import { DataFrame, Series } from "danfojs";
 
 /**
  * Replace NaN values with replacement value. Similar to danfo.js replace method except
@@ -21,7 +21,21 @@ export function setIndexColumn(df: DataFrame, name: string) {
     const columnList = df.columns.join(", ");
     throw new Error(`Column [${name}] does not exist in data\nColumns: ${columnList}`);
   }
-  df.setIndex({ column: name, inplace: true });
+  try {
+    df.setIndex({ column: name, inplace: true });
+  } catch (error) {
+    // track specific non-unique values in thrown error
+    if (error.message === "IndexError: Row index must contain unique values") {
+      const nonUniqueValues = findNonUniqueValues(df, name);
+      throw new Error("Duplicate ids found for entries: " + nonUniqueValues.join(", "));
+    }
+    // pass any other errors back with additional meta (e.g. non-unique values)
+    throw error;
+  }
+}
+
+function findNonUniqueValues(df: DataFrame, column: string) {
+  return df.column(column).dropDuplicates().values;
 }
 
 /**


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add log of explicit duplicate ids that are thrown in error when apply index to dataframe (e.g. during concat operation in data pipes)

## Review Notes
This is mostly just a quick fix to include a bit more error information. To provide full context (e.g. template names, path to excel etc.) it would need tighter integration with the current logging system which would need a larger PR. So suggest for now we move to merge these incremental changes and flag a new issue in the future if we find difficulty troubleshooting further errors. 

The only way to functionally test would be to author data pipes with known errors. This would probably be good to have more generally, but might be a bit time-consuming to do right now.

## Git Issues

Closes #1578

## Screenshots/Videos
When creating a dataframe that expects unique index values (e.g. _id_), it now explicitly states what values were found as duplicate
![image](https://user-images.githubusercontent.com/10515065/197032621-5e755943-1278-4a1b-a23a-664274b8ee37.png)

Additional logging also added to provide more information about the step being processed
![image](https://user-images.githubusercontent.com/10515065/197038511-082d203b-183b-4cd9-a86e-405d5b0b3c13.png)

Note - the above is generated from testing data with a data_list called _names_ (hence the repeated reference)

