### PR TITLE
fix: items nested name

### DIFF
--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -93,9 +93,7 @@ export class TemplateVariablesService extends AsyncServiceBase {
         if (dynamicFields) {
           for (const k of Object.keys(data)) {
             value[k] = data[k];
-            // ignore evaluation of meta, comment, and specifiedfields. Could provide single list of approved fields, but as dynamic fields
-            // also can be found in parameter lists would likely prove too restrictive
-            if (!k.startsWith("_") && !omitFields.includes(k)) {
+            if (this.shouldEvaluateField(k as any, omitFields)) {
               // evalute each object element with reference to any dynamic specified for it's index (instead of fieldname)
               const nestedContext = { ...context };
               nestedContext.field = nestedContext.field ? `${nestedContext.field}.${k}` : k;
@@ -119,6 +117,18 @@ export class TemplateVariablesService extends AsyncServiceBase {
       }
     }
     return value;
+  }
+
+  /**
+   * Inore evaluation of meta, comment, and specifiedfields.
+   * Could provide single list of approved fields, but as dynamic fields also can be found in parameter lists
+   * would likely prove too restrictive
+   **/
+  private shouldEvaluateField(fieldName: keyof FlowTypes.TemplateRow, omitFields: string[] = []) {
+    if (omitFields.includes(fieldName)) return false;
+    if (fieldName === "_nested_name") return true;
+    if (fieldName.startsWith("_")) return false;
+    return true;
   }
 
   /** Evaluate a dynamic expression that has not been pre-processed or evaluated for dynamic expressions */


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

When updating a local value from within an items context the reference is not populated correctly as the `_nested_name` property is excluded from dynamic variable evaluation. The local variable is automatically set by any component that updates its own value (e.g. text_box or combo_box inputs), so all of these will break whenever more than 1 item is displayed on the page (both will have a nested_name like `@item.id.text_box`). 

This PR fixes to include _nested_name in the list of fields that get evaluated for dynamic references

## Git Issues

Closes #1720

## Screenshots/Videos

http://localhost:4200/template/debug_teen_ages

[Parenting App (4).webm](https://user-images.githubusercontent.com/10515065/213838520-d044ea37-8ad1-4ef4-9199-6b65713928b4.webm)

