### PR TITLE
chore: applied correct naming convention to carousel component's parameters

### DIFF
--- a/src/app/shared/components/template/components/carousel/carousel.component.ts
+++ b/src/app/shared/components/template/components/carousel/carousel.component.ts
@@ -21,8 +21,8 @@ export class TmplCarouselComponent extends TemplateBaseComponent implements OnIn
 
   getParams() {
     this.config.slidesPerView =
-      getNumberParamFromTemplateRow(this._row, "slidesPerView", null) || "auto";
-    this.config.spaceBetween = getNumberParamFromTemplateRow(this._row, "spaceBetween", 10);
+      getNumberParamFromTemplateRow(this._row, "slides_per_view", null) || "auto";
+    this.config.spaceBetween = getNumberParamFromTemplateRow(this._row, "space_between", 10);
     this.config.loop = getBooleanParamFromTemplateRow(this._row, "loop", false);
     // "loopedSlides" is required in the Slider config iff "loop" is true
     if (this.config.loop) {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Minor PR to apply our usual template parameter naming convention to the parameters for the `carousel` component.
- `slidesPerView` -> `slides_per_view`
- `spaceBetween` -> `space_between`

Also updated the [comp_carousel](https://docs.google.com/spreadsheets/d/1f_vq3KFGlExf1-g1PwPiDad9gOZkIOdRE5X99jCIRsM/edit#gid=569531329) sheet

