### PR TITLE
feat: add template components page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -53,6 +53,13 @@ const FeatureRoutes: Routes = [
       import("./feature/template/template.module").then((m) => m.TemplatePageModule),
     outlet: "sidebar",
   },
+  {
+    path: "component",
+    loadChildren: () =>
+      import("./feature/template/pages/component/component.module").then(
+        (m) => m.TemplateComponentModule
+      ),
+  },
 ];
 
 @NgModule({

--- a/src/app/feature/template/pages/component/component.module.ts
+++ b/src/app/feature/template/pages/component/component.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+
+import { IonicModule } from "@ionic/angular";
+
+import { TemplateComponentsModule } from "src/app/shared/components/template/template.module";
+import { ComponentPage } from "./component.page";
+import { RouterModule, Routes } from "@angular/router";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: ComponentPage,
+  },
+  {
+    path: ":componentName",
+    component: ComponentPage,
+  },
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    RouterModule.forChild(routes),
+    TemplateComponentsModule,
+  ],
+  exports: [RouterModule],
+  declarations: [ComponentPage],
+})
+export class TemplateComponentModule {}

--- a/src/app/feature/template/pages/component/component.page.html
+++ b/src/app/feature/template/pages/component/component.page.html
@@ -1,0 +1,19 @@
+<!-- Individual component page (not currently used) -->
+<ion-content *ngIf="selectedComponent else componentList">
+  <h2>{{selectedComponent}}</h2>
+</ion-content>
+
+<!-- All components list -->
+<ng-template #componentList>
+  <ion-content>
+    <ion-list>
+      <ion-item
+        *ngFor="let component of components"
+        [routerLink]="component.template"
+        [disabled]="!component.template"
+      >
+        <ion-label>{{component.name}}</ion-label>
+      </ion-item>
+    </ion-list>
+  </ion-content>
+</ng-template>

--- a/src/app/feature/template/pages/component/component.page.spec.ts
+++ b/src/app/feature/template/pages/component/component.page.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { IonicModule } from "@ionic/angular";
+
+import { ComponentPage } from "./component.page";
+
+describe("ComponentPage", () => {
+  let component: ComponentPage;
+  let fixture: ComponentFixture<ComponentPage>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ComponentPage],
+        imports: [IonicModule.forRoot()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ComponentPage);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/feature/template/pages/component/component.page.ts
+++ b/src/app/feature/template/pages/component/component.page.ts
@@ -1,0 +1,51 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { TEMPLATE_COMPONENT_MAPPING } from "src/app/shared/components/template/components";
+import { AppDataService } from "src/app/shared/services/data/app-data.service";
+
+interface ITemplateComponent {
+  name: string;
+  /** rendered component import (not currently displayed) */
+  component: any;
+  /** Component example template name */
+  template?: string;
+}
+
+@Component({
+  selector: "template-component-page",
+  templateUrl: "./component.page.html",
+  styleUrls: ["./component.page.scss"],
+})
+export class ComponentPage implements OnInit {
+  selectedComponent: ITemplateComponent;
+  components: ITemplateComponent[] = [];
+
+  constructor(private route: ActivatedRoute, private appDataService: AppDataService) {}
+
+  ngOnInit() {
+    this.selectedComponent = this.route.snapshot.params.componentName;
+    const componentTemplates = this.getComponentTemplates();
+    this.components = Object.entries(TEMPLATE_COMPONENT_MAPPING)
+      .filter(([_, component]) => component !== null)
+      .map(([name, component]) => ({ name, component, template: componentTemplates[name] }))
+      .sort((a, b) => (a.name > b.name ? 1 : -1));
+  }
+
+  setSelectedComponent(name: string) {
+    const selectedComponent = this.components.find((c) => c.name === name);
+    this.selectedComponent = selectedComponent;
+  }
+
+  /** List all local templates defined for components, prefixed `comp_` */
+  private getComponentTemplates() {
+    const componentTemplates: Record<string, string> = {};
+    const allTemplates = this.appDataService.listSheetsByType("template");
+    for (const template of allTemplates) {
+      if (template.flow_name.startsWith("comp_")) {
+        const componentName = template.flow_name.replace("comp_", "");
+        componentTemplates[componentName] = `/template/${template.flow_name}`;
+      }
+    }
+    return componentTemplates;
+  }
+}


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description

- Adds a page at `/component` where a list of all authored display components can be found, alongside any specific `comp_mycomponent_name` templates

## Git Issues

Closes #

## Screenshots/Videos

[Parenting App.webm](https://user-images.githubusercontent.com/10515065/210656622-90a7f1d7-ba53-4c10-93d0-d9ebe3d08846.webm)
