### PR TITLE
fix: hack: reschedule campaign notifications after processing startup templates

### DIFF
--- a/src/app/shared/components/template/services/instance/template-process.service.ts
+++ b/src/app/shared/components/template/services/instance/template-process.service.ts
@@ -6,6 +6,7 @@ import { SyncServiceBase } from "src/app/shared/services/syncService.base";
 import { TemplateContainerComponent } from "../../template-container.component";
 import { TemplateNavService } from "../template-nav.service";
 import { TemplateService } from "../template.service";
+import { CampaignService } from "src/app/feature/campaign/campaign.service";
 
 /**
  * The template process service is a slightly hacky wrapper around the template container component so that
@@ -34,6 +35,9 @@ export class TemplateProcessService extends SyncServiceBase {
   }
   private get appDataService() {
     return getGlobalService(this.injector, AppDataService);
+  }
+  private get campaignService() {
+    return getGlobalService(this.injector, CampaignService);
   }
 
   /** Ensure services are intialised before being called from public methods  */
@@ -82,5 +86,13 @@ export class TemplateProcessService extends SyncServiceBase {
       const templateCopy = JSON.parse(JSON.stringify(template));
       await this.processTemplateWithoutRender(templateCopy);
     }
+    this.hackReinitialiseCampaignService();
+  }
+
+  /** Campaign notifications may have changed based on startup templates,
+   * so reinitialise after processing to schedule up-to-date notifications
+   */
+  private hackReinitialiseCampaignService() {
+    setTimeout(() => this.campaignService.reInitialise(), 5000);
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

A workaround to fix issue #1640.

## Dev notes

This workaround handles the cyclic dependency between the `template-process-service` and the `campaign-service` by forcing the latter to reinitialise after the former has finished processing the startup templates. The performance load of reinitialising the campaign service should be significantly lower after #1673.

## Git Issues

Closes #1640

## Screenshots/Videos

New behaviour shown in video. See issue for previous behaviour.

https://user-images.githubusercontent.com/64838927/206680541-5a5261c0-1d8a-4f13-9ad9-a4ddace124cf.mov

