### PR TITLE
Fix: Task card components update to reflect changes in completion status

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -48,7 +48,7 @@
             [taskGroupCompletedField]="completedField"
             [highlighted]="highlighted"
             [(progressStatus)]="progressStatus"
-            (newlyCompleted)="hackHandleNewlyCompleted($event)"
+            (newlyCompleted)="handleNewlyCompleted($event)"
           ></plh-task-progress-bar>
         </div>
       </div>

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -48,6 +48,7 @@
             [taskGroupCompletedField]="completedField"
             [highlighted]="highlighted"
             [(progressStatus)]="progressStatus"
+            (newlyCompleted)="hackHandleNewlyCompleted($event)"
           ></plh-task-progress-bar>
         </div>
       </div>

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -61,24 +61,9 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
     }
   }
 
-  /**
-   * Hack to handle the case where the task_group has been completed:
-   * the whole page must be reprocessed for all task-cards on the page to update
-   * to reflect the new completed status
-   * */
-  hackHandleNewlyCompleted(isNewlyCompleted: boolean) {
+  handleNewlyCompleted(isNewlyCompleted: boolean) {
     if (isNewlyCompleted) {
-      this.parent.handleActions(
-        [
-          {
-            action_id: "emit",
-            args: ["force_reload"],
-            trigger: "completed",
-            _triggeredBy: this._row,
-          },
-        ],
-        this._row
-      );
+      this.triggerActions("completed");
     }
   }
 }

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -60,4 +60,25 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
         this.progressStatus = "completed";
     }
   }
+
+  /**
+   * Hack to handle the case where the task_group has been completed:
+   * the whole page must be reprocessed for all task-cards on the page to update
+   * to reflect the new completed status
+   * */
+  hackHandleNewlyCompleted(isNewlyCompleted: boolean) {
+    if (isNewlyCompleted) {
+      this.parent.handleActions(
+        [
+          {
+            action_id: "emit",
+            args: ["force_reload"],
+            trigger: "completed",
+            _triggeredBy: this._row,
+          },
+        ],
+        this._row
+      );
+    }
+  }
 }

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -17,6 +17,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   @Input() highlighted: boolean | null;
   @Input() progressStatus: IProgressStatus;
   @Output() progressStatusChange = new EventEmitter<IProgressStatus>();
+  @Output() newlyCompleted = new EventEmitter<boolean>();
   subtasksTotal: number;
   subtasksCompleted: number;
   showText = true;
@@ -64,6 +65,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
       if (this.templateFieldService.getField(this.taskGroupCompletedField) !== true) {
         // If not, set completed field to "true"
         await this.setTaskGroupCompletedStatus(this.taskGroupCompletedField, true);
+        this.newlyCompleted.emit(true);
       }
     } else {
       await this.setTaskGroupCompletedStatus(this.taskGroupCompletedField, false);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The task-card component now triggers the "completed" actions when all of its constituent actions are completed for the first time. 

This, in conjunction with adding `nav_resume | emit: force_reload` to pages that display task-cards for modules, allows us to fix the issue outlined in #1605. The task-cards for modules must also handle the `completed` actions at the template level, namely by triggering a `force_reload` when the component fires a "completed" trigger (`completed | emit: force_reload`).

## Git Issues

Closes #1605

## Screenshots/Videos
[home_screen_mod_reload_1](https://docs.google.com/spreadsheets/d/1Whi-zledVspIAd_hmAiItv2OxWnmtOVs8PEuCl0Eu8U/edit#gid=1677084943)
<img width="1000" alt="Screenshot 2022-11-01 at 14 36 15" src="https://user-images.githubusercontent.com/64838927/199259291-d7b05630-0c01-4e04-9cbc-1a1d0c84ba2a.png">


Example of completing a module, demonstrating the expected behaviour of marking that module as completed and marking the following module as "active". Using templates [home_screen_mod_reload_1](https://docs.google.com/spreadsheets/d/1Whi-zledVspIAd_hmAiItv2OxWnmtOVs8PEuCl0Eu8U/edit#gid=1677084943) and [module_card](https://docs.google.com/spreadsheets/d/1WGXQpDIzsS-FbDX_aLXJ4geT03Uqjdc4Fm4m2C2W2fY/edit#gid=1771109624) updated to include `completed | emit: force_reload` on the `task_card` component.

https://user-images.githubusercontent.com/64838927/199258194-9461589c-5fa0-4819-91a3-b444e67eac12.mov

