### PR TITLE
feat: add docs spellcheck lint and action

### DIFF
--- a/.github/workflows/documentation-lint.yml
+++ b/.github/workflows/documentation-lint.yml
@@ -1,4 +1,4 @@
-name: Documentation - Deploy to GitHub Pages
+name: Docs Spellcheck
 on:
   pull_request:
     branches:
@@ -9,7 +9,7 @@ on:
       - "documentation/**"
 jobs:
   build:
-    name: Lint Docs
+    name: Spellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
@@ -20,5 +20,5 @@ jobs:
           node-version: 16
           cache: 'yarn'      
       - run: yarn install --immutable
-      - name: Lint
+      - name: Spellcheck
         run: yarn lint:docs

--- a/.github/workflows/documentation-lint.yml
+++ b/.github/workflows/documentation-lint.yml
@@ -1,0 +1,24 @@
+name: Documentation - Deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - master
+    # Only run action if changes have been made
+    # to the documentation or components packages
+    paths:
+      - "documentation/**"
+jobs:
+  build:
+    name: Lint Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'      
+      - run: yarn install --immutable
+      - name: Lint
+        run: yarn lint:docs

--- a/.github/workflows/documentation-lint.yml
+++ b/.github/workflows/documentation-lint.yml
@@ -1,6 +1,6 @@
 name: Documentation - Deploy to GitHub Pages
 on:
-  push:
+  pull_request:
     branches:
       - master
     # Only run action if changes have been made

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -1,0 +1,31 @@
+# cSpell Settings
+
+# Version of the setting file.  Always 0.2
+"version": "0.2"
+# language - current active spelling language
+"language": "en-gb"
+
+# words - list of words to be always considered correct
+"words":
+  [
+    "idems",
+    "quickstart",
+    "glitchtip",
+    "mkdocs",
+    "venv",
+    "linenums",
+    "sourcemaps",
+    "ionicons",
+    "nocheck",
+    "sidemenu",
+    "templatename",
+    "fontawesome",
+    "gdrive",
+    "lottie",
+  ]
+# flagWords - list of words to be always considered incorrect
+# This is useful for offensive words and common spelling errors.
+# For example "hte" should be "the"
+"flagWords": ["hte"]
+
+"ignorePaths": ["node_modules/**"]

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -22,6 +22,7 @@
     "fontawesome",
     "gdrive",
     "lottie",
+    "overidden",
   ]
 # flagWords - list of words to be always considered incorrect
 # This is useful for offensive words and common spelling errors.

--- a/documentation/docs/authors/feedback.md
+++ b/documentation/docs/authors/feedback.md
@@ -98,7 +98,7 @@ Alongside user-specified data various metadata will be added. See example output
             }
         ],
         "timestamp": "2022-01-07T18:49:53",
-        "uuid": "temp_auqm0orppvg"
+        "uuid": "my_user_id"
     },
     
 }

--- a/documentation/docs/authors/notifications.md
+++ b/documentation/docs/authors/notifications.md
@@ -22,10 +22,10 @@ Here is an example of two rows added to a `==content_list==` for creating notifi
 | schedule.start_date           | Date of earliest notification. If in past will be ignored |
 | schedule.end_date             | Date of latest notification. If in past will be ignored |
 | schedule.day_of_week          | Send notifications weekly on a given day of the week (numbered from 1 - Monday, to 7 - Sunday) |
-| schedule.batch_size           | Maximum number of notifications to schedule, e.g. if scheduling weekly specify number of weeks to preschedule |
-| time.hour                     | Hour of day to send notificaitons on, in 24h format       |
+| schedule.batch_size           | Maximum number of notifications to schedule, e.g. if scheduling weekly specify number of weeks to pre-schedule |
+| time.hour                     | Hour of day to send notifications on, in 24h format       |
 | time.minute                   | Minute of day to send notification on |
-| delay.days                    | Offset to schedule notfication a given number of days from today |
+| delay.days                    | Offset to schedule notification a given number of days from today |
 
 The default settings for notifications will schedule a daily at 12pm. These settings are defined in the `NOTIFICATION_DEFAULTS` variable.
 
@@ -39,7 +39,7 @@ The default settings for notifications will schedule a daily at 12pm. These sett
 | priority           | Number given to specify which notification should take priority when multiple active (highest priority sent sent) |
 | campaign_list             | List of campaign schedules to include notifications in |
 | text          | Send notifications weekly on a given day of the week (numbered from 1 - Monday, to 7 - Sunday) |
-| title                     | Hour of day to send notificaitons on, in 24h format       |
+| title                     | Hour of day to send notifications on, in 24h format       |
 
 ## Advanced Topics
 
@@ -58,9 +58,9 @@ Clicking the notification icon in the top-right will lead to another `/notificat
 
 
 ### Scheduling Frequency
-Notifications are automatatically evaluated and scheduled on app start
+Notifications are automatically evaluated and scheduled on app start
 
 !!! warning
-    When the app is not in active use sync timers pause and so no new notifications will be evaulated. That means that if the user closes the app 
+    When the app is not in active use sync timers pause and so no new notifications will be evaluated. That means that if the user closes the app 
 
 There is currently no workaround for this unfortunately except for reducing the re-schedule sync timer, however if this is required than it is suggested to [create an issue](https://github.com/IDEMSInternational/parenting-app-ui/issues/new/choose) for the feature (likely best handled by a trigger that can be called from authoring).

--- a/documentation/docs/authors/quickstart.md
+++ b/documentation/docs/authors/quickstart.md
@@ -14,9 +14,9 @@ yarn install
 
 ### Setup required configuration
 
-All configuration is pre-established in the `packages/scripts/config` folder, however is encrypted to avoid sharing sensitive information publically.
+All configuration is pre-established in the `packages/scripts/config` folder, however is encrypted to avoid sharing sensitive information publicly.
 
-You must optain a `private.key` file from the development team which you can copy into the `packages/scripts/config` folder.
+You must obtain a `private.key` file from the development team which you can copy into the `packages/scripts/config` folder.
 
 Once the file is copied run the following command:
 

--- a/documentation/docs/authors/template-component-parameter-list.md
+++ b/documentation/docs/authors/template-component-parameter-list.md
@@ -232,7 +232,7 @@ value_1: '' - (default)
 Parameter Name: reverse
 ##### Values and descriptions
 value_1: false - (default) 
-description: default postion - (checkbox label).
+description: default position - (checkbox label).
 value_1: true
 description: reversed - (label checkbox).
 
@@ -572,7 +572,7 @@ description: Name of class
 value_1: default - (default) 
 description: Primary text and border color
 value_2: alert 
-description: Text color white and secodary border color
+description: Text color white and secondary border color
 
 ## Title - TmplTitleComponent 
 ### Type 
@@ -610,11 +610,11 @@ description: Tiny font size (--font-size-title-tiny)
 value_2: standard 
 description: Primary color (--ion-color-primary)
 value_3: center
-description: Postition center
+description: Position center
 value_4: left - (default)
-description: Postition left
+description: Position left
 value_5: right 
-description: Postition right
+description: Position right
 value_6: alternative 
 description: White text color
 value_7: contextual 
@@ -634,17 +634,17 @@ Parameter Name: style
 value_1: standard - (default)
 description: Primary color (--ion-color-primary)
 value_2: medium - (default)
-description: Medium forn size (--font-size-subtitle-medium)
+description: Medium font size (--font-size-subtitle-medium)
 value_3: small 
 description: Small font size (--font-size-subtitle-small)
 value_4: large 
 description: Large font size (--font-size-subtitle-large)
 value_5: center
-description: Postition center
+description: Position center
 value_6: left
-description: Postition left
+description: Position left
 value_7: right 
-description: Postition right
+description: Position right
 value_8: alternative 
 description: White text color
 value_9: contextual 
@@ -664,17 +664,17 @@ Parameter Name: style
 value_1: standard - (default)
 description: Primary color (--ion-color-primary)
 value_2: medium
-description: Medium forn size (--font-size-text-medium)
+description: Medium font size (--font-size-text-medium)
 value_3: large - (default)
 description: large font size (--font-size-text-small)
 value_4: small 
 description: small font size (--font-size-text-large)
 value_5: center
-description: Postition center
+description: Position center
 value_6: left
-description: Postition left
+description: Position left
 value_7: right 
-description: Postition right
+description: Position right
 value_8: alternative 
 description: White text color
 value_9: contextual 
@@ -880,9 +880,9 @@ description: go_to value_2 after click form button
 Parameter Name: get_device_info
 ##### Values and descriptions
 value_1: false - (default) 
-description: Submit without divice info
+description: Submit without device info
 value_2: true 
-description: Submit with divice info
+description: Submit with device info
 
 ## AdvancedDashedBoxComponent - TmplAdvancedDashedBoxComponent
 ### Type 
@@ -910,7 +910,7 @@ description: Name of class
 value_1: default - (default) 
 description: Primary text and border color
 value_2: alert 
-description: Text color white and secodary border color
+description: Text color white and secondary border color
 
 ## HelpIconComponent - TmplHelpIconComponent
 ### Type 
@@ -930,5 +930,5 @@ description: Path to icon
 - no_margin_lr - remove left and right margin;
 - no_margin - remove all margins;
 - no_padding_t - remove top padding;
-- no_padding_lr - remove left and rigth padding
+- no_padding_lr - remove left and right padding
 - no_padding - remove all paddings

--- a/documentation/docs/components/round_button.md
+++ b/documentation/docs/components/round_button.md
@@ -23,7 +23,7 @@
 |style                  |yellow                  |Button colour yellow|
 |style                  |orange                  |Button colour orange|
 |style                  |dark_orange             |Button colour dark orange|
-|style                  |home_screen             |Button colour primary positioned to the righthand side of the screen|
+|style                  |home_screen             |Button colour primary positioned to the right hand side of the screen|
 |text                   |empty string (default)|No text on the button|
 |text                   |string                  |Any string as a button text|
 |disabled	            |false (default)         |To be removed|

--- a/documentation/docs/contributors/documentation/authoring.md
+++ b/documentation/docs/contributors/documentation/authoring.md
@@ -29,7 +29,7 @@ nav:
 A full set of styling options can be found from the theme documentation at https://squidfunk.github.io/mkdocs-material/reference/
 
 !!! info
-    This includes how to add things like callouts (admonitions), buttons, tables and more!
+    This includes how to add things like call-outs (admonitions), buttons, tables and more!
 
 [View Theme Docs :fontawesome-solid-external-link-alt:](https://squidfunk.github.io/mkdocs-material/reference/){ .md-button .md-button--primary }
 

--- a/documentation/docs/developers/deployments.md
+++ b/documentation/docs/developers/deployments.md
@@ -84,6 +84,7 @@ The deployment configuration requires IDs for two created Google Drive folders, 
 
 The folders should again be named without spaces or special characters, and once created their unique IDs can be found by looking at the end of the URL bar when navigating inside the folder on Google Drive.
 
+<!-- cspell:disable-next-line -->
 E.g. `1ja6lzbphZaxnVv5mpQ4YHnn2qmxMiEBW`
 
 ![](images/deployment-gdrive-ids.png)

--- a/documentation/docs/developers/device-testing.md
+++ b/documentation/docs/developers/device-testing.md
@@ -1,7 +1,7 @@
 # On-device Testing
 
 ## Generate apk 
-A custom github action exists that can be used to trigger the building of android apks from a given repo branch. Visit the action url and click Run workflow to initiate a build
+A custom github action exists that can be used to trigger the building of android APKs from a given repo branch. Visit the action url and click Run workflow to initiate a build
 https://github.com/IDEMSInternational/parenting-app-ui/actions/workflows/trigger-build.yml
 
 ![](./images/device-testing-1.png)

--- a/documentation/docs/developers/quickstart.md
+++ b/documentation/docs/developers/quickstart.md
@@ -62,7 +62,7 @@ Once you've installed those tools you'll also need to make sure you PATH and AND
 ### Running on an Android Emulator
 
 1. Open Android studio and follow the steps here https://developer.android.com/studio/run/managing-avds#createavd to create an Android emulator. When choosing a system image to create an emulator for do not choose a version of Android older than 5.0 Lollipop (API Level 21).
-2. Incase you are having problems with running the AVD you might receivean error message saying something like - _How to Enable Intel Virtualization Technology (vt-x) ……… you will need to get into your bios and enable virtualization_ if you are not sure what that is, then you can google it up for your computer model.
+2. In case you are having problems with running the AVD you might receive an error message saying something like - _How to Enable Intel Virtualization Technology (vt-x) ……… you will need to get into your bios and enable virtualization_ if you are not sure what that is, then you can google it up for your computer model.
 3. Once you've created an emulator run directly from Android Studio
 
 ### Running on a physical Android device (developing on Windows)

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -1,6 +1,6 @@
 # Getting Setup
 
-## Prequisites
+## Prerequisites
 
 1. Download and install [Git](https://git-scm.com/downloads)  
    This will be used to download the repository

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -47,7 +47,7 @@ the online database and authentication methods.
 ```
 $ cp src/environments/firebaseConfig.sample.ts src/environments/firebaseConfig.ts
 ```
-The default file is blank and so some features may not be availabe (e.g. testing google sign-in)
+The default file is blank and so some features may not be available (e.g. testing google sign-in)
 It can be replaced with a version requested from the dev team.
 
 (Note - this process will likely be simplified in the future)

--- a/documentation/docs/questions/hidden_condition.md
+++ b/documentation/docs/questions/hidden_condition.md
@@ -4,6 +4,6 @@
 
 _Asked on 25 May 2022_
 
-Right now the distinction I have is to always use a condition as this does not populate any content to the page. There may be some occasions where dynamic content is not updated correctly when updating condition that do display correctly with hidden (I can't remember the exact case anymore), however these should be identified as bugs and fixed in the future.
+Right now the distinction I have is to always use a condition as this does not populate any content to the page. There may be some occasions where dynamic content is not updated correctly when updating condition that do display correctly with hidden (I can't remember the exact case any more), however these should be identified as bugs and fixed in the future.
 
 _Answered on 25 May 2022 by CC_

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:unit:ci": "ng test --no-watch --no-progress",
     "test:e2e": "yarn workspace test-e2e start",
     "lint": "ng lint",
+    "lint:docs": "cspell \"documentation/docs/**/*.md\" --config \"cspell.config.yml\"",
     "analyse": "yarn build -- --stats-json && npx webpack-bundle-analyzer www/stats.json"
   },
   "private": true,
@@ -126,6 +127,7 @@
     "@typescript-eslint/parser": "5.17.0",
     "codelyzer": "^6.0.2",
     "concurrently": "^6.2.0",
+    "cspell": "^6.20.1",
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "2.23.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,6 +2303,402 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspell/cspell-bundled-dicts@npm:6.20.1":
+  version: 6.20.1
+  resolution: "@cspell/cspell-bundled-dicts@npm:6.20.1"
+  dependencies:
+    "@cspell/dict-ada": ^4.0.1
+    "@cspell/dict-aws": ^3.0.0
+    "@cspell/dict-bash": ^4.1.1
+    "@cspell/dict-companies": ^3.0.6
+    "@cspell/dict-cpp": ^4.0.1
+    "@cspell/dict-cryptocurrencies": ^3.0.1
+    "@cspell/dict-csharp": ^4.0.2
+    "@cspell/dict-css": ^4.0.2
+    "@cspell/dict-dart": ^2.0.1
+    "@cspell/dict-django": ^4.0.1
+    "@cspell/dict-docker": ^1.1.5
+    "@cspell/dict-dotnet": ^4.0.1
+    "@cspell/dict-elixir": ^4.0.1
+    "@cspell/dict-en-gb": 1.1.33
+    "@cspell/dict-en_us": ^4.2.1
+    "@cspell/dict-filetypes": ^3.0.0
+    "@cspell/dict-fonts": ^3.0.0
+    "@cspell/dict-fullstack": ^3.1.1
+    "@cspell/dict-gaming-terms": ^1.0.4
+    "@cspell/dict-git": ^2.0.0
+    "@cspell/dict-golang": ^5.0.1
+    "@cspell/dict-haskell": ^4.0.1
+    "@cspell/dict-html": ^4.0.2
+    "@cspell/dict-html-symbol-entities": ^4.0.0
+    "@cspell/dict-java": ^5.0.4
+    "@cspell/dict-k8s": ^1.0.0
+    "@cspell/dict-latex": ^3.1.0
+    "@cspell/dict-lorem-ipsum": ^3.0.0
+    "@cspell/dict-lua": ^4.0.0
+    "@cspell/dict-node": ^4.0.2
+    "@cspell/dict-npm": ^5.0.3
+    "@cspell/dict-php": ^3.0.4
+    "@cspell/dict-powershell": ^4.0.0
+    "@cspell/dict-public-licenses": ^2.0.1
+    "@cspell/dict-python": ^4.0.1
+    "@cspell/dict-r": ^2.0.1
+    "@cspell/dict-ruby": ^4.0.1
+    "@cspell/dict-rust": ^4.0.0
+    "@cspell/dict-scala": ^4.0.0
+    "@cspell/dict-software-terms": ^3.1.1
+    "@cspell/dict-sql": ^2.0.1
+    "@cspell/dict-svelte": ^1.0.2
+    "@cspell/dict-swift": ^2.0.1
+    "@cspell/dict-typescript": ^3.1.0
+    "@cspell/dict-vue": ^3.0.0
+  checksum: 08e92cf62d82f0de70d99d5fe4201212c8f6cd93a1b2582464985b64a78810de00560765eec8d19ad01e15430d92fe5f68f6f71e29e494810514aaf5116e3b14
+  languageName: node
+  linkType: hard
+
+"@cspell/cspell-pipe@npm:6.20.1":
+  version: 6.20.1
+  resolution: "@cspell/cspell-pipe@npm:6.20.1"
+  checksum: e718cc37f9310b06395dc64db4ba1f10b11dfe7e1bfbc6943b2879d9cbe5983e879d3031876b011545fd782803c612cb4e8ecd14cc496bd079be381720bed59e
+  languageName: node
+  linkType: hard
+
+"@cspell/cspell-service-bus@npm:6.20.1":
+  version: 6.20.1
+  resolution: "@cspell/cspell-service-bus@npm:6.20.1"
+  checksum: 5129594dc6d4031a0f516c11cdccb10cce382b03ee67c9e2b426b02a39ebdec0e755924a75474d37719d411b0c908c919f67693b3f7685eb67b57c02b055d0c8
+  languageName: node
+  linkType: hard
+
+"@cspell/cspell-types@npm:6.20.1":
+  version: 6.20.1
+  resolution: "@cspell/cspell-types@npm:6.20.1"
+  checksum: 4c1c2b4a954e57ebaa9f9761ea6e2e981e9255453ba0de155b508fdcb703bf603de123fabee4c9eae90da8a8f6820445f92f5651273569b87a0d3173ef2ab7e7
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-ada@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-ada@npm:4.0.1"
+  checksum: 3422487c8decf01d9dd14e666dcbe29557d730085f60fcd859d03fc5c177359d12df19171368cd105dad29f315d0decfa56f29eeb7c594a300d47c65805c4349
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-aws@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@cspell/dict-aws@npm:3.0.0"
+  checksum: d06284d5cc438c18175c26e4f5d450f3235d603dbc989fa2d7515bb01d1c7a8b303ce054d532ca4f814fc6cd7c65ef9558d46bf5bacb06d35504b3c259ebe95c
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-bash@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@cspell/dict-bash@npm:4.1.1"
+  checksum: 5b6fbb597c53fa6b9957213aa77688c6e0231f8d59eed02f0eecda456f3606855fc0f4c0c5121a909e9055c164de83e3f151b32a9abd1ccd4a161634ffee6691
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-companies@npm:^3.0.6":
+  version: 3.0.6
+  resolution: "@cspell/dict-companies@npm:3.0.6"
+  checksum: b56d20632f2e953c2b1a199701b4af4c1b5c5d6ea56c889b68bbac8f3e8f8645eb0386b3198274f14491fccf9608586ebdbe94c0835723934966682ffdc0c8f7
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-cpp@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-cpp@npm:4.0.1"
+  checksum: 53db5515d046bc1be80031f82be801edb9c349a5487f894db7fc54d45a86142f01476b35fe8453605a3402ba6dd850353bf628eba8223fbac8d6f9e7d002827e
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-cryptocurrencies@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@cspell/dict-cryptocurrencies@npm:3.0.1"
+  checksum: 5d646f569e8dc5998de8a508ff3de39db5f5a5db0a846ee4fc750ea3880080d922d5c28fdce38f93910eaacde2723e2fe4c305d50b3f9d53b817ce33a3bed66a
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-csharp@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@cspell/dict-csharp@npm:4.0.2"
+  checksum: d2ecb2aada51c5f0d6d557fd4f0c6eddb5b299e0955e066c49cd2afe96a1c6fe0afde699fdb885dd3183603a1efbd1d793b6a490b8d039256445b4b154b7375b
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-css@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@cspell/dict-css@npm:4.0.2"
+  checksum: 633dca714f4d7afaac3e3e4a2c4d417c68365521b414897d5a311369589f00f2adeb3a366e9588585134cea8a5ff62b1fceb63bf19813676a7d475817371f58b
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-dart@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cspell/dict-dart@npm:2.0.1"
+  checksum: 6536a47450ebcbaad90253802791e69567565ecab89d0eb00d8be8b8b2d94d3971fcd92c6e013e25e0f06e1994591fb5ae6b5674798d74e3f449ffa1ea556f3e
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-django@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-django@npm:4.0.1"
+  checksum: 1954c4b96c05bb2c6aad3a76dcd9963912ed177c49d2bcfb10992af83143c1d644f4306d79acb175eda7767a75444007c9c4d94ba10245aeb256613ae10f0306
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-docker@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@cspell/dict-docker@npm:1.1.5"
+  checksum: a983e3587cbe6f741dfbf40c509ca06d9489f1fb64f902128f9d738acb747b3a8651a73d256f2a7ef7750a54897eb76776403a47e4b55d84d785c7efa3a90e5e
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-dotnet@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-dotnet@npm:4.0.1"
+  checksum: 176b25bc36ea4407439852be685a421d0ea0be19d8c4eb48b897a1aa2bdde3f71731b94f33b6ae1260546260343d7ee1f2c1c1087848cd2ceac0c635c009e370
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-elixir@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-elixir@npm:4.0.1"
+  checksum: 080a71b4c3ffa98dafbad851aed31fe2f58c3cb1ca5f3cf7eee1f203168c2f9440076c2fe5970fd92a968af3f36255a3e633aa5962a32bba16c4b7095a0ef0bf
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-en-gb@npm:1.1.33":
+  version: 1.1.33
+  resolution: "@cspell/dict-en-gb@npm:1.1.33"
+  checksum: 09a9e7a3ee4cad75c87cc7adf6b5981b3ec52d4e3707e8de2e1a2a55cd5c8539057a7742d9c7035e23eb0aeff80a95b9599696c7192c9b3b9d8f14440fe01938
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-en_us@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@cspell/dict-en_us@npm:4.2.1"
+  checksum: 24491d7af08cedd04fda669ca49f8785dfcd3c08ac00592deb911f7d273ae932b02db699190e2075e21521c3c6f3d70a828247546b5bc5a5276b36bd9bb04e20
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-filetypes@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@cspell/dict-filetypes@npm:3.0.0"
+  checksum: 8afd0785583f913c8d6ad1a2b56a527600258b291fc6ed8e83f543ba70a5273095195495601aca7d80fdeb17cab6a10e8a8aa44bea3083962cd42af130260d8a
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-fonts@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@cspell/dict-fonts@npm:3.0.0"
+  checksum: 3cd3574c2f32d761775ddd1bb68360488f400cf310c0499e6fac53641596a51708719e57426c97e183b528ad142ee04c90af93bb38a016ceecb921d76a00e9d9
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-fullstack@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@cspell/dict-fullstack@npm:3.1.1"
+  checksum: 4fbbfd55f202d7c05291e072aed37dc0435ca5559dd8c3a4d30734e73a03f60944a5530167368a478b49df62fa212f3ce3011a11eaee4645abc39acf54ee63e5
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-gaming-terms@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@cspell/dict-gaming-terms@npm:1.0.4"
+  checksum: 3e57f5567747a8598b3e4de4f63a3b8090cccf7688f3e91f0a9e005e916645db1224ea600afd5b497b7e8c6a1f9291dfd4cb932278dfd423657107203a2ace0b
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-git@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@cspell/dict-git@npm:2.0.0"
+  checksum: eb3985f1f8717ad4e41e146f1b011e0476d7625ab1ebee55364575b727323300773a89a8dd5a20466c74c57b7d2678e0c92446453bd484a44203be737bc07964
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-golang@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@cspell/dict-golang@npm:5.0.1"
+  checksum: 5a82060a2cc87a129174c648e2b52db8af4b9de25d5c18d138299dba3c2783003c68883d5dc9623bca2eb7e35d95783d1af3f0fd5b577a965de934deb36e8578
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-haskell@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-haskell@npm:4.0.1"
+  checksum: cfb51e415b60c5eb266a5782d0a4b19a37f1389b9b018d1bbb2ff4358bd739af1f76f68f26a138d4b4bd0ab67146d6eb9032fc3d3c212695237c134e05339c79
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-html-symbol-entities@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cspell/dict-html-symbol-entities@npm:4.0.0"
+  checksum: 79f05f9080f39dbde703980eb587ed6624b8fc2f5cedc297327bc1b9b7e6022a7c382e6013149b1afe00609b96003ab5c8d18d378979f76f336ab626317183f4
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-html@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@cspell/dict-html@npm:4.0.2"
+  checksum: f4967d362a661408fcfc284292dd64280e4abda06ded0da95a5083473ea921043718b1694e9f0cec852d90e750d7d495fd639a57ce0d1dbd7097bb92c3b3e1b0
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-java@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@cspell/dict-java@npm:5.0.4"
+  checksum: 1bbb0acc81a6af5a8e0e0e09768b1b52bfac7412e02292b6dd663949cdf33d7245e0a4018148a7d10aae8e5436714191809623a342e7cb1d42a8484dba85d8f7
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-k8s@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@cspell/dict-k8s@npm:1.0.0"
+  checksum: ef6d12cfd81b41c843773f61fc923a0a48b18d871ae0b8e9cd7e1bca28fba543c4bcd6964b34e2ac760336a86abdf7c8bc81a7b94bfdb274e39244a5c016fc3c
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-latex@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@cspell/dict-latex@npm:3.1.0"
+  checksum: 90dafd4c1d0f9a9bd9e36734e624ca3d891023a5477ca9df62037a4297c8f751be5b33cbf4def9356d8bcec65a4e1ae89862d80ebe30675e91d10d69e0852de6
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-lorem-ipsum@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@cspell/dict-lorem-ipsum@npm:3.0.0"
+  checksum: 145a79ec536bee3ec515b189be3f4a5347a28c563060ac5da6f6783a288e63cb0662fc918be008e1a377bdeb48cfa7a2aa1f9e9f8aef6371109f95f4b049731d
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-lua@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cspell/dict-lua@npm:4.0.0"
+  checksum: a126021ab43157518710416e3741a145f87a0ba67b134f24854c01690a0a5c7932feedd1a1b4721e1137bff7586945782fa6578bdf58cd4f0e1167f8e3e71a20
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-node@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "@cspell/dict-node@npm:4.0.2"
+  checksum: 7a63ee44c4c493b429c821eb9e5fdcd1d0f549a2ada64d8ce3f7f0a88e2d26f82daada8801ee6f09a582502a1500d63985aa47204757b39014dff747211539d5
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-npm@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "@cspell/dict-npm@npm:5.0.3"
+  checksum: f250a7d67436f23965c04028eb39395595574ef4a2250c0c30ee736b32fb583ad285d0dc383cb2ac1a9a941caaa329eeb4f2e04fe6e253e6196746d77a980880
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-php@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@cspell/dict-php@npm:3.0.4"
+  checksum: ba3dcb8afcf214e331d1ee26c61130efb6192aaf62d24655582edf23d543605d42818fb146a3b13ae203a1b70b362d3f9f5c0e793984dafb3156aff979aa6a35
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-powershell@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cspell/dict-powershell@npm:4.0.0"
+  checksum: 93ae5813324858e3fb93572f74d83c28c11c7758088b97b9e6362e31da83e10bcdefad0e50be4b2de3d4b5979b1fca44e3df4c3132f8eb45d7ab81b9d8f51aa4
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-public-licenses@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cspell/dict-public-licenses@npm:2.0.1"
+  checksum: ce563b482df6f931290c0ba752417aedc993a173ae896002a4a30de9cd68418fa6a01664fe61239423388de09f17d8f68430f3ff95979a7e6e2090987aa7d968
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-python@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-python@npm:4.0.1"
+  checksum: 83ceb2779c64fb8370dfb6070015cea6337905a7066d38e69508a20976236a5e691b9926f11f4a2391ad5676a9245b5bf981a9118db2ad483baab04741467956
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-r@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cspell/dict-r@npm:2.0.1"
+  checksum: fe85939ad4c8ada34284a673918be711cca60b6d6f1c48ee98602c27905228dfbaea3462a350094633032c1d6b6bba9548df7019e0b21673cf1cf887c57ca228
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-ruby@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@cspell/dict-ruby@npm:4.0.1"
+  checksum: e802d322d67edd63fe7fec5f3aa95cc472711752675aa9d5ad3987ec7f17f3bb2ad537df60bdc54bed035a83b3b062eb072ddad6b15f7999b044309d8dac027e
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-rust@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cspell/dict-rust@npm:4.0.0"
+  checksum: 99dcc7009e1204fcabdb7caeca37d4eadf0963f6727e19860a1e7a2310598fd39729b89c87684c7067620b1679688fd57bf8f73a3e4b46216bdc755889a20da3
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-scala@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cspell/dict-scala@npm:4.0.0"
+  checksum: 811805e3a36e94dcd180bf299646df5ca672fd6a29a9ba13c08c8ed0135b59157e9685a72c66131aa8334a80491038198aaf7d1c430b4aa51ab0e9a1a6d01a6d
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-software-terms@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@cspell/dict-software-terms@npm:3.1.1"
+  checksum: 93a41afb50a4f445114083b7dadb34bba5f2676e47ab7d15084b36efac43b9cca28e068f1956559b442f10d493f348ef95a910abcbfa1711c204ff358c028d45
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-sql@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cspell/dict-sql@npm:2.0.1"
+  checksum: c92d2c9f3b22de02be5353dfe17e84ba3e562f463128fdcd46959ac9eacd9affb531a64ca374af159eeb8b1d3314a3a530d86ddaf35d972a76e0042614cb2d38
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-svelte@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@cspell/dict-svelte@npm:1.0.2"
+  checksum: 5b42989bc6743a26ca5172cc23ebc1449d930695b10c908376048ce1835bf57fef7a0004f02ec5e43219f24a97f154e125041df470441199a045ed0be9e654fc
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-swift@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@cspell/dict-swift@npm:2.0.1"
+  checksum: 0bbb106266205c5f5e12886a73ebf0db2078bab1bdd2e1f304fe28445cd72d847a4c5072bf4fe8f9e8cdb4bc69d52fffec0806aea19ea9b64b7a87c67ee01175
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-typescript@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@cspell/dict-typescript@npm:3.1.0"
+  checksum: b34a9f394a9426d0ec7ff6ee378b973b7e5a4483add7a19686cf923dd7047c0195e8ac155529c4a38e0bda4f48e50f7efe8de8df6ad71f875a29d28e64c8c01c
+  languageName: node
+  linkType: hard
+
+"@cspell/dict-vue@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@cspell/dict-vue@npm:3.0.0"
+  checksum: 4db58b1d6f9be1a523a35678877f2cca2bb04548b136ec5ec4e7186500978dbc32cc8747ced80ade3cad3acc3c80eb23afe980679165810f8f8f26802e952e2f
+  languageName: node
+  linkType: hard
+
+"@cspell/strong-weak-map@npm:6.20.1":
+  version: 6.20.1
+  resolution: "@cspell/strong-weak-map@npm:6.20.1"
+  checksum: f57f0a5e6be0c55dd408811f65cc7ebaea4e8542e0a83633e2ab6dbfd4f2c0240d5d6ed8abd19cf18e22bd67544e2d98f93201e67c961efd18a9a3ffc4119abf
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -7971,6 +8367,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-timsort@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "array-timsort@npm:1.0.3"
+  checksum: fd4b5b0911214bdc8b5699ed10d309685551b518b3819c611c967cff59b87aee01cf591a10e36a3f14dbff696984bd6682b845f6fdbf1217195e910f241a4f78
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
@@ -9466,6 +9869,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clear-module@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "clear-module@npm:4.1.2"
+  dependencies:
+    parent-module: ^2.0.0
+    resolve-from: ^5.0.0
+  checksum: 4931f0c461f5d7b9b79f62c2d1bc31c37f7f1d33b4e95eef7080a83955c0374f4c180f5a96cc4d63bbefc64a9aa5d12b155641109e8e489dfa50fd5820e5101f
+  languageName: node
+  linkType: hard
+
 "cli-boxes@npm:^2.2.0, cli-boxes@npm:^2.2.1":
   version: 2.2.1
   resolution: "cli-boxes@npm:2.2.1"
@@ -9888,6 +10301,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "commander@npm:10.0.0"
+  checksum: 9f6495651f878213005ac744dd87a85fa3d9f2b8b90d1c19d0866d666bda7f735adfd7c2f10dfff345782e2f80ea258f98bb4efcef58e4e502f25f883940acfd
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.11.0, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.5.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -9934,6 +10354,19 @@ __metadata:
   version: 2.17.1
   resolution: "commander@npm:2.17.1"
   checksum: 22e7ed5b422079a13a496e5eb8f73f36c15b5809d46f738e168e20f9ad485c12951bdc2cb366a36eb5f4927dae4f17b355b8adb96a5b9093f5fa4c439e8b9419
+  languageName: node
+  linkType: hard
+
+"comment-json@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "comment-json@npm:4.2.3"
+  dependencies:
+    array-timsort: ^1.0.3
+    core-util-is: ^1.0.3
+    esprima: ^4.0.1
+    has-own-prop: ^2.0.0
+    repeat-string: ^1.6.1
+  checksum: 7f8d26266b0d49de9661f6365cbcc373fee4f4d0f422a203dfb17ad8f3d84c5be5ded444874935a197cd03cff297c53fe48910256cb4171cb2e52a3e6b9d317c
   languageName: node
   linkType: hard
 
@@ -10304,7 +10737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:~1.0.0":
+"core-util-is@npm:^1.0.3, core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 9de8597363a8e9b9952491ebe18167e3b36e7707569eed0ebf14f8bba773611376466ae34575bca8cfe3c767890c859c74056084738f09d4e4a6f902b2ad7d99
@@ -10344,6 +10777,18 @@ __metadata:
     path-type: ^4.0.0
     yaml: ^1.10.0
   checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "cosmiconfig@npm:8.0.0"
+  dependencies:
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+  checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
   languageName: node
   linkType: hard
 
@@ -10434,6 +10879,126 @@ __metadata:
   version: 2.0.0
   resolution: "crypto-random-string@npm:2.0.0"
   checksum: 0283879f55e7c16fdceacc181f87a0a65c53bc16ffe1d58b9d19a6277adcd71900d02bb2c4843dd55e78c51e30e89b0fec618a7f170ebcc95b33182c28f05fd6
+  languageName: node
+  linkType: hard
+
+"cspell-dictionary@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-dictionary@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-pipe": 6.20.1
+    "@cspell/cspell-types": 6.20.1
+    cspell-trie-lib: 6.20.1
+    fast-equals: ^4.0.3
+    gensequence: ^4.0.3
+  checksum: bd2bcf4db5d84d806e0e801b01e3603b4fd1cd1d7dc4afe14cbd0c5bbc21386ce43d9b3b050e0e8e301cf9571a9f31bd3266472483ccc58b06e51aef902c4e2c
+  languageName: node
+  linkType: hard
+
+"cspell-gitignore@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-gitignore@npm:6.20.1"
+  dependencies:
+    cspell-glob: 6.20.1
+    find-up: ^5.0.0
+  bin:
+    cspell-gitignore: bin.js
+  checksum: 669a10721fd8c056a3877b03fed0230d408f20c8d7c120052f25072cc40c7600864082b404364dade5cafb73cae65ca451ebac3705e3a944e804989109dae876
+  languageName: node
+  linkType: hard
+
+"cspell-glob@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-glob@npm:6.20.1"
+  dependencies:
+    micromatch: ^4.0.5
+  checksum: c9b944ba9ff6ccd6abe8c7b4c9b6d32707ca086df5dea5d97e4dddc52d19e8da9bedf3146b3bbb0daddeb96292953f86138d00c808894c8fc732719e94c97ffb
+  languageName: node
+  linkType: hard
+
+"cspell-grammar@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-grammar@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-pipe": 6.20.1
+    "@cspell/cspell-types": 6.20.1
+  bin:
+    cspell-grammar: bin.js
+  checksum: 69cf47d48a3367bf3b2aacde7a3a6d924d7db335af18b08075ec9499f47be2736cf757733648c08ef4dcc9d9c4233e1ae34d6ec7d7cb4269570cf05a45ae8fec
+  languageName: node
+  linkType: hard
+
+"cspell-io@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-io@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-service-bus": 6.20.1
+    node-fetch: ^2.6.9
+  checksum: 528d432b03208e4767a1f02f5a79f5648fffd5f11e5c6e3309ef809c2f6d3421681fe87d8205a470b0878534eb5d588de54b1111f5ea0146a2f9dd415654c5a5
+  languageName: node
+  linkType: hard
+
+"cspell-lib@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-lib@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-bundled-dicts": 6.20.1
+    "@cspell/cspell-pipe": 6.20.1
+    "@cspell/cspell-types": 6.20.1
+    "@cspell/strong-weak-map": 6.20.1
+    clear-module: ^4.1.2
+    comment-json: ^4.2.3
+    configstore: ^5.0.1
+    cosmiconfig: ^8.0.0
+    cspell-dictionary: 6.20.1
+    cspell-glob: 6.20.1
+    cspell-grammar: 6.20.1
+    cspell-io: 6.20.1
+    cspell-trie-lib: 6.20.1
+    fast-equals: ^4.0.3
+    find-up: ^5.0.0
+    gensequence: ^4.0.3
+    import-fresh: ^3.3.0
+    resolve-from: ^5.0.0
+    resolve-global: ^1.0.0
+    vscode-languageserver-textdocument: ^1.0.8
+    vscode-uri: ^3.0.7
+  checksum: 3ef0304f03add47a5371da8798cb31c3fd31323fe888d5b57370ac1045157574ca2e1d5887d74557bacab24cbde4a9e7ccc7494f4410a51b79f4b4e809842955
+  languageName: node
+  linkType: hard
+
+"cspell-trie-lib@npm:6.20.1":
+  version: 6.20.1
+  resolution: "cspell-trie-lib@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-pipe": 6.20.1
+    "@cspell/cspell-types": 6.20.1
+    gensequence: ^4.0.3
+  checksum: 115ebfd65c04b455780e30eaac5e1a55143d9884893f758b619f4c49154bc48d73a8cb3007dac52af850826fac71f7522918a58d26786d93c937cb2924c5e175
+  languageName: node
+  linkType: hard
+
+"cspell@npm:^6.20.1":
+  version: 6.20.1
+  resolution: "cspell@npm:6.20.1"
+  dependencies:
+    "@cspell/cspell-pipe": 6.20.1
+    chalk: ^4.1.2
+    commander: ^10.0.0
+    cspell-gitignore: 6.20.1
+    cspell-glob: 6.20.1
+    cspell-lib: 6.20.1
+    fast-glob: ^3.2.12
+    fast-json-stable-stringify: ^2.1.0
+    file-entry-cache: ^6.0.1
+    get-stdin: ^8.0.0
+    imurmurhash: ^0.1.4
+    semver: ^7.3.8
+    strip-ansi: ^6.0.1
+    vscode-uri: ^3.0.7
+  bin:
+    cspell: bin.js
+  checksum: c0d261babea9d7a3f24d0225e781e718c1746ee358bb539edd46707a4142a58fa19257ea487dc23012864344d6efb4b7b2320332729c3f54ddad1806122c2cd1
   languageName: node
   linkType: hard
 
@@ -13524,7 +14089,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
+"fast-equals@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "fast-equals@npm:4.0.3"
+  checksum: 3d5935b757f9f2993e59b5164a7a9eeda0de149760495375cde14a4ed725186a7e6c1c0d58f7d42d2f91deb97f3fce1e0aad5591916ef0984278199a85c87c87
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -13537,7 +14109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.1.0, fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.1.0, fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -14232,6 +14804,7 @@ __metadata:
     concurrently: ^6.2.0
     cordova-res: ^0.15.4
     core-js: ^3.27.1
+    cspell: ^6.20.1
     data-models: "workspace:*"
     date-fns: ^2.22.1
     deep-object-diff: ^1.1.9
@@ -14570,6 +15143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gensequence@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "gensequence@npm:4.0.3"
+  checksum: 541824a242bb0a64e7e58b595c753a5a9cd07c02a1c6c41928e0d6e09f16047e774deab470ae484e4aded29cfe03a6325a3090dd6e5a0c32ff3726606b09ffc4
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -14639,6 +15219,13 @@ __metadata:
   version: 5.0.1
   resolution: "get-stdin@npm:5.0.1"
   checksum: f9784638ad3e68a0a8bdc031aedf0fca749843cd134956fbd4f3bbac17c359e0fb9210343fcbed72ee79fb19d8e4c49b7a6e742cc5d44e94ac1405e9371d4b3e
+  languageName: node
+  linkType: hard
+
+"get-stdin@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "get-stdin@npm:8.0.0"
+  checksum: 40128b6cd25781ddbd233344f1a1e4006d4284906191ed0a7d55ec2c1a3e44d650f280b2c9eeab79c03ac3037da80257476c0e4e5af38ddfb902d6ff06282d77
   languageName: node
   linkType: hard
 
@@ -14831,6 +15418,15 @@ __metadata:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
+  languageName: node
+  linkType: hard
+
+"global-dirs@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "global-dirs@npm:0.1.1"
+  dependencies:
+    ini: ^1.3.4
+  checksum: 10624f5a8ddb8634c22804c6b24f93fb591c3639a6bc78e3584e01a238fc6f7b7965824184e57d63f6df36980b6c191484ad7bc6c35a1599b8f1d64be64c2a4a
   languageName: node
   linkType: hard
 
@@ -15201,6 +15797,13 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 261a1357037ead75e338156b1f9452c016a37dcd3283a972a30d9e4a87441ba372c8b81f818cd0fbcd9c0354b4ae7e18b9e1afa1971164aef6d18c2b6095a8ad
+  languageName: node
+  linkType: hard
+
+"has-own-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "has-own-prop@npm:2.0.0"
+  checksum: ca6336e85ead2295c9603880cbc199e2d3ff7eaea0e9035d68fbc79892e9cf681abc62c0909520f112c671dad9961be2173b21dff951358cc98425c560e789e0
   languageName: node
   linkType: hard
 
@@ -15781,7 +16384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.0.0, import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
   dependencies:
@@ -20013,6 +20616,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:^2.6.9":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
+  languageName: node
+  linkType: hard
+
 "node-forge@npm:^1, node-forge@npm:^1.3.1":
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
@@ -21092,6 +21709,15 @@ __metadata:
   dependencies:
     callsites: ^3.0.0
   checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parent-module@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "parent-module@npm:2.0.0"
+  dependencies:
+    callsites: ^3.1.0
+  checksum: f131f13d687a938556a01033561fb1b274b39921eb4425c7a691f0d91dcfbe9b19759c2b8d425a3ee7c8a46874e57fa418a690643880c3c7c56827aba12f78dd
   languageName: node
   linkType: hard
 
@@ -23110,6 +23736,15 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 4ceeb9113e1b1372d0cd969f3468fa042daa1dd9527b1b6bb88acb6ab55d8b9cd65dbf18819f9f9ddf0db804990901dcdaade80a215e7b2c23daae38e64f5bdf
+  languageName: node
+  linkType: hard
+
+"resolve-global@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-global@npm:1.0.0"
+  dependencies:
+    global-dirs: ^0.1.1
+  checksum: c4e11d33e84bde7516b824503ffbe4b6cce863d5ce485680fd3db997b7c64da1df98321b1fd0703b58be8bc9bc83bc96bd83043f96194386b45eb47229efb6b6
   languageName: node
   linkType: hard
 
@@ -27080,6 +27715,20 @@ __metadata:
   version: 2.0.1
   resolution: "void-elements@npm:2.0.1"
   checksum: 700c07ba9cfa2dff88bb23974b3173118f9ad8107143db9e5d753552be15cf93380954d4e7f7d7bc80e7306c35c3a7fb83ab0ce4d4dcc18abf90ca8b31452126
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-textdocument@npm:^1.0.8":
+  version: 1.0.9
+  resolution: "vscode-languageserver-textdocument@npm:1.0.9"
+  checksum: 36b76f725098d3e0d97885c05c51fca47388d9b62e936f6c8824c44a4fac7a96e1406538538a0f46ef1fdb9f1053ddc1cacb5e7b168cecb36d3c018942ec6f52
+  languageName: node
+  linkType: hard
+
+"vscode-uri@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "vscode-uri@npm:3.0.7"
+  checksum: c899a0334f9f6ba53021328e083f6307978c09b94407d7e5fe86fcd8fcb8f1da0cb344123a335e55769055007a46d51aff83f9ee1dfc0296ee54b78f34ef0e4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

- Add tool to spellcheck documentation (cspell)
- Add github action to automatically run spellcheck whenever documentation files change

## Review Notes
I haven't corrected all the spelling, it would be great if somebody else could help make the required fixes.
Run the spellchecker locally via
```
yarn lint:docs
```
This will show a list of all potential typos, e.g.
![image](https://user-images.githubusercontent.com/10515065/216501632-1bc7908e-9d42-44c4-8a60-8525243bbd4e.png)

Any words that aren't recognised but spelt correctly can be added to the list of words in `cspell.config.yml`, e.g.
```yml
"words":
  [
    "idems",
    "quickstart",
    "glitchtip",
```

Any lines that should specifically be ignored should include a comment to disable
```yml
<!-- cspell:disable-next-line -->
E.g. `1ja6lzbphZaxnVv5mpQ4YHnn2qmxMiEBW`
```
Similarly sections of files or entire files can be disabled as required, discussed in more detail in [CSpell Docs](http://cspell.org/configuration/document-settings/#enable--disable-checking-sections-of-code)

## Git Issues

Closes #

## Screenshots/Videos
