### PR TITLE
test: add data list parser tests

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_list.parser.spec.ts
@@ -1,3 +1,43 @@
+import { DataListParser } from ".";
+
+const testFlow = {
+  flow_type: "data_list",
+  flow_name: "test_data_list",
+  rows: [
+    {
+      id: "test_1",
+      test_notification_schedule: "key_1:value_1; key_2:value_2",
+      test_condition_list: "@fields.workshop_number == 1",
+      "nested.test_1": 1,
+      "nested.test_2": "two",
+    },
+  ],
+};
+
 describe("data_list Parser", () => {
-  it("TODO - add tests", () => expect(true).toEqual(true));
+  let outputRows: any[];
+  beforeAll(() => {
+    const parser = new DataListParser({ processedFlowHashmap: {} } as any);
+    const output = parser.run(testFlow as any);
+    outputRows = output.rows;
+  });
+  it("Extracts condition_list", async () => {
+    const { test_condition_list } = outputRows[0];
+    expect(test_condition_list).toEqual([
+      {
+        condition_type: "calc",
+        condition_args: { calc: "@fields.workshop_number == 1" },
+        _raw: "@fields.workshop_number == 1",
+      },
+    ]);
+  });
+  it("Extracts nested properties", async () => {
+    const { nested } = outputRows[0];
+    expect(nested).toEqual({ test_1: 1, test_2: "two" });
+  });
+  // TODO - likely deprecated (can't see in codebase)
+  it("Extracts notification_schedule", async () => {
+    const { test_notification_schedule } = outputRows[0];
+    expect(test_notification_schedule).toEqual({ key_1: "value_1", key_2: "value_2" });
+  });
 });


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Add spec tests for data_list specific code. These were drafted while debugging some other issues, so thought would be a good time to add (will still need to add future tests for template and default parsers)

## Review Notes
- The data_list parser extends the default parser, and so doesn't actually handle many extra features. It would be good to review the features it does handle and see if still relevant (not sure `notification_schedule` is used in any data_lists)

- Run the tests via `yarn workspace scripts test:watch`. Any single test can be run standalone by converting `it(...)` to `fit(...)`

## Git Issues

Closes #

## Screenshots/Videos
**Specific data_list capabilities added to test spec**
![image](https://user-images.githubusercontent.com/10515065/198420755-eeafc9c1-18c0-4e7c-83f7-5d2af76d2b79.png)
