### PR TITLE
Style: Tweak display-group 'banner' colour in professional theme

### DIFF
--- a/src/theme/themes/professional.scss
+++ b/src/theme/themes/professional.scss
@@ -23,7 +23,7 @@
       tile-button-background-secondary-light: var(--ion-color-yellow),
       // audio-control-background: #1980d2,
       // points-item-background: #bce3fb,
-      display-group-background-banner-primary: var(--ion-color-primary-300),
+      display-group-background-banner-primary: var(--ion-color-primary-200),
       display-group-background-banner-secondary: var(--ion-color-secondary-300),
       // display-group-background-tool-1: #fa8e29,
       // display-group-background-tool-2: #ff7b00,


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Makes the colour of banners slightly lighter. This applies to instances of the `display_group` component with any of the following styles: `banner`, `banner_passive`, `banner_short` and `banner_welcome`.

See screenshots for visual changes.

## Git Issues

Closes #1532 

## Screenshots/Videos

Example of the changed colour in use. The colour suggested in #1532 sits somewhere between our `color-primary-200` and `color-primary-100` options, but the former looks closer to my eyes, so this is the one currently applied by this PR. It would be trivial to change it to any of our other `color-primary-<weight>` options if desired.
<img width="691" alt="Screenshot 2022-11-04 at 12 09 59" src="https://user-images.githubusercontent.com/64838927/199970510-a36fefdb-1921-4b8d-9f00-ed711c0fc2e2.png">

