### PR TITLE
chore: configure angular to not share usage data

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -193,7 +193,8 @@
   },
   "cli": {
     "defaultCollection": "@ionic/angular-toolkit",
-    "packageManager": "yarn"
+    "packageManager": "yarn",
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Since we updated Angular to version 15 in PR #1694, when running `yarn start` I would receive a prompt asking whether to share anonymous usage data with the Angular Team.
<img width="700" alt="Screenshot 2023-01-04 at 10 05 53 copy" src="https://user-images.githubusercontent.com/64838927/210533676-6297458e-5784-4b8c-8681-b75b812bd85d.png">

This prompt would disappear without allowing time for a response, but not providing a response would prevent the `yarn start` processes from completing successfully.

This PR commits the changes enacted by responding `N` to the prompt, so it should not be triggered in future.

(Similar to this issue: https://stackoverflow.com/questions/56355499/stop-angular-cli-asking-for-collecting-analytics-when-i-use-ng-build)

## Testing

On a branch without this change (e.g. master), run `yarn start`. On my machine, the process does not complete: the terminal hangs on this message and the app is not be available on localhost
<img width="500" alt="Screenshot 2023-01-04 at 09 43 16" src="https://user-images.githubusercontent.com/64838927/210535909-eb7e929f-9ad9-437b-8b24-c7e13ebdda54.png">

Now checkout this feature branch and run `yarn start`. The app should be available on localhost as expected.

## Git Issues

Closes #

## Screenshots/Videos
