### PR TITLE
fix: filter themes fix for deployments that don't specify available themes

### DIFF
--- a/packages/scripts/src/commands/app-data/copy.ts
+++ b/packages/scripts/src/commands/app-data/copy.ts
@@ -209,7 +209,7 @@ export const ASSETS_CONTENTS_LIST = ${JSON.stringify(cleanedContents, null, 2)}
     const assetFiles = readContentsFile(sourceFolder);
     const { assets_filter_function } = this.activeDeployment.app_data;
     const filterLanguages = this.activeDeployment.translations?.filter_language_codes;
-    const filterThemes = this.activeDeployment.app_config.APP_THEMES.available;
+    const filterThemes = this.activeDeployment.app_config?.APP_THEMES?.available;
 
     const filteredFiles = assetFiles.filter((fileEntry) => {
       const [parent_folder] = fileEntry.relativePath.split("/");


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Handle case in app-data copy script where a deployment does not specify any available themes

## Git Issues

Closes #

## Screenshots/Videos
