### PR TITLE
fix: dynamic item nested names

### DIFF
--- a/packages/app-data/sheets/data_list/number_data.json
+++ b/packages/app-data/sheets/data_list/number_data.json
@@ -51,15 +51,6 @@
     {
       "id": 12,
       "teen_age": "teen_12_age"
-    },
-    {
-      "id": ""
-    },
-    {
-      "id": ""
-    },
-    {
-      "id": ""
     }
   ],
   "_xlsxPath": "global/data/workshop_data/workshop_data_list.xlsx"

--- a/packages/app-data/sheets/template/debug/debug_teen_ages.json
+++ b/packages/app-data/sheets/template/debug/debug_teen_ages.json
@@ -303,21 +303,21 @@
       "rows": [
         {
           "type": "display_group",
-          "name": "dg_sect_@item.id",
+          "name": "dg_sect_{@item.id}",
           "condition": "@item.id != 0 && @item.id <= @local.household_teens",
           "rows": [
             {
               "type": "text",
-              "name": "text_age_@item.id",
+              "name": "text_age_{@item.id}",
               "value": "Age of teen @item.id",
               "_translations": {
                 "value": {}
               },
-              "_nested_name": "items.dg_sect_@item.id.text_age_@item.id",
+              "_nested_name": "items.dg_sect_{@item.id}.text_age_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
-                    "fullExpression": "text_age_@item.id",
+                    "fullExpression": "text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -333,13 +333,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_@item.id.text_age_@item.id",
-                    "matchedExpression": "@item.id.text_age_",
+                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
+                    "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_@item.id.text_age_@item.id",
+                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -350,16 +350,14 @@
                 "@item.id": [
                   "name",
                   "value",
-                  "_nested_name"
-                ],
-                "@item.id.text_age_": [
+                  "_nested_name",
                   "_nested_name"
                 ]
               }
             },
             {
               "type": "text_box",
-              "name": "number_box_@item.id",
+              "name": "number_box_{@item.id}",
               "value": "@fields.@item.teen_age",
               "_translations": {
                 "value": {}
@@ -372,8 +370,8 @@
                     "@item.teen_age",
                     "this.value"
                   ],
-                  "_raw": "changed | set_field: @item.teen_age: this.value",
-                  "_cleaned": "changed | set_field: @item.teen_age: this.value"
+                  "_raw": "changed | set_field: @item.teen_age : this.value",
+                  "_cleaned": "changed | set_field: @item.teen_age : this.value"
                 }
               ],
               "parameter_list": {
@@ -381,11 +379,11 @@
                 "placeholder": "@global.tap_and_type",
                 "number_input": "true"
               },
-              "_nested_name": "items.dg_sect_@item.id.number_box_@item.id",
+              "_nested_name": "items.dg_sect_{@item.id}.number_box_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
-                    "fullExpression": "number_box_@item.id",
+                    "fullExpression": "number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -413,7 +411,7 @@
                     },
                     "_raw": [
                       {
-                        "fullExpression": "changed | set_field: @item.teen_age: this.value",
+                        "fullExpression": "changed | set_field: @item.teen_age : this.value",
                         "matchedExpression": "@item.teen_age",
                         "type": "item",
                         "fieldName": "teen_age"
@@ -421,7 +419,7 @@
                     ],
                     "_cleaned": [
                       {
-                        "fullExpression": "changed | set_field: @item.teen_age: this.value",
+                        "fullExpression": "changed | set_field: @item.teen_age : this.value",
                         "matchedExpression": "@item.teen_age",
                         "type": "item",
                         "fieldName": "teen_age"
@@ -441,13 +439,13 @@
                 },
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_@item.id.number_box_@item.id",
-                    "matchedExpression": "@item.id.number_box_",
+                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
+                    "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_@item.id.number_box_@item.id",
+                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -457,6 +455,7 @@
               "_dynamicDependencies": {
                 "@item.id": [
                   "name",
+                  "_nested_name",
                   "_nested_name"
                 ],
                 "@item.teen_age": [
@@ -467,18 +466,15 @@
                 ],
                 "@global.tap_and_type": [
                   "parameter_list.placeholder"
-                ],
-                "@item.id.number_box_": [
-                  "_nested_name"
                 ]
               }
             }
           ],
-          "_nested_name": "items.dg_sect_@item.id",
+          "_nested_name": "items.dg_sect_{@item.id}",
           "_dynamicFields": {
             "name": [
               {
-                "fullExpression": "dg_sect_@item.id",
+                "fullExpression": "dg_sect_{@item.id}",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -506,7 +502,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.dg_sect_@item.id",
+                "fullExpression": "items.dg_sect_{@item.id}",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"

--- a/packages/app-data/sheets/template/demographics_teen_age.json
+++ b/packages/app-data/sheets/template/demographics_teen_age.json
@@ -316,22 +316,22 @@
       "rows": [
         {
           "type": "display_group",
-          "name": "dg_sect_@item.id",
+          "name": "dg_sect_{@item.id}",
           "condition": "@item.id != 0 && @item.id <= @local.household_teens",
           "rows": [
             {
               "type": "text",
-              "name": "text_age_@item.id",
+              "name": "text_age_{@item.id}",
               "value": "@local.age_of_teen @item.id",
               "_translations": {
                 "value": {}
               },
               "exclude_from_translation": true,
-              "_nested_name": "items.dg_sect_@item.id.text_age_@item.id",
+              "_nested_name": "items.dg_sect_{@item.id}.text_age_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
-                    "fullExpression": "text_age_@item.id",
+                    "fullExpression": "text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -353,13 +353,13 @@
                 ],
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_@item.id.text_age_@item.id",
-                    "matchedExpression": "@item.id.text_age_",
+                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
+                    "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_@item.id.text_age_@item.id",
+                    "fullExpression": "items.dg_sect_{@item.id}.text_age_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -370,19 +370,17 @@
                 "@item.id": [
                   "name",
                   "value",
+                  "_nested_name",
                   "_nested_name"
                 ],
                 "@local.age_of_teen": [
                   "value"
-                ],
-                "@item.id.text_age_": [
-                  "_nested_name"
                 ]
               }
             },
             {
               "type": "text_box",
-              "name": "number_box_@item.id",
+              "name": "number_box_{@item.id}",
               "value": "@fields.@item.teen_age",
               "_translations": {
                 "value": {}
@@ -404,11 +402,11 @@
                 "placeholder": "@global.tap_and_type",
                 "number_input": "true"
               },
-              "_nested_name": "items.dg_sect_@item.id.number_box_@item.id",
+              "_nested_name": "items.dg_sect_{@item.id}.number_box_{@item.id}",
               "_dynamicFields": {
                 "name": [
                   {
-                    "fullExpression": "number_box_@item.id",
+                    "fullExpression": "number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -464,13 +462,13 @@
                 },
                 "_nested_name": [
                   {
-                    "fullExpression": "items.dg_sect_@item.id.number_box_@item.id",
-                    "matchedExpression": "@item.id.number_box_",
+                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
+                    "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
                   },
                   {
-                    "fullExpression": "items.dg_sect_@item.id.number_box_@item.id",
+                    "fullExpression": "items.dg_sect_{@item.id}.number_box_{@item.id}",
                     "matchedExpression": "@item.id",
                     "type": "item",
                     "fieldName": "id"
@@ -480,6 +478,7 @@
               "_dynamicDependencies": {
                 "@item.id": [
                   "name",
+                  "_nested_name",
                   "_nested_name"
                 ],
                 "@item.teen_age": [
@@ -490,18 +489,15 @@
                 ],
                 "@global.tap_and_type": [
                   "parameter_list.placeholder"
-                ],
-                "@item.id.number_box_": [
-                  "_nested_name"
                 ]
               }
             }
           ],
-          "_nested_name": "items.dg_sect_@item.id",
+          "_nested_name": "items.dg_sect_{@item.id}",
           "_dynamicFields": {
             "name": [
               {
-                "fullExpression": "dg_sect_@item.id",
+                "fullExpression": "dg_sect_{@item.id}",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"
@@ -529,7 +525,7 @@
             ],
             "_nested_name": [
               {
-                "fullExpression": "items.dg_sect_@item.id",
+                "fullExpression": "items.dg_sect_{@item.id}",
                 "matchedExpression": "@item.id",
                 "type": "item",
                 "fieldName": "id"

--- a/src/app/shared/components/template/processors/item.ts
+++ b/src/app/shared/components/template/processors/item.ts
@@ -1,5 +1,5 @@
 // TODO - shared package name conflicts with local shared
-import { AppStringEvaluator } from "packages/shared";
+import { AppStringEvaluator, TemplatedData } from "packages/shared";
 import { shuffleArray } from "src/app/shared/utils";
 import { FlowTypes } from "../models";
 import { objectToArray } from "../utils";
@@ -11,7 +11,8 @@ export class ItemProcessor {
     const data = objectToArray(this.dataList);
     const pipedData = this.pipeData(data, this.parameterList);
     const itemRows = this.generateLoopItemRows(templateRows, pipedData);
-    return itemRows;
+    const parsedItemRows = this.hackSetNestedName(itemRows);
+    return parsedItemRows;
   }
 
   private pipeData(data: any[], parameter_list: any) {
@@ -59,6 +60,25 @@ export class ItemProcessor {
       }
     }
     return rowWithEvalContext;
+  }
+
+  /**
+   * When working with items nested names cannot be parsed by regular parser,
+   * so use delimited syntax and parse via newer TemplatedData processor
+   * @see https://github.com/IDEMSInternational/parenting-app-ui/issues/1765
+   */
+  private hackSetNestedName(itemRows: FlowTypes.TemplateRow[]) {
+    const parsedRows = [];
+    for (const row of itemRows) {
+      const parser = new TemplatedData({ context: { item: row._evalContext.itemContext } });
+      const { rows, _nested_name } = row;
+      row._nested_name = parser.parse(_nested_name);
+      if (rows) {
+        row.rows = this.hackSetNestedName(rows);
+      }
+      parsedRows.push(row);
+    }
+    return parsedRows;
   }
 }
 

--- a/src/app/shared/components/template/services/instance/template-action.service.ts
+++ b/src/app/shared/components/template/services/instance/template-action.service.ts
@@ -162,8 +162,9 @@ export class TemplateActionService extends SyncServiceBase {
   private async processAction(action: FlowTypes.TemplateRowAction) {
     action.args = action.args.map((arg) => {
       // HACK - update any self referenced values (see note from template.parser method)
-      if (arg === "this.value") {
-        arg = this.container?.templateRowMap[action._triggeredBy?._nested_name]?.value;
+      if (typeof arg === "string" && arg.startsWith("this.")) {
+        const selfField = arg.split(".")[1];
+        arg = this.container?.templateRowMap[action._triggeredBy?._nested_name]?.[selfField];
       }
       return arg;
     });
@@ -348,7 +349,7 @@ export class TemplateActionService extends SyncServiceBase {
     );
     // no match found
     if (matchedRows.length === 0) {
-      console.error(`row [${name}] not found`, this.container.templateRowService.templateRowMap);
+      console.error(`row "${name}" not found`, this.container.templateRowService.templateRowMap);
       return null;
     }
     // match found - return least nested (in case of duplicates)

--- a/src/app/shared/components/template/services/template-variables.service.ts
+++ b/src/app/shared/components/template/services/template-variables.service.ts
@@ -126,7 +126,6 @@ export class TemplateVariablesService extends AsyncServiceBase {
    **/
   private shouldEvaluateField(fieldName: keyof FlowTypes.TemplateRow, omitFields: string[] = []) {
     if (omitFields.includes(fieldName)) return false;
-    if (fieldName === "_nested_name") return true;
     if (fieldName.startsWith("_")) return false;
     return true;
   }


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Setting and using values from nested items does not work due to inconsistencies in how the nested name is referenced. This PR aims to fix by providing moving the logic to evaluate nested names into the item generator itself (previously the main template parser), which also has improved support for delimited templates.

I've also updated the debug sheet to use the delimited item syntax, and the data list to remove some empty rows (not problematic but side-effect of testing lots of different things)

## Git Issues

Closes #1765

## Screenshots/Videos

[Untitled_ Jan 31, 2023 11_09 PM.webm](https://user-images.githubusercontent.com/10515065/215975262-14baabe8-7069-40d7-aa80-dfa6c29e9859.webm)

