### PR TITLE
fix: drawer component always expands fully

### DIFF
--- a/src/app/shared/components/template/components/drawer/drawer.component.ts
+++ b/src/app/shared/components/template/components/drawer/drawer.component.ts
@@ -8,16 +8,10 @@ import { TemplateBaseComponent } from "../base";
   styleUrls: ["./drawer.component.scss"],
 })
 export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit {
-  @ViewChild("drawer", { read: ElementRef, static: false }) drawer: ElementRef;
+  @ViewChild("drawer") drawer: ElementRef;
 
   isOpen = false;
   style: string;
-
-  get openHeight() {
-    const drawer = this.drawer.nativeElement;
-    const handle = drawer.children[0];
-    return drawer.offsetHeight - handle.offsetHeight - 10;
-  }
 
   ngOnInit() {
     this.getParams();
@@ -35,8 +29,14 @@ export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit
       this.isOpen = false;
     } else {
       drawer.style.transition = "transform .3s ease-out";
-      drawer.style.transform = `translateY(${-this.openHeight}px)`;
+      drawer.style.transform = `translateY(${-this.getOpenHeight()}px)`;
       this.isOpen = true;
     }
+  }
+
+  private getOpenHeight() {
+    const drawer = this.drawer.nativeElement;
+    const handle = drawer.children[0];
+    return drawer.offsetHeight - handle.offsetHeight - 10;
   }
 }

--- a/src/app/shared/components/template/components/drawer/drawer.component.ts
+++ b/src/app/shared/components/template/components/drawer/drawer.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild, AfterViewInit, OnInit } from "@angular/core";
+import { Component, ElementRef, ViewChild, OnInit } from "@angular/core";
 import { getStringParamFromTemplateRow } from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 
@@ -7,22 +7,20 @@ import { TemplateBaseComponent } from "../base";
   templateUrl: "./drawer.component.html",
   styleUrls: ["./drawer.component.scss"],
 })
-export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit, AfterViewInit {
-  @ViewChild("drawer", { read: ElementRef }) drawer: ElementRef;
+export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit {
+  @ViewChild("drawer", { read: ElementRef, static: false }) drawer: ElementRef;
 
   isOpen = false;
-  openHeight = 0;
   style: string;
+
+  get openHeight() {
+    const drawer = this.drawer.nativeElement;
+    const handle = drawer.children[0];
+    return drawer.offsetHeight - handle.offsetHeight - 10;
+  }
 
   ngOnInit() {
     this.getParams();
-  }
-
-  async ngAfterViewInit() {
-    // Allow elements to render before initialising
-    setTimeout(() => {
-      this.init();
-    }, 500);
   }
 
   getParams() {
@@ -31,7 +29,6 @@ export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit
 
   toggleDrawer() {
     const drawer = this.drawer.nativeElement;
-
     if (this.isOpen) {
       drawer.style.transition = "transform .3s ease-out";
       drawer.style.transform = "";
@@ -41,11 +38,5 @@ export class TmplDrawerComponent extends TemplateBaseComponent implements OnInit
       drawer.style.transform = `translateY(${-this.openHeight}px)`;
       this.isOpen = true;
     }
-  }
-
-  init() {
-    const drawer = this.drawer.nativeElement;
-    const handle = drawer.children[0];
-    this.openHeight = drawer.offsetHeight - handle.offsetHeight - 10;
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes a bug whereby the drawer component would sometimes not fully open (Issue #1628).

This bug was due to the "open height" for the drawer being calculated on initialisation of the component, which would sometimes happen before the drawer element and its children had finished loading. This PR forces the open height to be recalculated each time the drawer is expanded, ensuring that the value is up to date with the DOM. This has the additional benefit of allowing for the drawer's contents to change dynamically between being opened, should this functionality be required.

## Git Issues

Closes #1628

## Screenshots/Videos

Demonstrating the drawer working as expected in the template [home_screen_modular](https://docs.google.com/spreadsheets/d/1Whi-zledVspIAd_hmAiItv2OxWnmtOVs8PEuCl0Eu8U/edit#gid=1771109624). As the bug was intermittent, this doesn't demonstrate that it is fixed, but it does show that the new method is functional.

https://user-images.githubusercontent.com/64838927/199494388-f65f90fe-341a-4526-9ecc-555d0ca13e82.mov



