### PR TITLE
Fix: Handle theme asset folders when syncing from different deployments

### DIFF
--- a/packages/scripts/src/commands/app-data/copy.ts
+++ b/packages/scripts/src/commands/app-data/copy.ts
@@ -216,7 +216,9 @@ export const ASSETS_CONTENTS_LIST = ${JSON.stringify(cleanedContents, null, 2)}
       // language filter
       if (filterLanguages) {
         const [lang_folder] = fileEntry.relativePath.split("/");
-        if (!filterLanguages.includes(lang_folder)) return false;
+        // Theme asset folders live at the same level as language asset folders, so allow them to pass through filter
+        if (!(filterLanguages.includes(lang_folder) || isThemeAssetsFolderName(lang_folder)))
+          return false;
       }
       // global filter
       return assets_filter_function(fileEntry);

--- a/packages/scripts/src/commands/app-data/copy.ts
+++ b/packages/scripts/src/commands/app-data/copy.ts
@@ -14,6 +14,7 @@ import {
   logOutput,
   recursiveFindByExtension,
   replicateDir,
+  getThemeNameFromThemeAssetFolderName,
 } from "../../utils";
 import { spawnSync } from "child_process";
 
@@ -208,18 +209,20 @@ export const ASSETS_CONTENTS_LIST = ${JSON.stringify(cleanedContents, null, 2)}
     const assetFiles = readContentsFile(sourceFolder);
     const { assets_filter_function } = this.activeDeployment.app_data;
     const filterLanguages = this.activeDeployment.translations?.filter_language_codes;
+    const filterThemes = this.activeDeployment.app_config.APP_THEMES.available;
 
-    if (filterLanguages) {
-      filterLanguages.push("global");
-    }
     const filteredFiles = assetFiles.filter((fileEntry) => {
+      const [parent_folder] = fileEntry.relativePath.split("/");
       // language filter
-      if (filterLanguages) {
-        const [lang_folder] = fileEntry.relativePath.split("/");
-        // Theme asset folders live at the same level as language asset folders, so allow them to pass through filter
-        if (!(filterLanguages.includes(lang_folder) || isThemeAssetsFolderName(lang_folder)))
-          return false;
+      if (isCountryLanguageCode(parent_folder) && filterLanguages) {
+        if (!filterLanguages.includes(parent_folder)) return false;
       }
+      // theme filter
+      if (
+        isThemeAssetsFolderName(parent_folder) &&
+        !filterThemes.includes(getThemeNameFromThemeAssetFolderName(parent_folder))
+      )
+        return false;
       // global filter
       return assets_filter_function(fileEntry);
     });

--- a/packages/scripts/src/utils/string-utils.ts
+++ b/packages/scripts/src/utils/string-utils.ts
@@ -29,3 +29,11 @@ export function isCountryLanguageCode(str: string) {
 export function isThemeAssetsFolderName(str: string) {
   return str.startsWith("theme_");
 }
+
+/**
+ * For a given theme asset folder name, return the name of the respective theme.
+ * Expected format of the theme asset folder name is "theme_<theme_name>"
+ */
+export function getThemeNameFromThemeAssetFolderName(str: string) {
+  return str.replace("theme_", "");
+}


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Where an active deployment filtered for language codes (i.e. when it specified `filter_language_codes`), theme asset folders were not being included when syncing. E.g. in the case of the `plh_tz` deployment, the assets in the `theme_professional` folder were not being included when syncing assets, as outlined in #1622.

This PR ensures that theme asset folders are not automatically excluded when a deployment filters on language codes. Additionally, it applies a filter on the theme asset folders, excluding any assets that are in folders relating to themes that are not included in the list of `available` assets for that deployment. This allows for the case of sub-deployments (or deployments with the same gdrive `assets_folder_id`) with different "available" themes – the assets for themes that are not available will be excluded automatically. 

This is a product of theme asset folders and language asset folders currently living at the same level. Whilst we may want to address this at some point, these changes are a relatively quick win.

## Testing

In order to test that the assets are being synced correctly:
- Checkout master (or another clean branch)
- Set the deployment to `plh_tz`
- Run an assets sync (`yarn workflow sync_assets`)
- Among any other asset changes, you will see in Source Control that the `theme_professional` assets have been deleted
- Checkout this feature branch, `fix/deployment-assets`
- Stage your content changes
- Re-set the deployment to `plh_tz` (may not be necessary)
- Run an assets sync (`yarn workflow sync_assets`)
- You should see the content changes in Source Control, showing only the `theme_professional` assets re-populated
  <img width="300" alt="Screenshot 2022-11-03 at 13 12 53" src="https://user-images.githubusercontent.com/64838927/199730218-e23c9ed1-ca2e-400e-b2fb-55378c6cb175.png">

## Git Issues

Closes #1622 

## Screenshots/Videos

The blue box shows that the assets arepopulated from the expected folders for the `plh_tz` deployment
<img width="400" alt="Screenshot 2022-11-03 at 13 03 57" src="https://user-images.githubusercontent.com/64838927/199727799-16926384-56b0-435a-ac93-4219efc1bf1d.png">
