### PR TITLE
feat: added 'button' style param to task-card

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -30,6 +30,17 @@
       </plh-template-component>
     </ng-container>
     <ng-container *ngIf="title">
+      <ng-container *ngIf="isButton">
+        <div class="button-content">
+          <plh-template-component
+            *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+            [row]="childRow"
+            [parent]="parent"
+            [attr.data-rowname]="_row.name"
+          >
+          </plh-template-component>
+        </div>
+      </ng-container>
       <div class="text-wrapper">
         <div *ngIf="title" class="title-wrapper">
           <h1>

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -36,7 +36,7 @@
   }
 
   &.button {
-    padding: 0px 8px 0px;
+    padding: 0px 8px 0px 12px;
     height: 56px;
     .content-wrapper {
       height: 100%;
@@ -44,13 +44,14 @@
       justify-content: flex-end;
       .image-wrapper {
         height: 36px;
-        width: 48px;
-        padding: 0px 4px;
+        width: 44px;
+        padding-left: 4px;
         img {
           height: 100%;
         }
       }
       .text-wrapper {
+        padding-left: 8px;
         h1 {
           padding: 0px;
           font-size: var(--font-size-subtitle-medium);

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -34,6 +34,36 @@
       }
     }
   }
+
+  &.button {
+    padding: 0px 8px 0px;
+    height: 56px;
+    .content-wrapper {
+      height: 100%;
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+      .image-wrapper {
+        height: 36px;
+        width: 48px;
+        padding: 0px 4px;
+        img {
+          height: 100%;
+        }
+      }
+      .text-wrapper {
+        h1 {
+          padding: 0px;
+          font-size: var(--font-size-subtitle-medium);
+          line-height: var(--line-height-text-small);
+        }
+      }
+      .button-content {
+        width: fit-content;
+        margin-left: auto;
+      }
+    }
+  }
+
   .content-wrapper {
     height: 100%;
     width: 100%;

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -35,9 +35,10 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
 
   ngOnInit() {
     this.getParams();
-    this.highlighted = this.taskGroupId
-      ? this.taskService.checkHighlightedTaskGroup(this.taskGroupId)
-      : false;
+    this.highlighted =
+      this.taskGroupId && !this.taskId
+        ? this.taskService.checkHighlightedTaskGroup(this.taskGroupId)
+        : false;
     this.checkProgressStatus();
   }
 

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -58,7 +58,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
 
   checkProgressStatus() {
     if (this.taskId) {
-      if (this.templateFieldService.getField(this.completedField))
+      if (this.completedField && this.templateFieldService.getField(this.completedField))
         this.progressStatus = "completed";
     }
   }

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -12,7 +12,6 @@ import { TemplateFieldService } from "../../services/template-field.service";
 })
 export class TmplTaskCardComponent extends TemplateBaseComponent implements OnInit {
   style: string;
-  orientation: "landscape" | "portrait";
   highlighted: boolean;
   highlightedText = "Active";
   progressStatus: IProgressStatus = "notStarted";
@@ -25,6 +24,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   image: string | null;
   completedIcon: string;
   inProgressIcon: string;
+  isButton: boolean;
 
   constructor(
     private taskService: TaskService,
@@ -50,6 +50,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
     this.subtitle = getStringParamFromTemplateRow(this._row, "subtitle", null);
     this.image = getStringParamFromTemplateRow(this._row, "image", null);
     this.style = getStringParamFromTemplateRow(this._row, "style", "landscape");
+    this.isButton = this.style.includes("button");
     this.completedIcon = getStringParamFromTemplateRow(this._row, "completed_icon", null);
     this.inProgressIcon = getStringParamFromTemplateRow(this._row, "in_progress_icon", null);
   }

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.scss
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.scss
@@ -68,16 +68,14 @@ ion-toggle {
   max-width: calc(50% - 45px);
 }
 
-.right .label {
-  order: 1;
-  text-align: left;
+.right {
+  flex-direction: row-reverse;
+  .label {
+    text-align: left;
+  }
 }
 
 .toggle_wrapper {
   align-self: baseline;
   margin-top: 5px;
-}
-
-.right .toggle_wrapper {
-  order: 2;
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds a new style parameter option to the `task-card` component: `style: button`. Makes the task card display as a narrow button with the image appearing small and on the right. A toggle can also be provided in the child rows of the component. This is visually equivalent to the existing `button` component with `style: card`, but, as outlined in Issue #1608, the `task-card` component supports displaying the completion status of its related task, e.g. a green tick.

## Git Issues

Closes #1608 

## Screenshots/Videos

[comp_task_card](http://localhost:4200/template/comp_task_card) updated with examples of new style.

<img width="1000" alt="Screenshot 2022-11-01 at 12 52 22" src="https://user-images.githubusercontent.com/64838927/199236471-0eec4735-e902-4345-a3a6-00401a32497d.png">

<img width="376" alt="Screenshot 2022-11-01 at 12 52 55" src="https://user-images.githubusercontent.com/64838927/199236559-6ecc802e-8d18-4077-9aab-78c6c3ca72b5.png">
