### PR TITLE
feat: add support for deployment encrypted files

### DIFF
--- a/packages/data-models/workflows/deployment.workflows.ts
+++ b/packages/data-models/workflows/deployment.workflows.ts
@@ -46,6 +46,15 @@ const workflows: IDeploymentWorkflows = {
           },
         ],
       },
+      encrypt: {
+        label: "Encrypt deployment config",
+        steps: [
+          {
+            name: "encrypt",
+            function: async ({ tasks }) => tasks.encryption.encrypt(),
+          },
+        ],
+      },
     },
   },
 };

--- a/packages/data-models/workflows/workflow.model.ts
+++ b/packages/data-models/workflows/workflow.model.ts
@@ -1,7 +1,7 @@
 // NOTE - this import can lead to build issues
 // https://www.codejam.info/2021/10/typescript-cannot-write-file-overwrite-input.html
+import { IDeploymentConfigJson } from "scripts/src/commands/deployment/common";
 import type { ITasks } from "scripts/src/tasks";
-import type { IDeploymentConfig } from "../deployment.model";
 
 export interface IWorkflowContext {
   [step_name: string]: { output: any };
@@ -13,7 +13,7 @@ interface IWorkflowStep {
   function: (context: IWorkflowStepContext) => Promise<any>;
 }
 interface IWorkflowStepContext {
-  config: IDeploymentConfig;
+  config: IDeploymentConfigJson;
   workflow: IWorkflowContext;
   tasks: ITasks;
   /** Positional args passed to workflow script */

--- a/packages/scripts/src/tasks/index.ts
+++ b/packages/scripts/src/tasks/index.ts
@@ -1,6 +1,7 @@
 import android from "./providers/android";
 import appData from "./providers/appData";
 import deployment from "./providers/deployment";
+import encryption from "./providers/encryption";
 import file from "./providers/file";
 import gdrive from "./providers/gdrive";
 import subtitles from "./providers/subtitles";
@@ -18,6 +19,7 @@ const ALL_TASKS = {
   android,
   appData,
   deployment,
+  encryption,
   file,
   gdrive,
   subtitles,

--- a/packages/scripts/src/tasks/providers/encryption.ts
+++ b/packages/scripts/src/tasks/providers/encryption.ts
@@ -1,0 +1,137 @@
+import chalk from "chalk";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "fs-extra";
+import NodeRSA from "node-rsa";
+import { basename, resolve } from "path";
+import { WorkflowRunner } from "../../commands/workflow/run";
+import { Logger, logOutput, promptConfirmation } from "../../utils";
+
+const ENCRYPTED_SUFFIX = "crypt";
+const ENCRYPTED_FOLDER_NAME = "encrypted";
+const IGNORE_LIST = ["*.crypt", ".gitignore", "public.key"];
+
+class EncryptionProvider {
+  private publicKeyPath: string;
+  private privateKeyPath: string;
+  private publicKey: NodeRSA;
+
+  public async encrypt() {
+    const { _workspace_path } = WorkflowRunner.config;
+    const folderPath = resolve(_workspace_path, ENCRYPTED_FOLDER_NAME);
+    await this.setupEncryptionFolders(folderPath);
+    // Get list of files requiring encryption
+    let filesToEncrypt = [];
+    const fileNames = readdirSync(folderPath, { withFileTypes: true })
+      .filter((f) => f.isFile())
+      .map((f) => f.name);
+    for (const filename of fileNames) {
+      const filePath = resolve(folderPath, filename);
+      if (this.shouldEncryptFile(filePath)) {
+        filesToEncrypt.push(filePath);
+      }
+    }
+    // Handle encryption
+    for (const filePath of filesToEncrypt) {
+      this.encryptFile(filePath);
+    }
+    if (filesToEncrypt.length > 0) {
+      logOutput({ msg1: `${filesToEncrypt.length} files encrypted`, msg2: folderPath });
+    } else {
+      console.log(chalk.gray("Files already encrypted"));
+    }
+  }
+
+  public async decrypt(folderPath: string) {
+    await this.setupEncryptionFolders(folderPath);
+  }
+
+  private encryptFile(filePath: string) {
+    if (!this.publicKey) {
+      const publicKeyData = readFileSync(this.publicKeyPath);
+      this.publicKey = new NodeRSA().importKey(publicKeyData, "public");
+    }
+    const decryptedData = readFileSync(filePath);
+    const encryptedData = this.publicKey.encrypt(decryptedData);
+    writeFileSync(`${filePath}.${ENCRYPTED_SUFFIX}`, encryptedData);
+  }
+
+  private async setupEncryptionFolders(folderPath: string) {
+    if (!existsSync(folderPath)) {
+      if (!existsSync(folderPath)) {
+        const shouldCreate = await promptConfirmation(
+          "No encrypted folder exists\nWould you like to create one?"
+        );
+        if (shouldCreate) {
+          this.createEncryptionFolder(folderPath);
+          generateEncryptionKeys(folderPath);
+        } else {
+          process.exit(0);
+        }
+      }
+    }
+    this.privateKeyPath = resolve(folderPath, "private.key");
+    if (!existsSync(this.privateKeyPath)) {
+      const shouldCreate = await promptConfirmation(
+        "No encryption key found\nWould you like to create one?"
+      );
+      if (shouldCreate) {
+        generateEncryptionKeys(folderPath);
+      } else {
+        process.exit(0);
+      }
+    }
+    this.publicKeyPath = resolve(folderPath, "public.key");
+    if (!existsSync(this.publicKeyPath)) {
+      // TODO - handle case where private key exists but public missing (regenerate?)
+      Logger.error({ msg1: "Public key not found, cannot continue", msg2: this.publicKeyPath });
+    }
+  }
+
+  private shouldEncryptFile(filePath: string) {
+    const filename = basename(filePath);
+    if (IGNORE_LIST.includes(filename)) return false;
+    if (filename === "private.key") return false;
+    if (filename.endsWith(`.${ENCRYPTED_SUFFIX}`)) return false;
+    // Check if encrypted version already exists and up-to-date
+    const encryptedFilePath = `${filePath}.${ENCRYPTED_SUFFIX}`;
+    if (existsSync(encryptedFilePath)) {
+      return statSync(encryptedFilePath).mtime.getTime() === statSync(filePath).mtime.getTime();
+    }
+    return true;
+  }
+
+  private createEncryptionFolder(folderPath: string) {
+    mkdirSync(folderPath);
+    const gitIgnorePath = resolve(folderPath, ".gitignore");
+    const gitignoreTemplate = `
+      *.*
+      ${IGNORE_LIST.map((name) => `!${name}`).join("\n")}
+      `
+      .replace(/ /g, "")
+      .trim();
+    writeFileSync(gitIgnorePath, gitignoreTemplate);
+  }
+}
+
+/*************************************************************************
+ * Utils
+ *************************************************************************/
+
+function generateEncryptionKeys(folderPath: string) {
+  const key = new NodeRSA({ b: 512 });
+  const publicKeyPath = resolve(folderPath, "public.key");
+  const privateKeyPath = resolve(folderPath, "private.key");
+  writeFileSync(publicKeyPath, key.exportKey("public"));
+  writeFileSync(privateKeyPath, key.exportKey("private"));
+  logOutput({
+    msg1: "New encryption key created\nYou should keep a backup of this and only share with trusted collaborators",
+    msg2: privateKeyPath,
+  });
+}
+export default new EncryptionProvider();

--- a/packages/scripts/src/utils/cli-utils.ts
+++ b/packages/scripts/src/utils/cli-utils.ts
@@ -19,6 +19,11 @@ export async function promptInput(message: string) {
   const res = await inquirer.prompt([{ type: "input", message, name }]);
   return res[name];
 }
+export async function promptConfirmation(message: string, defaultValue = true) {
+  const name = "confirm";
+  const res = await inquirer.prompt([{ type: "confirm", name, message, default: defaultValue }]);
+  return res[name] as boolean;
+}
 export function pad(str: string | number, chars: number) {
   str = `${str}`;
   const padChars = Math.max(chars - str.length + 1, 0);


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
Add supports for encrypted files within a designated deployment folder (`./encrypted`), and workflow methods to encrypt and decrypt data

An example use-case for this is including service accounts with a deployment that can automatically sync a specific set of google sheets

- [x] `deployment encrypt` workflow
- [ ] `deployment decrypt` workflow
- [x] Utilities to help process of generating new encrypted folder and private key
- [ ] Documentation  
- [ ] Refactor legacy config decrypt methods

**To Discuss**
- File naming conventions (couldn't find standards so opting for files ending `.crypt` (previously `.enc`))
- Clarify potential use cases or questions

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
