### PR TITLE
feat: add seo service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -34,6 +34,7 @@ import { IAppConfig } from "./shared/model";
 import { TaskService } from "./shared/services/task/task.service";
 import { AsyncServiceBase } from "./shared/services/asyncService.base";
 import { SyncServiceBase } from "./shared/services/syncService.base";
+import { SeoService } from "./shared/services/seo/seo.service";
 
 @Component({
   selector: "app-root",
@@ -79,6 +80,7 @@ export class AppComponent {
     private crashlyticsService: CrashlyticsService,
     private appDataService: AppDataService,
     private authService: AuthService,
+    private seoService: SeoService,
     private taskService: TaskService,
     /** Inject in the main app component to start tracking actions immediately */
     private taskActions: TaskActionService,
@@ -197,6 +199,7 @@ export class AppComponent {
         this.appDataService,
         this.authService,
         this.serverService,
+        this.seoService,
       ],
       deferred: [this.analyticsService],
       implicit: [

--- a/src/app/shared/services/seo/seo.service.spec.ts
+++ b/src/app/shared/services/seo/seo.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { SeoService } from "./seo.service";
+
+describe("SeoService", () => {
+  let service: SeoService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SeoService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -23,9 +23,8 @@ type IMetaName =
 export class SeoService extends SyncServiceBase {
   constructor() {
     super("SEO Service");
-    this.updateMeta({
-      title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
-    });
+    // call after init to apply defaults
+    this.updateMeta({});
   }
 
   /**
@@ -65,7 +64,7 @@ export class SeoService extends SyncServiceBase {
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
     return {
-      title: "",
+      title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
       description: "",
       faviconUrl: `${PUBLIC_URL}/assets/icon/favicon.png`,
       imageUrl: ``,

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -9,8 +9,8 @@ interface ISEOMeta {
   imageUrl: string;
 }
 /** Reduced list of meta properties used within site index.html for update */
-type IPlatformMetaProperty = "og:title" | "og:image" | "og:description" | "og:url";
-type IPlatformMetaName =
+type IMetaProperty = "og:title" | "og:image" | "og:description" | "og:url";
+type IMetaName =
   | "description"
   | "twitter:title"
   | "twitter:description"
@@ -23,7 +23,9 @@ type IPlatformMetaName =
 export class SeoService extends SyncServiceBase {
   constructor() {
     super("SEO Service");
-    this.updateMeta({ title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title });
+    this.updateMeta({
+      title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
+    });
   }
 
   /**
@@ -58,27 +60,25 @@ export class SeoService extends SyncServiceBase {
   };
 
   /**
-   * Load the default SEO tags for the site (as currently hardcoded into the public index.html file)
-   * TODO - it would be better if these were linked to the active site/deployment/theme in some way
+   * Load the default SEO tags for the site as currently hardcoded into the public index.html file
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
     return {
-      title: "Community Platform",
-      description:
-        "A series of tools for the Precious Plastic community to collaborate around the world. Connect, share and meet each other to tackle plastic waste.",
-      faviconUrl: `${PUBLIC_URL}/favicon.ico`,
-      imageUrl: `${PUBLIC_URL}/social-image.jpg`,
+      title: "",
+      description: "",
+      faviconUrl: `${PUBLIC_URL}/assets/icon/favicon.png`,
+      imageUrl: ``,
     };
   }
 
-  private setMetaName(name: IPlatformMetaName, value: string) {
+  private setMetaName(name: IMetaName, value: string) {
     const el = document.querySelector(`meta[name="${name}"]`);
     if (el) {
       el.setAttribute("content", value);
     }
   }
-  private setMetaProperty(property: IPlatformMetaProperty, value: string) {
+  private setMetaProperty(property: IMetaProperty, value: string) {
     const el = document.querySelector(`meta[property="${property}"]`);
     if (el) {
       el.setAttribute("content", value);

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from "@angular/core";
+import { environment } from "src/environments/environment";
+import { SyncServiceBase } from "../syncService.base";
+
+interface ISEOMeta {
+  title: string;
+  faviconUrl: string;
+  description: string;
+  imageUrl: string;
+}
+/** Reduced list of meta properties used within site index.html for update */
+type IPlatformMetaProperty = "og:title" | "og:image" | "og:description" | "og:url";
+type IPlatformMetaName =
+  | "description"
+  | "twitter:title"
+  | "twitter:description"
+  | "twitter:image"
+  | "twitter:card";
+
+@Injectable({
+  providedIn: "root",
+})
+export class SeoService extends SyncServiceBase {
+  constructor() {
+    super("SEO Service");
+    this.updateMeta({ title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title });
+  }
+
+  /**
+   * Update document SEO tags
+   *
+   * NOTE - this only updates tags that already appear in the public index.html file and does not
+   * add additional
+   */
+  public updateMeta = (update: Partial<ISEOMeta>) => {
+    const allTags = { ...this.getDefaultSEOTags(), ...update };
+    const { title, description, imageUrl, faviconUrl } = allTags;
+    if (title) {
+      document.title = title;
+      this.setMetaProperty("og:title", title);
+      this.setMetaName("twitter:title", title);
+    }
+    if (description) {
+      this.setMetaName("description", description);
+      this.setMetaProperty("og:description", description);
+      this.setMetaName("twitter:description", description);
+    }
+    if (faviconUrl) {
+      const el = document.getElementById("favicon") as HTMLLinkElement;
+      if (el) {
+        el.href = faviconUrl;
+      }
+    }
+    if (imageUrl) {
+      this.setMetaName("twitter:image", imageUrl);
+      this.setMetaProperty("og:image", imageUrl);
+    }
+  };
+
+  /**
+   * Load the default SEO tags for the site (as currently hardcoded into the public index.html file)
+   * TODO - it would be better if these were linked to the active site/deployment/theme in some way
+   */
+  private getDefaultSEOTags(): ISEOMeta {
+    const PUBLIC_URL = location.origin;
+    return {
+      title: "Community Platform",
+      description:
+        "A series of tools for the Precious Plastic community to collaborate around the world. Connect, share and meet each other to tackle plastic waste.",
+      faviconUrl: `${PUBLIC_URL}/favicon.ico`,
+      imageUrl: `${PUBLIC_URL}/social-image.jpg`,
+    };
+  }
+
+  private setMetaName(name: IPlatformMetaName, value: string) {
+    const el = document.querySelector(`meta[name="${name}"]`);
+    if (el) {
+      el.setAttribute("content", value);
+    }
+  }
+  private setMetaProperty(property: IPlatformMetaProperty, value: string) {
+    const el = document.querySelector(`meta[property="${property}"]`);
+    if (el) {
+      el.setAttribute("content", value);
+    }
+  }
+}

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -59,7 +59,8 @@ export class SeoService extends SyncServiceBase {
   };
 
   /**
-   * Load the default SEO tags for the site as currently hardcoded into the public index.html file
+   * Load the default SEO tags for the site as currently hardcoded into the
+   * public index.html file or specified in deployment
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;

--- a/src/index.html
+++ b/src/index.html
@@ -12,14 +12,13 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="icon" type="image/png" href="assets/icon/favicon.png" />
-
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
     <!-- SEO -->
     <title></title>
+    <link rel="icon" id="favicon" type="image/png" href="assets/icon/favicon.png" />
     <meta name="description" content="" />
     <meta property="og:title" content="" />
     <meta property="og:description" content="" />

--- a/src/index.html
+++ b/src/index.html
@@ -2,8 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Parenting App</title>
-
     <base href="/" />
 
     <meta name="color-scheme" content="light dark" />
@@ -19,6 +17,18 @@
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+
+    <!-- SEO -->
+    <title></title>
+    <meta name="description" content="" />
+    <meta property="og:title" content="" />
+    <meta property="og:description" content="" />
+    <meta property="og:image" content="" />
+    <meta property="og:url" content="" />
+    <meta name="twitter:title" content="" />
+    <meta name="twitter:description" content="" />
+    <meta name="twitter:image" content="" />
+    <meta name="twitter:card" content="" />
   </head>
 
   <body>


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add a service to handle update of any SEO metadata
- Add placeholders for future SEO properties
- Remove default `title` from main page HTML ("Parenting App" for all deployments)
- Set page title from deployment

## Review Notes
The only property being set is the document title, which is what the browser tab uses for a name. So can just test that on a couple different deployments (should be same as app header title)

## Author Notes
I expect we will also want to include an authoring option to change the icon that appears in the browser bar, this would be best as a follow-up issue as we will likely need to update the deployments a little so better after #1763 sorted.
We may also want to provide best-practice info for authors, e.g.
https://www.emergeinteractive.com/insights/detail/the-essentials-of-favicons/ 
(tl;dr - a square svg should work fine in most browsers, or otherwise a square png up to 192x192)

## Dev Notes
I've also included additional SEO metadata fields for opengraph (facebook) and twitter as these are the most commonly used. If we decide in the future that we want web deployments to be more SEO friendly we could think of strategies of how these might get updated as we navigate different templates, so for now they are really just a placeholder. Examples of the tags in action can be seen at https://metatags.io 

Additionally depending on the service retrieving the data there is a good chance the bot will not wait long enough for the full spa to load and populate the tags from the SEO service, so in those cases we would want to use a service like https://prerender.io to add an intermediate caching layer between bots and web deployment

## Git Issues

Closes #

## Screenshots/Videos
**ParentApp populates title (tab name) from deployment config**
![image](https://user-images.githubusercontent.com/10515065/216478097-142a6270-fa24-46f3-80c8-2d916ef0adcd.png)

**Early Family Math deployment sets a different title**
![image](https://user-images.githubusercontent.com/10515065/216479332-5fc294f8-a617-4c30-b496-4699ee1332e1.png)

