### PR TITLE
feat: Carousel component

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "rxjs": "^6.6.7",
     "shared": "workspace:*",
     "stacktrace-js": "^2.0.2",
+    "swiper": "^8.4.4",
     "zone.js": "~0.11.4"
   },
   "devDependencies": {

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -284,7 +284,8 @@ export namespace FlowTypes {
     | "html"
     | "latex"
     | "animated_slides"
-    | "qr_code";
+    | "qr_code"
+    | "carousel";
 
   export interface TemplateRow extends Row_with_translations {
     type: TemplateRowType;

--- a/src/app/shared/components/template/components/carousel/carousel.component.html
+++ b/src/app/shared/components/template/components/carousel/carousel.component.html
@@ -1,0 +1,11 @@
+<div class="carousel-wrapper">
+  <swiper [config]="config">
+    <ng-template
+      swiperSlide
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+    >
+      <plh-template-component [row]="childRow" [parent]="parent" [attr.data-rowname]="_row.name">
+      </plh-template-component>
+    </ng-template>
+  </swiper>
+</div>

--- a/src/app/shared/components/template/components/carousel/carousel.component.scss
+++ b/src/app/shared/components/template/components/carousel/carousel.component.scss
@@ -1,0 +1,7 @@
+.swiper {
+  width: 100%;
+}
+
+.swiper-slide {
+  // Add any styling for the individual slides here
+}

--- a/src/app/shared/components/template/components/carousel/carousel.component.scss
+++ b/src/app/shared/components/template/components/carousel/carousel.component.scss
@@ -3,5 +3,6 @@
 }
 
 .swiper-slide {
-  // Add any styling for the individual slides here
+  padding: var(--small-padding);
+  width: fit-content;
 }

--- a/src/app/shared/components/template/components/carousel/carousel.component.spec.ts
+++ b/src/app/shared/components/template/components/carousel/carousel.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { IonicModule } from "@ionic/angular";
+
+import { CarouselComponent } from "./carousel.component";
+
+describe("CarouselComponent", () => {
+  let component: CarouselComponent;
+  let fixture: ComponentFixture<CarouselComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [CarouselComponent],
+        imports: [IonicModule.forRoot()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(CarouselComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/template/components/carousel/carousel.component.ts
+++ b/src/app/shared/components/template/components/carousel/carousel.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { TemplateBaseComponent } from "../base";
+import { SwiperOptions } from "swiper";
+import { getNumberParamFromTemplateRow } from "src/app/shared/utils";
+
+@Component({
+  selector: "plh-carousel",
+  templateUrl: "./carousel.component.html",
+  styleUrls: ["./carousel.component.scss"],
+  encapsulation: ViewEncapsulation.None,
+})
+export class TmplCarouselComponent extends TemplateBaseComponent implements OnInit {
+  config: SwiperOptions = {};
+
+  ngOnInit() {
+    this.getParams();
+  }
+
+  getParams() {
+    this.config.slidesPerView = getNumberParamFromTemplateRow(this._row, "slidesPerView", 2.5);
+    this.config.spaceBetween = getNumberParamFromTemplateRow(this._row, "spaceBetween", 10);
+  }
+}

--- a/src/app/shared/components/template/components/carousel/carousel.component.ts
+++ b/src/app/shared/components/template/components/carousel/carousel.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { SwiperOptions } from "swiper";
-import { getNumberParamFromTemplateRow } from "src/app/shared/utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getNumberParamFromTemplateRow,
+} from "src/app/shared/utils";
 
 @Component({
   selector: "plh-carousel",
@@ -17,7 +20,13 @@ export class TmplCarouselComponent extends TemplateBaseComponent implements OnIn
   }
 
   getParams() {
-    this.config.slidesPerView = getNumberParamFromTemplateRow(this._row, "slidesPerView", 2.5);
+    this.config.slidesPerView =
+      getNumberParamFromTemplateRow(this._row, "slidesPerView", null) || "auto";
     this.config.spaceBetween = getNumberParamFromTemplateRow(this._row, "spaceBetween", 10);
+    this.config.loop = getBooleanParamFromTemplateRow(this._row, "loop", false);
+    // "loopedSlides" is required in the Slider config iff "loop" is true
+    if (this.config.loop) {
+      this.config.loopedSlides = this._row.rows.length;
+    }
   }
 }

--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -50,6 +50,7 @@ import { TmplAccordionComponent } from "./accordion/accordion.component";
 import { TmplLatexComponent } from "./latex/latex.component";
 import { TmplAnimatedSlidesComponent } from "./animated-slides/animated-slides.component";
 import { TmplQRCodeComponent } from "./qr-code/qr-code.component";
+import { TmplCarouselComponent } from "./carousel/carousel.component";
 
 /** All components should be exported as a single array for easy module import */
 export const TEMPLATE_COMPONENTS = [
@@ -97,6 +98,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplLatexComponent,
   TmplAnimatedSlidesComponent,
   TmplQRCodeComponent,
+  TmplCarouselComponent,
 ];
 
 /***************************************************************************************
@@ -159,4 +161,5 @@ export const TEMPLATE_COMPONENT_MAPPING: Record<
   latex: TmplLatexComponent,
   animated_slides: TmplAnimatedSlidesComponent,
   qr_code: TmplQRCodeComponent,
+  carousel: TmplCarouselComponent,
 };

--- a/src/app/shared/components/template/template.module.ts
+++ b/src/app/shared/components/template/template.module.ts
@@ -4,6 +4,7 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { IonicModule } from "@ionic/angular";
 import { LottieModule } from "ngx-lottie";
 import { NouisliderModule } from "ng2-nouislider";
+import { SwiperModule } from "swiper/angular";
 
 import { SharedPipesModule } from "../../pipes";
 import { TooltipDirective } from "../common/directives/tooltip.directive";
@@ -24,6 +25,7 @@ import { createCustomElement } from "@angular/elements";
     SharedPipesModule,
     NouisliderModule,
     LottieModule,
+    SwiperModule,
   ],
   exports: [...TEMPLATE_COMPONENTS, ...TEMPLATE_PIPES, TemplateContainerComponent],
   declarations: [

--- a/src/global.scss
+++ b/src/global.scss
@@ -35,9 +35,14 @@
 @import "./theme/variables.scss";
 @import "./theme/deployment/deployment.scss";
 
+/* Styles for 3rd prty libraries */
 @import "~nouislider/distribute/nouislider.min.css";
+@import "~swiper/scss";
 
-$tour-next-button-background: var(--tour-next-button-background, var(--gradient-secondary-mid-vertical));
+$tour-next-button-background: var(
+  --tour-next-button-background,
+  var(--gradient-secondary-mid-vertical)
+);
 
 .slide-up-modal {
   .modal-wrapper {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10985,6 +10985,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom7@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "dom7@npm:4.0.4"
+  dependencies:
+    ssr-window: ^4.0.0
+  checksum: b38604f74e915b4d05b6634f9ff239a708c468180f498a28ff67f2a61233697d9bd7192703b788a24541c3591e7f1a6e83a2cbf70bc871a85e033f82e19abc31
+  languageName: node
+  linkType: hard
+
 "domain-browser@npm:^4.16.0":
   version: 4.22.0
   resolution: "domain-browser@npm:4.22.0"
@@ -13668,6 +13677,7 @@ __metadata:
     rxjs: ^6.6.7
     shared: "workspace:*"
     stacktrace-js: ^2.0.2
+    swiper: ^8.4.4
     typescript: 4.4.2
     zone.js: ~0.11.4
   languageName: unknown
@@ -24473,6 +24483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssr-window@npm:^4.0.0, ssr-window@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "ssr-window@npm:4.0.2"
+  checksum: df182600927f4f3225224cf8c02338ea637c9750519505bbfb9a9236741a2a7ec088386fb948bca7b447b8303d9109e7dc7672e3de041c79ac2a0e03665af7d2
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^8.0.0, ssri@npm:^8.0.1":
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
@@ -25129,6 +25146,16 @@ __metadata:
   peerDependencies:
     express: ">=4.0.0"
   checksum: aff79812940fa1e693eb9a9f2abd7f6e38d62a9d60b9a70fc90749e572d997d70f4cc110b791774f09c5197f8da32941bec25da780ab4c6d58593df23628d735
+  languageName: node
+  linkType: hard
+
+"swiper@npm:^8.4.4":
+  version: 8.4.4
+  resolution: "swiper@npm:8.4.4"
+  dependencies:
+    dom7: ^4.0.4
+    ssr-window: ^4.0.2
+  checksum: 1b016e2be22573f764d00963c919dc3338a47e261bce3d5b50d6e2abb5e1760c606441739b789c96a777675457e85595d76d851a80c3d34417e0c78c9886cb93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds a `carousel` component.

Our current use case is on the home page of the new ["professional" skin](https://github.com/IDEMSInternational/parenting-app-ui/issues/1455). Currently this component includes the minimal functionality for this use case, but it could be expanded upon in future to offer additional functionality and expose more options to the templates, making use of the features of the [SwiperJs](https://swiperjs.com/angular#swiper-component-props) library.

## Git Issues

Closes #

## Screenshots/Videos

Demo of basic functionality, using the template [comp_carousel](https://docs.google.com/spreadsheets/d/1f_vq3KFGlExf1-g1PwPiDad9gOZkIOdRE5X99jCIRsM/edit#gid=569531329).

https://user-images.githubusercontent.com/64838927/197522625-8b6e2115-eeec-4457-b001-2f09ed6b83b6.mov
