### PR TITLE
feat: first and last slides of carousel component are no longer centred by default

### DIFF
--- a/src/app/shared/components/template/components/carousel/carousel.component.html
+++ b/src/app/shared/components/template/components/carousel/carousel.component.html
@@ -1,4 +1,5 @@
 <div class="carousel-wrapper">
+  Config: {{ config | json }}
   <swiper (swiper)="handleSwiperInitialised($event)" [config]="config">
     <ng-template
       swiperSlide

--- a/src/app/shared/components/template/components/carousel/carousel.component.ts
+++ b/src/app/shared/components/template/components/carousel/carousel.component.ts
@@ -24,11 +24,11 @@ export class TmplCarouselComponent extends TemplateBaseComponent implements OnIn
   }
 
   async ngOnInit() {
-    await this.getParams();
+    this.getParams();
     await this.hackSetHighlightedTask();
   }
 
-  async getParams() {
+  getParams() {
     this.config.slidesPerView =
       getNumberParamFromTemplateRow(this._row, "slides_per_view", null) || "auto";
     this.config.spaceBetween = getNumberParamFromTemplateRow(this._row, "space_between", 10);
@@ -43,13 +43,24 @@ export class TmplCarouselComponent extends TemplateBaseComponent implements OnIn
       "centre_first_and_last",
       false
     );
-    this.initialSlide = getNumberParamFromTemplateRow(this._row, "initial_slide_index", 0);
+    this.config.initialSlide = getNumberParamFromTemplateRow(this._row, "initial_slide_index", 0);
   }
 
   /** Event emitter called when swiper initialised */
   public handleSwiperInitialised(swiper: Swiper) {
+    // setInterval(() => console.log("initial slide:", this.swiper.params.initialSlide), 10)
+    console.log("swiper initialised");
     this.swiper = swiper;
-    this.swiper.slideTo(this.initialSlide, 0, false);
+    this.swiper.slideTo(this.config.initialSlide, 0, false);
+    console.log("swiper params:", this.swiper.params);
+    console.log("active index:", this.swiper.activeIndex);
+    this.swiper.params.centeredSlidesBounds = true;
+    this.swiper.update();
+
+    setTimeout(() => {
+      console.log("hi");
+      this.swiper.slideTo(this.config.initialSlide, 0, false);
+    }, 1000);
   }
 
   /** When using carousel within task_group context set additional highlighted slide from task data */
@@ -58,10 +69,12 @@ export class TmplCarouselComponent extends TemplateBaseComponent implements OnIn
     if (taskGroupsList) {
       const highlightedTaskGroup = this.taskService.getHighlightedTaskGroup();
       if (highlightedTaskGroup) {
-        this.initialSlide = await this.taskService.getHighlightedTaskGroupIndex(
+        this.config.initialSlide = await this.taskService.getHighlightedTaskGroupIndex(
           highlightedTaskGroup,
           taskGroupsList
         );
+        // If the Swiper instance has already been intialised, update it
+        if (this.swiper) this.swiper.update();
       }
     }
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Following feedback from the designer, the carousel component now defaults to not centring the first and last slide (previously all slides would be centred, including first and last, leaving a large amount of negative space – see issue #1707).

This behaviour can be changed from an authoring level via a new component parameter, `centre_first_and_last`, i.e. by setting `centre_first_and_last: true`. This parameter only has an effect when the carousel slides are set to be centred in general – the default behaviour, which can be overridden by setting `centred_slides: false`.

The template [comp_carousel](https://docs.google.com/spreadsheets/d/1f_vq3KFGlExf1-g1PwPiDad9gOZkIOdRE5X99jCIRsM/edit#gid=569531329) has been updated to reflect these options.

## Git Issues

Closes #1707 

## Screenshots/Videos

The carousel as it appears in the app, showing the desired behaviour:

https://user-images.githubusercontent.com/64838927/212364834-0592d4a3-2423-43b3-858f-3b30a51fb14c.mov

Updated [comp_carousel](https://docs.google.com/spreadsheets/d/1f_vq3KFGlExf1-g1PwPiDad9gOZkIOdRE5X99jCIRsM/edit#gid=569531329)
<img width="376" alt="Screenshot 2023-01-13 at 16 04 21" src="https://user-images.githubusercontent.com/64838927/212365041-595b1073-fa14-482a-ba64-875af6ded21f.png">
