### PR TITLE
chore: add push to master branch trigger for sourcemaps-upload github action

### DIFF
--- a/.github/workflows/sourcemaps-upload.yml
+++ b/.github/workflows/sourcemaps-upload.yml
@@ -6,10 +6,7 @@
 
 # NOTE - currently only used for debugging as methods are integrated into build scripts
 name: Sourcemaps Upload
-on:
-  push:
-    branches:
-      - master
+on: workflow_dispatch
 jobs:
   sourcemaps_upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/sourcemaps-upload.yml
+++ b/.github/workflows/sourcemaps-upload.yml
@@ -6,10 +6,10 @@
 
 # NOTE - currently only used for debugging as methods are integrated into build scripts
 name: Sourcemaps Upload
-# on:
-  # push:
-  #   branches:
-  #     - feat/glitchtip-error-logs
+on:
+  push:
+    branches:
+      - master
 jobs:
   sourcemaps_upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Pushing any branch was causing the `sourcemap-upload` action to fail, as [here](https://github.com/IDEMSInternational/parenting-app-ui/actions/runs/3656503088), with the error `No event triggers defined in 'on'`.

This PR adds a trigger to the github action. I've assumed that we want the action to trigger on pushes to master, but I'm happy to be corrected.
