### PR TITLE
chore: task-card takes additional params: task_group_data_list and completed_field

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -44,7 +44,8 @@
         <!-- If a taskGroupId is provided, show the progress bar for the relevant task group -->
         <div *ngIf="taskGroupId && !taskId">
           <plh-task-progress-bar
-            [taskGroupId]="taskGroupId"
+            [taskGroupDataList]="taskGroupDataList"
+            [taskGroupCompletedField]="taskGroupCompletedField"
             [highlighted]="highlighted"
             [(progressStatus)]="progressStatus"
           ></plh-task-progress-bar>

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -16,6 +16,8 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   highlightedText = "Active";
   progressStatus: IProgressStatus = "notStarted";
   taskGroupId: string | null;
+  taskGroupDataList: string | null;
+  taskGroupCompletedField: string | null;
   taskId: string | null;
   title: string | null;
   subtitle: string | null;
@@ -34,6 +36,12 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
 
   getParams() {
     this.taskGroupId = getStringParamFromTemplateRow(this._row, "task_group_id", null);
+    this.taskGroupDataList = getStringParamFromTemplateRow(this._row, "task_group_data_list", null);
+    this.taskGroupCompletedField = getStringParamFromTemplateRow(
+      this._row,
+      "completed_field",
+      null
+    );
     this.taskId = getStringParamFromTemplateRow(this._row, "task_id", null);
     this.title = getStringParamFromTemplateRow(this._row, "title", null);
     this.subtitle = getStringParamFromTemplateRow(this._row, "subtitle", null);

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -45,7 +45,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   }
 
   async getTaskGroupData(taskGroupId: string) {
-    const dataList = await this.appDataService.getSheet("data_list", `${taskGroupId}_tasks`);
+    const dataList = await this.appDataService.getSheet("data_list", `${taskGroupId}_task_gs`);
     const subtasks = dataList.rows;
     this.subtasksTotal = subtasks.length;
     this.subtasksCompleted = subtasks.filter((task) =>
@@ -56,12 +56,8 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
       this.progressStatusChange.emit(this.progressStatus);
       // Check whether task group has already been completed
       if (this.templateFieldService.getField(`${taskGroupId}_completed`) !== true) {
-        // If not, set completed field to "true" and emit "completed"
+        // If not, set completed field to "true"
         this.setTaskGroupCompleted(taskGroupId);
-        // TODO? Alternatively, leave setting the field to the template, and just emit "completed", i.e.
-        // this.triggerActions("completed")
-        // Currently the task-progress-bar cannot trigger actions, since it is only instantiated inside
-        // the task-card so has now "_row"
       }
     } else if (this.subtasksCompleted) {
       this.progressStatus = "inProgress";

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -12,7 +12,8 @@ import { IProgressStatus } from "src/app/shared/services/task/task.service";
   styleUrls: ["./task-progress-bar.component.scss"],
 })
 export class TmplTaskProgressBarComponent extends TemplateBaseComponent implements OnInit {
-  @Input() taskGroupId: string | null;
+  @Input() taskGroupDataList: string | null;
+  @Input() taskGroupCompletedField: string | null;
   @Input() highlighted: boolean | null;
   @Input() progressStatus: IProgressStatus;
   @Output() progressStatusChange = new EventEmitter<IProgressStatus>();
@@ -31,12 +32,21 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
 
   ngOnInit() {
     this.getParams();
-    this.getTaskGroupData(this.taskGroupId);
+    this.getTaskGroupData();
   }
 
   getParams() {
     if (this._row) {
-      this.taskGroupId = getStringParamFromTemplateRow(this._row, "taskGroupId", null);
+      this.taskGroupDataList = getStringParamFromTemplateRow(
+        this._row,
+        "task_group_data_list",
+        null
+      );
+      this.taskGroupCompletedField = getStringParamFromTemplateRow(
+        this._row,
+        "completed_field",
+        null
+      );
     }
   }
 
@@ -44,9 +54,10 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
     return (this.subtasksCompleted / this.subtasksTotal) * 100;
   }
 
-  async getTaskGroupData(taskGroupId: string) {
-    const dataList = await this.appDataService.getSheet("data_list", `${taskGroupId}_task_gs`);
+  async getTaskGroupData() {
+    const dataList = await this.appDataService.getSheet("data_list", this.taskGroupDataList);
     const subtasks = dataList.rows;
+    console.log(this.taskGroupDataList, subtasks);
     this.subtasksTotal = subtasks.length;
     this.subtasksCompleted = subtasks.filter((task) =>
       this.templateFieldService.getField(task.completed_field)
@@ -55,9 +66,9 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
       this.progressStatus = "completed";
       this.progressStatusChange.emit(this.progressStatus);
       // Check whether task group has already been completed
-      if (this.templateFieldService.getField(`${taskGroupId}_completed`) !== true) {
+      if (this.templateFieldService.getField(this.taskGroupCompletedField) !== true) {
         // If not, set completed field to "true"
-        this.setTaskGroupCompleted(taskGroupId);
+        this.setTaskGroupCompleted(this.taskGroupCompletedField);
       }
     } else if (this.subtasksCompleted) {
       this.progressStatus = "inProgress";
@@ -65,9 +76,8 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
     }
   }
 
-  setTaskGroupCompleted(taskGroupId: string) {
-    const completedField = `${taskGroupId}_completed`;
-    console.log(`Setting ${completedField} to true`);
-    return this.templateFieldService.setField(completedField, "true");
+  setTaskGroupCompleted(taskGroupCompletedField: string) {
+    console.log(`Setting ${taskGroupCompletedField} to true`);
+    return this.templateFieldService.setField(taskGroupCompletedField, "true");
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The task-card component should be passed the following parameters (in addition to `title`, `subtitle`, `image`, `style`, `in_progress_icon` and `completed_icon`):
- `task_group_id`: i.e. a `workshop_id`, e.g. `w_self_care`
- `task_group_data`: the data list that lists the constituent tasks of the task group e.g. `w_self_care_task_gs` (or just `w_self_care_tasks`?) 
- `completed_field`, the field that store whether this particular task group is complete, e.g. `w_self_care_completed`

Previously, just the `task_group_id` was passed, and the other 2 values were inferred from it. However this involved appending hardcoded suffixes within the code (`_task_gs` and `_completed`)

[module_card](https://docs.google.com/spreadsheets/d/1WGXQpDIzsS-FbDX_aLXJ4geT03Uqjdc4Fm4m2C2W2fY/edit#gid=1771109624) has been updated to reflect these changes

## Git Issues

Closes #

## Screenshots/Videos

[module_card](https://docs.google.com/spreadsheets/d/1WGXQpDIzsS-FbDX_aLXJ4geT03Uqjdc4Fm4m2C2W2fY/edit#gid=1771109624)
<img width="1000" alt="Screenshot 2022-10-27 at 10 55 41" src="https://user-images.githubusercontent.com/64838927/198254083-2ae5269e-5e01-40c6-beb7-aad52e9159b7.png">
