### PR TITLE
Fix/unit tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "root": true,
   "ignorePatterns": ["projects/**/*"],
+  "plugins": ["jasmine"],
+  "env": { "jasmine": true },
   "overrides": [
     {
       "files": ["*.ts"],
@@ -101,6 +103,16 @@
       "extends": ["plugin:@angular-eslint/template/recommended"],
       "rules": {
         "@angular-eslint/template/eqeqeq": "warn"
+      }
+    },
+    {
+      "files": ["*.spec.ts"],
+      "extends": ["plugin:jasmine/recommended"],
+      "rules": {
+        "jasmine/no-focused-tests": 2,
+        "jasmine/new-line-before-expect": 0,
+        "jasmine/new-line-between-declarations": 0,
+        "jasmine/prefer-toHaveBeenCalledWith": 0
       }
     }
   ]

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,6 @@ on:
       - master
 jobs:
   build:
-    if: "!contains(github.event.pull_request.labels.*.name, 'Test - preview')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,6 +32,8 @@ jobs:
       - run: yarn install
       - name: Set Scripts Deployment
         run: yarn workflow deployment set $DEPLOYMENT_NAME
+      - name: Lint
+        run: yarn lint
       - name: Unit Tests Workspaces
         run: yarn test:workspaces  
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "2.23.4",
+    "eslint-plugin-jasmine": "^4.1.3",
     "eslint-plugin-jsdoc": "35.4.0",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "firebase-tools": "^9.14.0",

--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -4,7 +4,7 @@ import { Command } from "commander";
 import * as path from "path";
 import chalk from "chalk";
 import { FlowTypes } from "data-models";
-import { getActiveDeployment } from "../../deployment/get";
+import { ActiveDeployment } from "../../deployment/get";
 import { IConverterPaths, IParsedWorkbookData } from "./types";
 import { XLSXWorkbookProcessor } from "./processors/xlsxWorkbook";
 import { JsonFileCache } from "./cacheStrategy/jsonFile";
@@ -14,7 +14,7 @@ import {
   createChildLogger,
   logSheetsSummary,
   getLogs,
-  logError,
+  Logger,
   getLogFiles,
   logWarning,
   clearLogs,
@@ -56,7 +56,7 @@ export class AppDataConverter {
   /** Change version to invalidate all underlying caches */
   public version = 20221027.0;
 
-  public activeDeployment = getActiveDeployment();
+  public activeDeployment = ActiveDeployment.get();
 
   private paths: IConverterPaths = {
     SHEETS_INPUT_FOLDER: "",
@@ -161,7 +161,7 @@ export class AppDataConverter {
     const errors = getLogs("error");
     if (errors.length > 0) {
       const errorLogFile = getLogFiles().error;
-      logError({
+      Logger.error({
         msg1: `Completed with errors`,
         msg2: errorLogFile,
         logOnly: true,

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/default.parser.ts
@@ -7,7 +7,7 @@ import {
   parseAppDataActionString,
   parseAppDateValue,
 } from "../../../utils";
-import { getActiveDeployment } from "../../../../../deployment/get";
+import { ActiveDeployment } from "../../../../../deployment/get";
 import { FlowParserProcessor } from "../flowParser";
 // When running this parser assumes there is a 'type' column
 type IRowData = { type: string; name?: string; rows?: IRowData };
@@ -22,7 +22,7 @@ type IRowData = { type: string; name?: string; rows?: IRowData };
 export class DefaultParser<
   FlowType extends FlowTypes.FlowTypeWithData = FlowTypes.FlowTypeWithData
 > {
-  activeDeployment = getActiveDeployment();
+  activeDeployment = ActiveDeployment.get();
 
   public flow: FlowType;
 

--- a/packages/scripts/src/commands/app-data/copy.spec.ts
+++ b/packages/scripts/src/commands/app-data/copy.spec.ts
@@ -5,8 +5,8 @@ import fs from "fs-extra";
 import mockFs from "mock-fs";
 
 // Use default imports to allow spying on functions and replacing with mock methods
-import * as spyDeployment from "../deployment/get";
-import * as spyLoggingUtils from "../../utils/logging.utils";
+import { ActiveDeployment } from "../deployment/get";
+import { Logger } from "../../utils/logging.utils";
 import path from "path";
 
 /** Mock file system folders for use in tests */
@@ -34,16 +34,18 @@ const mockDirContents = {
   "mock/localSheetsFolder": {},
   "mock/localTranslationsFolder": {},
 };
-/** Mock function that will replace default `logError` function to instead just record any invocations */
-const mockErrorLogger = jasmine.createSpy("mockErrorLogger", spyLoggingUtils.logError);
+
+/** Mock function that will replace default `Logger` function to instead just record any invocations */
+const mockErrorLogger = jasmine.createSpy("mockErrorLogger", Logger.error);
 
 describe("App Data Converter", () => {
   /** Initial setup */
   // replace prettier codeTidying method
-  // relpace `logError` function with created spy method
+  // relpace `Logger` function with created spy method
   beforeAll(() => {
     spyOn(AppDataCopy.prototype, "runPrettierCodeTidy" as any).and.stub();
-    spyOn(spyLoggingUtils, "logError").and.callFake(mockErrorLogger);
+
+    spyOn(Logger, "error").and.callFake(mockErrorLogger);
   });
   // Populate a fake file system before each test. This will automatically be called for any fs operations
   // Restore regular file functionality after each test.
@@ -116,7 +118,5 @@ function stubDeploymentConfig(
       APP_THEMES: { available: app_themes_available },
     } as any,
   };
-  spyOn(spyDeployment, "getActiveDeployment").and.returnValue(
-    stubDeployment as IDeploymentConfigJson
-  );
+  spyOn(ActiveDeployment, "get").and.returnValue(stubDeployment as IDeploymentConfigJson);
 }

--- a/packages/scripts/src/commands/app-data/copy.ts
+++ b/packages/scripts/src/commands/app-data/copy.ts
@@ -8,7 +8,7 @@ import {
   isCountryLanguageCode,
   isThemeAssetsFolderName,
   listFolderNames,
-  logError,
+  Logger,
   readContentsFile,
   IContentsEntry,
   logOutput,
@@ -18,7 +18,7 @@ import {
 } from "../../utils";
 import { spawnSync } from "child_process";
 
-import { getActiveDeployment } from "../deployment/get";
+import { ActiveDeployment } from "../deployment/get";
 import { ROOT_DIR } from "../../paths";
 import { FlowTypes } from "data-models";
 
@@ -61,7 +61,7 @@ export default program
  *
  **/
 export class AppDataCopy {
-  private activeDeployment = getActiveDeployment();
+  private activeDeployment = ActiveDeployment.get();
   constructor(private options: IProgramOptions) {}
 
   public run() {
@@ -265,13 +265,13 @@ export const ASSETS_CONTENTS_LIST = ${JSON.stringify(cleanedContents, null, 2)}
       }
     }
     if (!output.hasGlobalFolder) {
-      logError({
+      Logger.error({
         msg1: "Assets global folder not found",
         msg2: `Assets folder should include a folder named "${ASSETS_GLOBAL_FOLDER_NAME}"`,
       });
     }
     if (output.invalidFolders.length > 0) {
-      logError({
+      Logger.error({
         msg1: "Asset folders named incorrectly",
         msg2: `Invalid language codes: [${output.invalidFolders.join(", ")}]`,
       });
@@ -335,14 +335,14 @@ export const SHEETS_CONTENT_LIST:ISheetContents = ${contentsString}
   ) {
     const { flow_name, flow_type, _xlsxPath } = sheetContents;
     if (!existingContents.hasOwnProperty(flow_type)) {
-      logError({
+      Logger.error({
         msg1: `Unsupported flow_type: [${flow_type}]`,
         msg2: `${_xlsxPath}`,
       });
     }
     if (existingContents[flow_type].hasOwnProperty(flow_name)) {
       const duplicateFlowContents = existingContents[flow_type][flow_name];
-      logError({
+      Logger.error({
         msg1: `Duplicate flow_name found: [${flow_type}]`,
         msg2: `${_xlsxPath}\n${duplicateFlowContents._xlsxPath}`,
       });

--- a/packages/scripts/src/commands/app-data/download.ts
+++ b/packages/scripts/src/commands/app-data/download.ts
@@ -6,7 +6,7 @@ import fs from "fs-extra";
 import path from "path";
 import { CREDENTIALS_PATH, AUTH_TOKEN_PATH } from "../../paths";
 import { logWarning, promptOptions } from "../../utils";
-import { getActiveDeployment } from "../deployment/get";
+import { ActiveDeployment } from "../deployment/get";
 
 /***************************************************************************************
  * CLI
@@ -37,7 +37,7 @@ export default program
  * Read the default deployment json and retrieve parsed ts for the named active deployment
  */
 async function appDataDownload(options: IProgramOptions) {
-  const activeDeployment = getActiveDeployment();
+  const activeDeployment = ActiveDeployment.get();
   const { _workspace_path } = activeDeployment;
   const {
     assets_folder_id,

--- a/packages/scripts/src/commands/config/decrypt.ts
+++ b/packages/scripts/src/commands/config/decrypt.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import fs from "fs-extra";
-import { logError, logOutput } from "../../utils";
+import { Logger, logOutput } from "../../utils";
 import { CONFIG_FOLDER_PATH, PRIVATE_KEY_PATH } from "../../paths";
 import { Command } from "commander";
 import NodeRSA from "node-rsa";
@@ -20,7 +20,7 @@ export default program.description("Decrypt Config Files").action(async () => {
  *************************************************************************************/
 async function decryptConfig() {
   if (!fs.existsSync(PRIVATE_KEY_PATH)) {
-    logError({
+    Logger.error({
       msg1: "Private decrypt key not found, ask for one from the dev team and copy to path",
       msg2: PRIVATE_KEY_PATH,
     });

--- a/packages/scripts/src/commands/deployment/compile.ts
+++ b/packages/scripts/src/commands/deployment/compile.ts
@@ -5,7 +5,7 @@ import { IDeploymentConfig } from "data-models";
 import fs from "fs-extra";
 import path from "path";
 import { ROOT_DIR } from "../../paths";
-import { logError } from "../../utils";
+import { Logger } from "../../utils";
 import { DEPLOYMENT_CONFIG_VERSION, IDeploymentConfigJson } from "./common";
 import { convertFunctionsToStrings } from "./utils";
 
@@ -59,7 +59,7 @@ export async function loadTSFileDefaultExport(input: string) {
     return res.default;
   } catch (error) {
     console.error(error);
-    logError({ msg1: "Could not compile", msg2: input });
+    Logger.error({ msg1: "Could not compile", msg2: input });
   }
 }
 

--- a/packages/scripts/src/commands/deployment/create.ts
+++ b/packages/scripts/src/commands/deployment/create.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import fs from "fs-extra";
 import path from "path";
 import { DEPLOYMENTS_PATH } from "../../paths";
-import { logError, logOutput, logWarning, promptInput, promptOptions } from "../../utils";
+import { Logger, logOutput, logWarning, promptInput, promptOptions } from "../../utils";
 import type { IDeploymentConfigJson } from "./common";
 import { DeploymentSet } from "./set";
 import generateDefaultConfig from "./templates/config.default";
@@ -130,7 +130,7 @@ export function listValidDeployments() {
 
 function writeConfig(targetConfigFile: string, configTs: string) {
   if (fs.existsSync(targetConfigFile)) {
-    logError({ msg1: "Deployment already exists", msg2: targetConfigFile });
+    Logger.error({ msg1: "Deployment already exists", msg2: targetConfigFile });
   }
   fs.ensureDirSync(path.dirname(targetConfigFile));
   fs.writeFileSync(targetConfigFile, configTs);
@@ -147,7 +147,7 @@ function writeGitIgnore(targetFile: string) {
   ];
   const gitIgnoreTxt = ignoredPaths.join("\n");
   if (fs.existsSync(targetFile)) {
-    logError({ msg1: "Gitignore file already exists", msg2: targetFile });
+    Logger.error({ msg1: "Gitignore file already exists", msg2: targetFile });
   }
   fs.writeFileSync(targetFile, gitIgnoreTxt);
 }

--- a/packages/scripts/src/commands/deployment/set.ts
+++ b/packages/scripts/src/commands/deployment/set.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import path from "path";
 import { DEPLOYMENTS_PATH, ROOT_DIR } from "../../paths";
 import { promptOptions, logOutput, logWarning } from "../../utils";
-import { getActiveDeployment } from "./get";
+import { ActiveDeployment } from "./get";
 import { loadDeploymentJson } from "./utils";
 
 const program = new Command("set");
@@ -74,7 +74,7 @@ export class DeploymentSet {
       .filter((d) => d.isDirectory())
       .map((d) => d.name)
       .filter((name) => fs.existsSync(path.resolve(DEPLOYMENTS_PATH, name, "config.ts")));
-    const currentDeploymentName = getActiveDeployment({
+    const currentDeploymentName = ActiveDeployment.get({
       ignoreMissing: true,
       skipRecompileCheck: true,
     })?.name;

--- a/packages/scripts/src/commands/deployment/utils.ts
+++ b/packages/scripts/src/commands/deployment/utils.ts
@@ -1,6 +1,6 @@
 import fs, { statSync } from "fs-extra";
 import path from "path";
-import { logError } from "../../utils";
+import { Logger } from "../../utils";
 import chalk from "chalk";
 import { compileDeploymentTSSync } from "./compile";
 import { DEPLOYMENT_CONFIG_VERSION, IDeploymentConfigJson } from "./common";
@@ -20,7 +20,7 @@ export function loadDeploymentJson(
   const tsPath = path.join(workspacePath, "config.ts");
   const jsonPath = path.join(workspacePath, "config.json");
   if (!fs.existsSync(tsPath)) {
-    logError({ msg1: "Config file not found", msg2: tsPath, logOnly: true });
+    Logger.error({ msg1: "Config file not found", msg2: tsPath, logOnly: true });
     process.exit(1);
   }
 
@@ -38,7 +38,7 @@ export function loadDeploymentJson(
   }
   // Otherwise attempt compile the ts to json and retry (exiting if already retry)
   if (options.isRetryCheck) {
-    logError({ msg1: "Failed to compile", msg2: tsPath, logOnly: true });
+    Logger.error({ msg1: "Failed to compile", msg2: tsPath, logOnly: true });
     process.exit(1);
   } else {
     const folderName = path.dirname(tsPath).split(path.sep).pop();

--- a/packages/scripts/src/commands/workflow/run.ts
+++ b/packages/scripts/src/commands/workflow/run.ts
@@ -6,8 +6,8 @@ import path from "path";
 import { Command } from "commander";
 import { IDeploymentWorkflows, IWorkflow, WORKFLOW_DEFAULTS } from "data-models";
 import ALL_TASKS from "../../tasks";
-import { logError, logProgramHelp, pad, promptOptions } from "../../utils";
-import { getActiveDeployment } from "../deployment/get";
+import { Logger, logProgramHelp, pad, promptOptions } from "../../utils";
+import { ActiveDeployment } from "../deployment/get";
 import type { IDeploymentConfigJson } from "../deployment/common";
 
 const program = new Command("run");
@@ -53,7 +53,7 @@ export class WorkflowRunnerClass {
     // load default workflows
     this.workflows = WORKFLOW_DEFAULTS;
     // load custom workflows
-    this.config = getActiveDeployment({ ignoreMissing: true });
+    this.config = ActiveDeployment.get({ ignoreMissing: true });
     const { workflow, _workspace_path } = this.config as any;
     const customWorkflowFiles = [];
     if (workflow) {
@@ -101,7 +101,7 @@ export class WorkflowRunnerClass {
       const available = Object.keys(this.workflows).join(", ");
       const msg1 = `Workflow not found: ${name}`;
       const msg2 = `Available workflows: ${available}`;
-      logError({ msg1, msg2 });
+      Logger.error({ msg1, msg2 });
     }
     // If args passed and first arg matches a child workflow name replace child workflow and args
     const childWorkflowName = args[0];
@@ -155,7 +155,7 @@ export class WorkflowRunnerClass {
         const output = await step.function(context);
         this.activeWorkflow[step.name].output = output;
         // re-evaluate active deployment in case step changed it
-        this.config = getActiveDeployment({ ignoreMissing: true });
+        this.config = ActiveDeployment.get({ ignoreMissing: true });
       } else {
         console.log(chalk.gray("skipped"));
       }

--- a/packages/scripts/src/tasks/providers/android.ts
+++ b/packages/scripts/src/tasks/providers/android.ts
@@ -2,11 +2,11 @@ import * as path from "path";
 import { Options, run } from "cordova-res";
 import fs from "fs";
 import { ROOT_DIR } from "../../paths";
-import { logError } from "../../utils";
+import { Logger } from "../../utils";
 
 const set_splash_image = async (splashAssetPath: string) => {
   if (!fs.existsSync(splashAssetPath)) {
-    return logError({
+    return Logger.error({
       msg1: "Splash source image not found",
       msg2: `A source .png file is required to generate a splash screen. No asset was found at the path supplied in the deployment config: ${splashAssetPath}.`,
     });
@@ -46,7 +46,7 @@ const set_launcher_icon = async (options: {
   if (fs.existsSync(iconAssetPath)) {
     iconSources.push(iconAssetPath);
   } else {
-    return logError({
+    return Logger.error({
       msg1: "Icon source asset not found",
       msg2: `A source .png file is required to be used as a fall back for when the device's android version does not support adaptive icons. No asset was found at the path supplied in the deployment config: ${iconAssetPath}.`,
     });

--- a/packages/scripts/src/tasks/providers/subtitles.ts
+++ b/packages/scripts/src/tasks/providers/subtitles.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import * as path from "path";
 import parser from "subtitles-parser-vtt";
 import { ROOT_DIR } from "../../paths";
-import { recursiveFindByExtension, logError, logOutput, promptOptions } from "../../utils";
+import { recursiveFindByExtension, Logger, logOutput, promptOptions } from "../../utils";
 
 // This is an interim solution for manually generating translated .vtt files,
 // to be used pending reworking the translations repo/pipeline to handle assets more generally
@@ -43,7 +43,7 @@ const translateAllVttFilesAndSave = async (
     });
     console.log(outputFiles);
   } else {
-    logError({
+    Logger.error({
       msg1: "No files generated",
     });
   }
@@ -67,7 +67,7 @@ const findVttFiles = (sourceFolder, subpath?: string) => {
   const folderPath = subpath ? path.join(sourceFolder, subpath) : sourceFolder;
   const result = recursiveFindByExtension(folderPath, "vtt");
   if (!result.length) {
-    logError({
+    Logger.error({
       msg1: "No files found",
       msg2: "No VTT files found in target folder",
     });
@@ -94,7 +94,7 @@ const translateJson = async (
     const translatedString = translationStrings[cue.text];
     if (translatedString === undefined) {
       console.log(chalk.grey(translationStringsPath));
-      return logError({
+      return Logger.error({
         msg1: `No [${languageCode}] translations found for cue text`,
         msg2: cue.text,
       });

--- a/packages/scripts/src/tasks/providers/translate.ts
+++ b/packages/scripts/src/tasks/providers/translate.ts
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "fs-extra";
 import { spawnSync } from "child_process";
 import { WorkflowRunner } from "../../commands/workflow/run";
-import { logError, recursiveFindByExtension } from "../../utils";
+import { Logger, recursiveFindByExtension } from "../../utils";
 
 /**
  * Apply translations to sheets
@@ -26,7 +26,7 @@ const apply = (options: { inputFolder: string }) => {
     shell: true,
   });
   if (status === 1) {
-    logError({ msg1: "Translations failed", msg2: stderr.toString() });
+    Logger.error({ msg1: "Translations failed", msg2: stderr.toString() });
   }
   // Returns path to both compiled strings and translated sheets
   return {

--- a/packages/scripts/src/utils/logging.utils.ts
+++ b/packages/scripts/src/utils/logging.utils.ts
@@ -110,7 +110,7 @@ export function createChildLogger(meta = {}) {
 }
 
 /** Record a 2-line error message in a box with additional optional logging and exit */
-export function logError(opts: Partial<ILogOptions> = {}) {
+function error(opts: Partial<ILogOptions> = {}) {
   const { msg1, msg2, error, logOnly } = { ...defaultLog, ...opts };
   console.log(
     boxen(
@@ -130,6 +130,13 @@ export function logError(opts: Partial<ILogOptions> = {}) {
     process.exit(1);
   }
 }
+/**
+ * HACK - export error within a Logger const to allow easier mocking in tests
+ * https://github.com/jasmine/jasmine/issues/1414
+ */
+export const Logger = {
+  error,
+};
 
 /** Display an output message in a blue box with 2 lines of text */
 export function logOutput(opts: Partial<ILogOptions> = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12646,6 +12646,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-jasmine@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "eslint-plugin-jasmine@npm:4.1.3"
+  checksum: 845f25626934bb372b0d013216e1d5cbf8c4069404cf042b7325ee78e60033641d6ca397b341d7ba29ae9f01a5c22718a438bbaa4b90914240cde4b86ea112c8
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-jsdoc@npm:35.4.0":
   version: 35.4.0
   resolution: "eslint-plugin-jsdoc@npm:35.4.0"
@@ -14243,6 +14250,7 @@ __metadata:
     eslint: ^8.12.0
     eslint-config-prettier: ^8.3.0
     eslint-plugin-import: 2.23.4
+    eslint-plugin-jasmine: ^4.1.3
     eslint-plugin-jsdoc: 35.4.0
     eslint-plugin-prefer-arrow: 1.2.3
     extract-math: ^1.2.3


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
The build test action is currently failing on #1771, due to some unit tests that were broken in #1763. The broken tests weren't detected due to a quirk where the unit tests weren't being run if a preview deployment is being created (had assumed the deployment preview would run the same checks that the standalone build test does, however that is not the case)

This PR fixes the underlying issue with the tests, namely how due to some updates in ts-node and deployment configs the tests can't add mock functions for anything that is exported (needs to be refactored either into a class or nested in another constant)
`https://github.com/jasmine/jasmine/issues/1414`

It also adds an extra set of linting rules to catch issues with tests (namely if focused tests are set with keywords like `fit`, which omits the rest of the testbase). It also adds a lint check to the build-test ci pipeline and enforces it even when a deployment preview is being used

## Review Notes
The only real changes are two functions which we sometimes need to mock in our tests, namely `getActiveDeployment` which now is wrapped as `ActiveDeployment.get` and `logError` which is now wrapped as `Logger.error`. So most the file changes are just making those replacements

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
