### PR TITLE
feat: add support for template action registry

### DIFF
--- a/src/app/feature/tour/tour.service.ts
+++ b/src/app/feature/tour/tour.service.ts
@@ -7,6 +7,7 @@ import { FlowTypes } from "data-models";
 import { TemplateFieldService } from "src/app/shared/components/template/services/template-field.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { AsyncServiceBase } from "src/app/shared/services/asyncService.base";
+import { TemplateActionRegistry } from "src/app/shared/components/template/services/instance/template-action.registry";
 
 @Injectable({
   providedIn: "root",
@@ -21,15 +22,22 @@ export class TourService extends AsyncServiceBase {
     private router: Router,
     private templateFieldService: TemplateFieldService,
     private translateService: TemplateTranslateService,
-    private appDataService: AppDataService
+    private appDataService: AppDataService,
+    private templateActionRegistry: TemplateActionRegistry
   ) {
     super("Tour");
     this.registerInitFunction(this.initialise);
+    this.registerTemplateActionHandlers();
   }
   private async initialise() {
     await this.ensureAsyncServicesReady([this.templateFieldService, this.translateService]);
     this.ensureSyncServicesReady([this.appDataService]);
     this.toursList = this.appDataService.listSheetsByType("tour");
+  }
+  private registerTemplateActionHandlers() {
+    this.templateActionRegistry.register({
+      start_tour: async (action) => this.startTour(action.args[0]),
+    });
   }
 
   /**

--- a/src/app/shared/components/template/services/instance/template-action.registry.spec.ts
+++ b/src/app/shared/components/template/services/instance/template-action.registry.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from "@angular/core/testing";
+
+import { TemplateActionRegistry } from "./template-action.registry";
+
+describe("TemplateActionRegistry", () => {
+  let registry: TemplateActionRegistry;
+
+  let fakeHandler: jasmine.Spy;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [],
+    });
+
+    registry = TestBed.inject(TemplateActionRegistry);
+    fakeHandler = jasmine.createSpy();
+    registry.register({
+      test_action_1: (args) => fakeHandler(args),
+      test_action_2: () => null,
+    } as any);
+  });
+
+  it("should create", () => {
+    expect(registry).toBeTruthy();
+  });
+
+  it("registers action handler", () => {
+    expect(registry.has("test_action_1" as any)).toBeTrue();
+    expect(registry.has("test_action_2" as any)).toBeTrue();
+  });
+
+  it("triggers action handlers", async () => {
+    const action = {
+      action_id: "test_action_1" as any,
+      args: [1, 2, 3],
+      trigger: "click" as any,
+    };
+    await registry.trigger(action);
+    expect(fakeHandler).toHaveBeenCalledOnceWith(action);
+  });
+
+  // QA
+  it("throws on duplicate registration", () => {
+    expect(() =>
+      registry.register({
+        test_action_1: () => null,
+      } as any)
+    ).toThrowError("Action handler already exists for trigger: test_action_1");
+  });
+
+  it("throws on missing action handler", () => {
+    const action = {
+      action_id: "missing_action" as any,
+      args: [],
+      trigger: "click" as any,
+    };
+    expect(() => registry.trigger(action)).toThrowError(
+      "No handler registered for action_id: missing_action"
+    );
+  });
+});

--- a/src/app/shared/components/template/services/instance/template-action.registry.ts
+++ b/src/app/shared/components/template/services/instance/template-action.registry.ts
@@ -8,9 +8,6 @@ type IHandlers = Record<IActionId, (action: FlowTypes.TemplateRowAction) => Prom
 /**
  * The template action registry goes alongside the default template action service
  * to allow external modules to register their own action handlers.
- *
- * TODO - Refactor all global handlers to use registry instead of direct import in service
- * NOTE - specific instance handlers will need to remain in service (e.g. set_local)
  */
 export class TemplateActionRegistry {
   private handlers: Partial<IHandlers> = {};

--- a/src/app/shared/components/template/services/instance/template-action.registry.ts
+++ b/src/app/shared/components/template/services/instance/template-action.registry.ts
@@ -1,0 +1,41 @@
+import { Injectable } from "@angular/core";
+import { FlowTypes } from "packages/data-models";
+
+type IActionId = FlowTypes.TemplateRowAction["action_id"];
+type IHandlers = Record<IActionId, (action: FlowTypes.TemplateRowAction) => Promise<any>>;
+
+@Injectable({ providedIn: "root" })
+/**
+ * The template action registry goes alongside the default template action service
+ * to allow external modules to register their own action handlers.
+ *
+ * TODO - Refactor all global handlers to use registry instead of direct import in service
+ * NOTE - specific instance handlers will need to remain in service (e.g. set_local)
+ */
+export class TemplateActionRegistry {
+  private handlers: Partial<IHandlers> = {};
+
+  /** Check if a handler has been registered for a specific action trigger */
+  public has(trigger: IActionId) {
+    return trigger in this.handlers;
+  }
+
+  public trigger(action: FlowTypes.TemplateRowAction) {
+    const { action_id } = action;
+    const handler = this.handlers[action_id];
+    if (!handler) {
+      throw new Error("No handler registered for action_id: " + action_id);
+    }
+    return handler(action);
+  }
+
+  public register(handlers: Partial<IHandlers> = {}) {
+    for (const [trigger, handler] of Object.entries(handlers)) {
+      if (trigger in this.handlers) {
+        throw new Error("Action handler already exists for trigger: " + trigger);
+      } else {
+        this.handlers[trigger] = handler;
+      }
+    }
+  }
+}

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -180,6 +180,9 @@ export class TemplateActionService extends SyncServiceBase {
       return this.templateActionRegistry.trigger(action);
     }
 
+    // Handle specific actions
+    // TODO - Refactor action handlers that call global services to use registry instead
+    // NOTE - instance-specific handlers will likely need to remain in service (e.g. set_local)
     switch (action_id) {
       case "reset_app":
         return this.settingsService.resetApp();

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -9,7 +9,6 @@ import { AnalyticsService } from "src/app/shared/services/analytics/analytics.se
 import { Injector } from "@angular/core";
 import { TemplateNavService } from "../template-nav.service";
 import { TemplateService } from "../template.service";
-import { TourService } from "src/app/feature/tour/tour.service";
 import { TemplateTranslateService } from "../template-translate.service";
 import { TemplateFieldService } from "../template-field.service";
 import { EventService } from "src/app/shared/services/event/event.service";
@@ -20,6 +19,7 @@ import { ThemeService } from "src/app/feature/theme/services/theme.service";
 import { TaskService } from "src/app/shared/services/task/task.service";
 import { getGlobalService } from "src/app/shared/services/global.service";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
+import { TemplateActionRegistry } from "./template-action.registry";
 
 /** Logging Toggle - rewrite default functions to enable or disable inline logs */
 let SHOW_DEBUG_LOGS = false;
@@ -54,9 +54,6 @@ export class TemplateActionService extends SyncServiceBase {
   private get templateService() {
     return getGlobalService(this.injector, TemplateService);
   }
-  private get tourService() {
-    return getGlobalService(this.injector, TourService);
-  }
   private get templateFieldService() {
     return getGlobalService(this.injector, TemplateFieldService);
   }
@@ -81,10 +78,13 @@ export class TemplateActionService extends SyncServiceBase {
   private get taskService() {
     return getGlobalService(this.injector, TaskService);
   }
+  private get templateActionRegistry() {
+    // HACK - as only service that does not extend sync/async base just return
+    return this.injector.get(TemplateActionRegistry);
+  }
 
   private async ensurePublicServicesReady() {
     await this.ensureAsyncServicesReady([
-      this.tourService,
       this.templateTranslateService,
       this.templateFieldService,
       this.dbSyncService,
@@ -175,6 +175,11 @@ export class TemplateActionService extends SyncServiceBase {
     });
     let [key, value] = args;
 
+    // Call any action registered with global handler
+    if (this.templateActionRegistry.has(action_id)) {
+      return this.templateActionRegistry.trigger(action);
+    }
+
     switch (action_id) {
       case "reset_app":
         return this.settingsService.resetApp();
@@ -207,8 +212,6 @@ export class TemplateActionService extends SyncServiceBase {
         const toggleValue = !currentValue;
         console.log("[SET FIELD]", key, toggleValue);
         return this.templateFieldService.setField(key, `${toggleValue}`);
-      case "start_tour":
-        return this.tourService.startTour(key);
       case "feedback": {
         const [subtopic, ...payload] = args;
         return this.eventService.publish({ topic: "FEEDBACK", subtopic, payload });


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Currently, any actions triggered from the template-action service need to first be registered from within the action service. This is somewhat an anti-pattern, as it means the action service needs to import every other service it will interact with (e.g. template, field, tour, analytics, theme etc.), and quickly leads to confusing dependency issues. To make matters more confusing, the action service is instantiated per template container, resulting in a large number of references to the same global services.

This PR tries to reverse this pattern by creating a separate template action registry which can be used to register action handlers from within the child service they originate from. This provides an alternative way to register actions without import into the action service. 

The main motivation for this is to allow easier decoupling/registration of specific dynamic data action handlers planned for use in #1698

## Dev Notes
You'll notice I've only started by refactoring the `start_tour` action out of the template-action service, but in the future could probably move around half of the action handlers to their own services (anything that calls global services can be refactored, but more work would be required for things like `set_local` as that makes use of the specific context of the instantiate template-action service, and so each template could try to intercept the wrong actions)

## Review Notes
As the only refactored action is `start_tour` simply checking that tours do start should suffice

Unit tests have been added and can be run via
```
yarn ng test --include="src\app\shared\components\template\services\instance" 
```

## Git Issues

Closes #

## Screenshots/Videos
**Unit Tests**
![image](https://user-images.githubusercontent.com/10515065/210496899-eae8317f-3b04-4bb1-8fc9-cf3522d0fec8.png)
