### PR TITLE
fix: deployments without task groups do not error on initialisation

### DIFF
--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -11,8 +11,8 @@ export class TaskService {
   highlightedTaskFieldName = "_task_highlighted_group_id";
   taskGroupsListName = "workshop_tasks";
 
-  taskGroups: any[];
-  taskGroupsHashmap: Record<string, any>;
+  taskGroups: any[] = [];
+  taskGroupsHashmap: Record<string, any> = {};
   constructor(
     private templateFieldService: TemplateFieldService,
     private appDataService: AppDataService
@@ -20,7 +20,7 @@ export class TaskService {
 
   async init() {
     await this.getListOfTaskGroups();
-    if (this.taskGroups.length) {
+    if (this.taskGroups.length > 0) {
       this.evaluateHighlightedTaskGroup();
     }
   }

--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -7,7 +7,10 @@ import { arrayToHashmap } from "../../utils";
   providedIn: "root",
 })
 export class TaskService {
+  // TODO: These should be set from the deployment/skin level (ultimately should come from templates)
   highlightedTaskFieldName = "_task_highlighted_group_id";
+  taskGroupsListName = "workshop_tasks";
+
   taskGroups: any[];
   taskGroupsHashmap: Record<string, any>;
   constructor(
@@ -17,14 +20,17 @@ export class TaskService {
 
   async init() {
     await this.getListOfTaskGroups();
-    this.evaluateHighlightedTaskGroup();
+    if (this.taskGroups.length) {
+      this.evaluateHighlightedTaskGroup();
+    }
   }
 
   /** Get the list of highlight-able task groups, from the relevant data_list */
   private async getListOfTaskGroups() {
-    // TODO: This should be set from the template/skin level
-    const taskGroupsListName = "workshop_tasks";
-    const taskGroupsDataList = await this.appDataService.getSheet("data_list", taskGroupsListName);
+    const taskGroupsDataList = await this.appDataService.getSheet(
+      "data_list",
+      this.taskGroupsListName
+    );
     this.taskGroups = taskGroupsDataList?.rows || [];
     this.taskGroupsHashmap = arrayToHashmap(this.taskGroups, "id");
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

The task service was causing a breaking error for builds of deployments that did not make use of the task system. Specifically, the task service currently uses a hardcoded value, `workshop_tasks`, to look up the data list of task groups that can be highlighted. If this data list was not present for a given build, the app would error on initialising the core services.

This PR offers a workaround by not fully initialising the task service unless the `workshop_tasks` data list is found. There is further discussion to be had about the potential for generalising the "task" system in a way that makes sense across deployments.

## Git Issues

Closes #

## Screenshots/Videos

The bug as it previously presented:
<img width="945" alt="image-1" src="https://user-images.githubusercontent.com/64838927/200020149-75c04e60-13fb-449a-9117-141b03d10afe.png">

