### PR TITLE
feat: override strings in task-card from templates

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -58,6 +58,7 @@
             [taskGroupDataList]="taskGroupDataList"
             [taskGroupCompletedField]="completedField"
             [highlighted]="highlighted"
+            [subtasksText]="subtasksText"
             [(progressStatus)]="progressStatus"
             (newlyCompleted)="handleNewlyCompleted($event)"
           ></plh-task-progress-bar>

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -58,7 +58,7 @@
             [taskGroupDataList]="taskGroupDataList"
             [taskGroupCompletedField]="completedField"
             [highlighted]="highlighted"
-            [subtasksText]="subtasksText"
+            [progressUnitsName]="progressUnitsName"
             [(progressStatus)]="progressStatus"
             (newlyCompleted)="handleNewlyCompleted($event)"
           ></plh-task-progress-bar>

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -13,7 +13,8 @@ import { TemplateFieldService } from "../../services/template-field.service";
 export class TmplTaskCardComponent extends TemplateBaseComponent implements OnInit {
   style: string;
   highlighted: boolean;
-  highlightedText = "Active";
+  highlightedText: string;
+  subtasksText: string;
   progressStatus: IProgressStatus = "notStarted";
   taskGroupId: string | null;
   taskGroupDataList: string | null;
@@ -54,6 +55,8 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
     this.isButton = this.style.includes("button");
     this.completedIcon = getStringParamFromTemplateRow(this._row, "completed_icon", null);
     this.inProgressIcon = getStringParamFromTemplateRow(this._row, "in_progress_icon", null);
+    this.highlightedText = getStringParamFromTemplateRow(this._row, "highlighted_text", "Active");
+    this.subtasksText = getStringParamFromTemplateRow(this._row, "subtasks_text", "sections");
   }
 
   checkProgressStatus() {

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -14,7 +14,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   style: string;
   highlighted: boolean;
   highlightedText: string;
-  subtasksText: string;
+  progressUnitsName: string;
   progressStatus: IProgressStatus = "notStarted";
   taskGroupId: string | null;
   taskGroupDataList: string | null;
@@ -56,7 +56,11 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
     this.completedIcon = getStringParamFromTemplateRow(this._row, "completed_icon", null);
     this.inProgressIcon = getStringParamFromTemplateRow(this._row, "in_progress_icon", null);
     this.highlightedText = getStringParamFromTemplateRow(this._row, "highlighted_text", "Active");
-    this.subtasksText = getStringParamFromTemplateRow(this._row, "subtasks_text", "sections");
+    this.progressUnitsName = getStringParamFromTemplateRow(
+      this._row,
+      "progress_units_name",
+      "sections"
+    );
   }
 
   checkProgressStatus() {

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
@@ -1,5 +1,5 @@
 <div class="progress-bar-wrapper" [class.highlighted]="highlighted" [class]="progressStatus">
-  <p *ngIf="showText" class="tiny progress-text">{{ subtasksTotal + " " + sectionsName }}</p>
+  <p *ngIf="showText" class="tiny progress-text">{{ subtasksTotal + " " + subtasksText }}</p>
   <div class="progress-bar-background">
     <div class="progress-bar" [style.width]="progressPercentage + '%'"></div>
   </div>

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
@@ -1,5 +1,5 @@
 <div class="progress-bar-wrapper" [class.highlighted]="highlighted" [class]="progressStatus">
-  <p *ngIf="showText" class="tiny progress-text">{{ subtasksTotal + " " + subtasksText }}</p>
+  <p *ngIf="showText" class="tiny progress-text">{{ subtasksTotal + " " + progressUnitsName }}</p>
   <div class="progress-bar-background">
     <div class="progress-bar" [style.width]="progressPercentage + '%'"></div>
   </div>

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -16,12 +16,12 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   @Input() taskGroupCompletedField: string | null;
   @Input() highlighted: boolean | null;
   @Input() progressStatus: IProgressStatus;
+  @Input() subtasksText: string;
   @Output() progressStatusChange = new EventEmitter<IProgressStatus>();
   @Output() newlyCompleted = new EventEmitter<boolean>();
   subtasksTotal: number;
   subtasksCompleted: number;
   showText = true;
-  sectionsName = "sections";
 
   constructor(
     private taskService: TaskService,
@@ -44,6 +44,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
         "completed_field",
         null
       );
+      this.subtasksText = getStringParamFromTemplateRow(this._row, "subtasks_text", "sections");
     }
   }
 

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -16,7 +16,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   @Input() taskGroupCompletedField: string | null;
   @Input() highlighted: boolean | null;
   @Input() progressStatus: IProgressStatus;
-  @Input() subtasksText: string;
+  @Input() progressUnitsName: string;
   @Output() progressStatusChange = new EventEmitter<IProgressStatus>();
   @Output() newlyCompleted = new EventEmitter<boolean>();
   subtasksTotal: number;
@@ -44,7 +44,11 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
         "completed_field",
         null
       );
-      this.subtasksText = getStringParamFromTemplateRow(this._row, "subtasks_text", "sections");
+      this.progressUnitsName = getStringParamFromTemplateRow(
+        this._row,
+        "progress_units_name",
+        "sections"
+      );
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Adds 2 optional parameters to the `task_card` component: `highlighted_text` and `progress_units_name`. If provided, the values replace the strings that were previously hardcoded into the component: "Active" and "sections" respectively.

This enables these strings to be included in the translation system. These parameters should be specified, with the values "Active" and "sections", for all instances of the `task_card` component currently in the templates that display a task group (i.e. a workshop in our current usage), along with taking any other steps to ensure that the values of these parameters are included in the translation system. 

## Git Issues

Closes #

## Screenshots/Videos

Demonstration of custom values in [feature_task_card_params](https://docs.google.com/spreadsheets/d/1_RY8HbsATOAZU2EDXY5R9OOE_YBEbW0EjTP5zxYP2aA/edit#gid=1039832506)
<img width="377" alt="Screenshot 2022-11-02 at 14 01 56" src="https://user-images.githubusercontent.com/64838927/199511774-00ace286-0166-4f63-bf86-b878a09f219d.png">
