### PR TITLE
feat: add 'secondary' style to drawer component

### DIFF
--- a/src/app/shared/components/template/components/drawer/drawer.component.html
+++ b/src/app/shared/components/template/components/drawer/drawer.component.html
@@ -1,5 +1,5 @@
 <div class="bottom-spacer"></div>
-<div class="drawer" #drawer>
+<div [class]="'drawer ' + style" #drawer>
   <div class="handle" (click)="toggleDrawer()">
     <div class="handle-icon"></div>
     <p>{{ _row.value }}</p>

--- a/src/app/shared/components/template/components/drawer/drawer.component.scss
+++ b/src/app/shared/components/template/components/drawer/drawer.component.scss
@@ -22,10 +22,27 @@ $header-height: 56px;
   background-color: var(--ion-background-color);
   z-index: 100;
 
+  &.secondary {
+    background-color: var(--ion-color-secondary);
+    border: none;
+    .handle {
+      &:active {
+        background-color: var(--ion-color-secondary-600);
+      }
+      p {
+        color: white;
+      }
+      .handle-icon {
+        background-color: white;
+      }
+    }
+  }
+
   .handle {
     height: $handle-height;
     @include mixins.flex-centered;
     flex-direction: column;
+    border-radius: var(--ion-border-radius-standard) var(--ion-border-radius-standard) 0 0;
     p {
       text-align: center;
       font-weight: var(--font-weight-bold);

--- a/src/app/shared/components/template/components/drawer/drawer.component.ts
+++ b/src/app/shared/components/template/components/drawer/drawer.component.ts
@@ -1,4 +1,5 @@
-import { Component, ElementRef, ViewChild, AfterViewInit } from "@angular/core";
+import { Component, ElementRef, ViewChild, AfterViewInit, OnInit } from "@angular/core";
+import { getStringParamFromTemplateRow } from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 
 @Component({
@@ -6,17 +7,26 @@ import { TemplateBaseComponent } from "../base";
   templateUrl: "./drawer.component.html",
   styleUrls: ["./drawer.component.scss"],
 })
-export class TmplDrawerComponent extends TemplateBaseComponent implements AfterViewInit {
+export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit, AfterViewInit {
   @ViewChild("drawer", { read: ElementRef }) drawer: ElementRef;
 
   isOpen = false;
   openHeight = 0;
+  style: string;
+
+  ngOnInit() {
+    this.getParams();
+  }
 
   async ngAfterViewInit() {
     // Allow elements to render before initialising
     setTimeout(() => {
       this.init();
     }, 500);
+  }
+
+  getParams() {
+    this.style = getStringParamFromTemplateRow(this._row, "style", null);
   }
 
   toggleDrawer() {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds an optional `style` parameter to the `drawer` component. When `style` is set to `secondary`, the background colour of the drawer takes the secondary colour of the active theme.

Currently the text colour of the component with `style: secondary` is hardcoded as white, in order to match the designs of the modular skin (see issue #1604). 

## Git Issues

Closes #1604 

## Screenshots/Videos
From template [comp_drawer](https://docs.google.com/spreadsheets/d/1NY-FwPH7AZNlBoaS3Oi0E5j20ppdZwt0zbnqh72D1Tk/edit#gid=569531329)
<img width="979" alt="Screenshot 2022-11-01 at 15 56 55" src="https://user-images.githubusercontent.com/64838927/199278503-d8507adf-6921-4ce4-a80b-4fe65eddb335.png">

https://user-images.githubusercontent.com/64838927/199278347-b0028fff-88c0-4674-983f-4274b1f1a118.mov


