### PR TITLE
Fix: styling of task-card with button style can handle longer strings of text

### DIFF
--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -36,8 +36,10 @@
   }
 
   &.button {
-    padding: 0px 8px 0px 12px;
-    height: 56px;
+    display: flex;
+    align-items: center;
+    padding: var(--small-padding);
+    min-height: 56px;
     .content-wrapper {
       height: 100%;
       flex-direction: row-reverse;

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -46,11 +46,13 @@
         height: 36px;
         width: 44px;
         padding-left: 4px;
+        flex-shrink: 0;
         img {
           height: 100%;
         }
       }
       .text-wrapper {
+        width: auto;
         padding-left: 8px;
         h1 {
           padding: 0px;

--- a/src/app/shared/components/template/components/task-card/task-card.component.scss
+++ b/src/app/shared/components/template/components/task-card/task-card.component.scss
@@ -55,7 +55,7 @@
       }
       .text-wrapper {
         width: auto;
-        padding-left: 8px;
+        padding: 6px 8px;
         h1 {
           padding: 0px;
           font-size: var(--font-size-subtitle-medium);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes a visual bug concerning the task-card component with the parameter `style: button`: longer strings of text would wrap prematurely and the button would not expand to fit in all text.

## Git Issues

Closes #1727 

## Screenshots/Videos

The template [comp_task_card](https://docs.google.com/spreadsheets/d/1_RY8HbsATOAZU2EDXY5R9OOE_YBEbW0EjTP5zxYP2aA/edit#gid=569531329), showing the new styling:
<img width="381" alt="Screenshot 2023-01-25 at 14 40 03" src="https://user-images.githubusercontent.com/64838927/214592911-77b3ee1f-5f16-40ef-a0bb-4c7d55c02219.png">

The "One-on-One Time" [module_details](https://docs.google.com/spreadsheets/d/1WGXQpDIzsS-FbDX_aLXJ4geT03Uqjdc4Fm4m2C2W2fY/edit#gid=1796638918) component, before and after comparison:
<img width="942" alt="Screenshot 2023-01-25 at 14 48 43" src="https://user-images.githubusercontent.com/64838927/214594846-c68575f3-0e35-407f-81c3-e773b0687971.png">
