### PR TITLE
feat: add fade animation to sections

### DIFF
--- a/packages/app-data/sheets/template/pair.json
+++ b/packages/app-data/sheets/template/pair.json
@@ -20,7 +20,7 @@
     {
       "type": "animated_section",
       "name": "animated_section_1",
-      "condition": "@local.show_animated_section_1",
+      "hidden": "!@local.show_animated_section_1",
       "rows": [
         {
           "type": "template",
@@ -62,25 +62,25 @@
       ],
       "_nested_name": "animated_section_1",
       "_dynamicFields": {
-        "condition": [
+        "hidden": [
           {
-            "fullExpression": "@local.show_animated_section_1",
-            "matchedExpression": "@local.show_animated_section_1",
+            "fullExpression": "!@local.show_animated_section_1",
+            "matchedExpression": "!@local.show_animated_section_1",
             "type": "local",
             "fieldName": "show_animated_section_1"
           }
         ]
       },
       "_dynamicDependencies": {
-        "@local.show_animated_section_1": [
-          "condition"
+        "!@local.show_animated_section_1": [
+          "hidden"
         ]
       }
     },
     {
       "type": "animated_section",
       "name": "animated_section_2",
-      "condition": "@local.show_animated_section_2",
+      "hidden": "!@local.show_animated_section_2",
       "rows": [
         {
           "type": "template",
@@ -122,18 +122,18 @@
       ],
       "_nested_name": "animated_section_2",
       "_dynamicFields": {
-        "condition": [
+        "hidden": [
           {
-            "fullExpression": "@local.show_animated_section_2",
-            "matchedExpression": "@local.show_animated_section_2",
+            "fullExpression": "!@local.show_animated_section_2",
+            "matchedExpression": "!@local.show_animated_section_2",
             "type": "local",
             "fieldName": "show_animated_section_2"
           }
         ]
       },
       "_dynamicDependencies": {
-        "@local.show_animated_section_2": [
-          "condition"
+        "!@local.show_animated_section_2": [
+          "hidden"
         ]
       }
     }

--- a/src/app/shared/components/template/components/layout/animated-section.scss
+++ b/src/app/shared/components/template/components/layout/animated-section.scss
@@ -1,0 +1,6 @@
+:host {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}

--- a/src/app/shared/components/template/components/layout/animated_section.ts
+++ b/src/app/shared/components/template/components/layout/animated_section.ts
@@ -1,4 +1,5 @@
-import { Component, ElementRef, OnInit } from "@angular/core";
+import { animate, state, style, transition, trigger } from "@angular/animations";
+import { Component, OnInit } from "@angular/core";
 import { TemplateLayoutComponent } from "./layout";
 
 @Component({
@@ -8,18 +9,23 @@ import { TemplateLayoutComponent } from "./layout";
       *ngFor="let childRow of _row.rows; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
+      [@faseSection]="_row?.hidden ? 'out' : 'in'"
+      [attr.data-hidden]="false"
     ></plh-template-component>
   `,
-  styles: [
-    `
-      :host {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-      }
-    `,
+  animations: [
+    // HACK - rough copy of shared fadeInOut method
+    // Would work better if all sections grouped to apply transition across sections (support fade out as well as in)
+    trigger("faseSection", [
+      state("in", style({ opacity: 1 })),
+      state("out", style({ opacity: 0 })),
+      // when fading in include 1s delay for previous animations to complete
+      transition("* => in", [animate("1s ease-in-out")]),
+      // transition("in => out", [animate("0.3s ease-out")]),
+      // TODO - fade out not possible as parent block display set to hidden before time to watch
+    ]),
   ],
+  styleUrls: ["./animated-section.scss"],
 })
 export class AnimatedSectionComponent extends TemplateLayoutComponent implements OnInit {
   ngOnInit() {

--- a/src/app/shared/components/template/components/layout/animated_section.ts
+++ b/src/app/shared/components/template/components/layout/animated_section.ts
@@ -9,14 +9,13 @@ import { TemplateLayoutComponent } from "./layout";
       *ngFor="let childRow of _row.rows; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
-      [@faseSection]="_row?.hidden ? 'out' : 'in'"
-      [attr.data-hidden]="false"
+      [@fadeSection]="_row?.hidden ? 'out' : 'in'"
     ></plh-template-component>
   `,
   animations: [
     // HACK - rough copy of shared fadeInOut method
     // Would work better if all sections grouped to apply transition across sections (support fade out as well as in)
-    trigger("faseSection", [
+    trigger("fadeSection", [
       state("in", style({ opacity: 1 })),
       state("out", style({ opacity: 0 })),
       // when fading in include 1s delay for previous animations to complete


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
- Add fade animation for animated sections
- Includes authoring fix for #1356

## Review notes
To test issue in 1356 will need to run PR preview link in chrome 80 and go to `/template/w_stress_read_1_temp` - should be working whereas not working on something like the plh-global web app version
https://chromium.cypress.io/win64

Otherwise can view animated section fade by viewing any animated section content (including the link above). 
Note - the video below is a little bit more jerky than live version

## Git Issues

Closes #1356

## Screenshots/Videos

[Parenting App (3).webm](https://user-images.githubusercontent.com/10515065/204918575-d9fa807d-ab81-45e3-8e61-1c7bfaaac577.webm)