### PR TITLE
chore: add gdrive empty folder deletion

### DIFF
--- a/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
+++ b/packages/@idemsInternational/gdrive-tools/src/commands/download.ts
@@ -16,6 +16,7 @@ import {
   generateFolderFlatMapStats,
   ILocalFileWithStats,
   logProgramHelp,
+  cleanupEmptyFolders,
 } from "../utils";
 import { authorizeGDrive } from "./authorize";
 
@@ -214,6 +215,8 @@ export class GDriveDownloader {
     logUpdate.done();
     queue.start();
     await queue.onIdle();
+    // Remove empty folders left after deletions
+    cleanupEmptyFolders(this.options.outputPath);
     // Update logs
     const actionsLogPath = path.resolve(PATHS.LOGS_DIR, `${this.options.logName}.json`);
     console.log(chalk.gray(actionsLogPath));
@@ -242,6 +245,7 @@ export class GDriveDownloader {
         // add to hashmap for use in local-server comparison
         const cacheRelativePath = getRelativeLocalPath(serverFile);
         serverFilesHashmap[cacheRelativePath] = serverFile;
+        const cacheFile = localFilesHashmap[cacheRelativePath];
 
         // run a regex test for anything ending .abc(d)
         // gdrive keeps duplicate open office formats of gsheets without extension
@@ -251,15 +255,21 @@ export class GDriveDownloader {
           output.ignored.push(serverFile);
           return;
         }
+        // Apply any server filter functions, removing files that already exist and ignoring
+        // files that do not
         if (filterFn) {
           const included = filterFn(serverFile);
           if (!included) {
-            output.ignored.push(serverFile);
-            return;
+            if (cacheFile) {
+              output.deleted.push({ folderPath: cacheRelativePath });
+              return;
+            } else {
+              output.ignored.push(serverFile);
+              return;
+            }
           }
         }
 
-        const cacheFile = localFilesHashmap[cacheRelativePath];
         if (cacheFile) {
           const isSame = this.isServerFileSameAsLocalFile(serverFile, cacheFile);
 

--- a/packages/@idemsInternational/gdrive-tools/src/utils/file.utils.ts
+++ b/packages/@idemsInternational/gdrive-tools/src/utils/file.utils.ts
@@ -86,3 +86,24 @@ export function getFileMD5Checksum(filePath: string) {
   const checksum = hash.digest("hex");
   return checksum;
 }
+
+/**
+ * Recursively remove any empty folders
+ * (duplicate from scripts file-utils)
+ */
+export const cleanupEmptyFolders = (folder: string) => {
+  if (!fs.existsSync(folder)) return;
+  if (!fs.statSync(folder).isDirectory()) return;
+  let files = fs.readdirSync(folder);
+
+  if (files.length > 0) {
+    files.forEach((file) => cleanupEmptyFolders(path.join(folder, file)));
+    // Re-evaluate files; after deleting subfolders we may have an empty parent
+    // folder now.
+    files = fs.readdirSync(folder);
+  }
+
+  if (files.length === 0) {
+    fs.rmdirSync(folder);
+  }
+};

--- a/packages/scripts/src/tasks/providers/gdrive.ts
+++ b/packages/scripts/src/tasks/providers/gdrive.ts
@@ -22,10 +22,14 @@ const authorize = () => {
  * @returns path to output files
  * }
  */
-const download = (options: { folderId: string }) => {
-  const { folderId } = options;
+const download = (options: { folderId: string; filterFn?: any }) => {
+  const { folderId, filterFn } = options;
   const outputPath = getOutputFolder(folderId);
-  const dlArgs = `--folder-id ${folderId} --output-path "${outputPath}" --log-name "${folderId}.log"`;
+  let dlArgs = `--folder-id ${folderId} --output-path "${outputPath}" --log-name "${folderId}.log"`;
+  if (filterFn) {
+    const filterFnBase64 = Buffer.from(filterFn.toString()).toString("base64");
+    dlArgs += ` --filter-function-64 "${filterFnBase64}"`;
+  }
   gdriveExec("download", dlArgs);
   return outputPath;
 };


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Minor PR (extracted from #1755), to add additional housekeeping to gdrive download scripts, namely:
- Delete any downloaded files that are no longer included in the deployment (previously would keep download and just omit on copy)
- Clear any empty folders
- Add support for passing filter functions to gdrive download script (included already in deployment config but never implemented)

## Review Notes
Shouldn't have any real knock-ons anywhere, if you had previously synced lots of files into a workspace there might be some lingering folders that get removed from the tasks cache (e.g. `.idems_app\deployments\plh_global\tasks\gdrive\outputs\1dp9QAQ84m8pm0IBQTSPXe1ramyynKPNn`).

When running a sync myself saw no changes to the files actually populated into the main app, and when repeating sync saw no new files to download (all from cache)


## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
