### PR TITLE
fix: add default app themes to copy spec

### DIFF
--- a/packages/scripts/src/commands/app-data/copy.spec.ts
+++ b/packages/scripts/src/commands/app-data/copy.spec.ts
@@ -100,16 +100,19 @@ function stubDeploymentConfig(
   stub: {
     filter_language_codes?: string[];
     assets_filter_function?: IAssetsFilterFunction;
+    app_themes_available?: string[];
   } = {}
 ) {
   const filter_language_codes = stub.filter_language_codes ?? [];
   const assets_filter_function = stub.assets_filter_function
     ? stub.assets_filter_function
     : () => true;
+  const app_themes_available = stub.app_themes_available ?? [];
 
   const stubDeployment: Partial<IDeploymentConfigJson> = {
     app_data: { assets_filter_function },
     translations: { filter_language_codes },
+    app_config: { APP_THEMES: { available: app_themes_available } },
   };
   spyOn(spyDeployment, "getActiveDeployment").and.returnValue(
     stubDeployment as IDeploymentConfigJson


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Spec tests for copy script were likely written before changes to theme support, and so fail on recent builds. Minor fix to provide default available themes for spec tests

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
