### PR TITLE
fix: set deployment after config update bug

### DIFF
--- a/packages/scripts/src/commands/deployment/get.ts
+++ b/packages/scripts/src/commands/deployment/get.ts
@@ -81,7 +81,7 @@ export function getActiveDeployment(
 
 /** Run interactive command prompt to specify config */
 function promptConfigSet() {
-  const cmd = `yarn workspace scripts start deployment set`;
+  const cmd = `yarn workspace scripts start deployment set --workflow`;
   spawnSync(cmd, { stdio: "inherit", shell: true });
 }
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

I noticed a bug after #1756 was merged, whereby the CLI would enter an infinite loop – I believe this was when trying to set the deployment after the current deployment's config had been updated. See video below. This PR should fix this issue.

## Git Issues

Closes #

## Screenshots/Videos

https://user-images.githubusercontent.com/64838927/215776024-9f9837e8-b98c-4dca-9a91-bd6d8b3d68e1.mov
