### PR TITLE
fix: add string matchAll polyfill

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -18,6 +18,9 @@
  * BROWSER POLYFILLS
  */
 
+/** Add support for String.prototype.matchAll in older browsers */
+import "core-js/es/string/match-all";
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
This fixes a bug for older devices that do not support the `matchAll` function (as noted in #1660)

Whilst this will fix the bug, for reasons noted in #1615 it isn't actually a very good solution, as there's enough other issues with older browsers that fixing this alone is unlikely to achieve very much. But it does at least give a good example for how we can add specific support in the future is similar issues arise

The final implementation is very minimal, so review more just for reference/interest

## Dev Notes
Support is added by including a link to the relevant polyfill in the polyfills.ts file. It uses the same polyfills that angular exposes in the `core-js` package (no install needed, part of angular deps). 

## Review Notes
This is particularly tricky to test as it involves running a legacy browser that does not support `matchAll` for strings, namely one from https://caniuse.com/mdn-javascript_builtins_string_matchall (e.g. chrome 72 or lower, internet explorer), add script to reference the matchAll function in the main app component (couldn't figure out what template would reference otherwise), and serving as a local production build.

These are the steps I took to test (repeat only if interested)
1. Download a legacy version of chrome. It has to be lower than chrome 72 which unfortunately discounts all version at https://chromium.cypress.io/ 

I actually cross-checked the user id that created the original crashlytics log with the webviewversion stored in the db (definitely overkill)
![image](https://user-images.githubusercontent.com/10515065/205199862-be542ed7-c8da-47f7-92c8-9d22989f3298.png)

The version retrieved from the user for google-chrome has to be mapped to a corresponding version for chromium. This can be done with https://omahaproxy.appspot.com/

![image](https://user-images.githubusercontent.com/10515065/205199784-ef8c64c8-fbc1-45f6-929d-6f1ead2dc9b3.png)

Finally that version number can be used to download the archive (or at least the version that closest matches). E.g. direct link for that chrome version: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Win_x64/520847/ 

(Did I mention this was all a bit overkill???)


2.  You will also need to add a short script to the main app component to call the string matchAll function, e.g. 
![image](https://user-images.githubusercontent.com/10515065/205198721-3b7e1516-5a96-45a1-bcb5-784258336478.png)

3. Create a new production build of the app (serving will not be supported in the older browser), i.e. `yarn build`

4. Serve the production build folder, e.g. `npx serve www`


## Git Issues

Closes #1660

## Screenshots/Videos

**Before polyfill**
![image](https://user-images.githubusercontent.com/10515065/205199678-feb3ff53-cc02-4589-9df8-50ddbe740186.png)

![image](https://user-images.githubusercontent.com/10515065/205198762-67f9f0c6-c342-4732-9aeb-fac34b5169ce.png)

**After polyfill**
![image](https://user-images.githubusercontent.com/10515065/205198787-60cbd17b-fd77-4029-8b3f-2945e09e560e.png)

