### PR TITLE
feat: reschedule campaign notifications when the highlighted task group changes

### DIFF
--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -185,7 +185,7 @@ export class CampaignService extends AsyncServiceBase {
    * Check all campaigns for those with notification schedules and evaluate
    * any notifications requiring scheduling
    */
-  private async scheduleCampaignNotifications() {
+  public async scheduleCampaignNotifications() {
     const scheduled: IScheduledNotificationsHashmap = {};
     for (const campaign of Object.values(this.scheduledCampaigns)) {
       scheduled[campaign.id] = {};

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -5,6 +5,7 @@ import { TemplateBaseComponent } from "../base";
 import { TemplateFieldService } from "../../services/template-field.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { IProgressStatus } from "src/app/shared/services/task/task.service";
+import { CampaignService } from "src/app/feature/campaign/campaign.service";
 
 @Component({
   selector: "plh-task-progress-bar",
@@ -26,7 +27,8 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   constructor(
     private taskService: TaskService,
     private templateFieldService: TemplateFieldService,
-    private appDataService: AppDataService
+    private appDataService: AppDataService,
+    private campaignService: CampaignService
   ) {
     super();
   }
@@ -79,7 +81,13 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
         this.progressStatusChange.emit(this.progressStatus);
       }
     }
-    this.taskService.evaluateHighlightedTaskGroup();
+    const [previousHighlightedTaskGroup, newHighlightedTaskGroup] =
+      this.taskService.evaluateHighlightedTaskGroup();
+    // HACK - reschedule campaign notifications when the highlighted task group has changed,
+    // in order to handle any that are conditional on the highlighted task group
+    if (previousHighlightedTaskGroup !== newHighlightedTaskGroup) {
+      this.campaignService.scheduleCampaignNotifications();
+    }
   }
 
   async setTaskGroupCompletedStatus(taskGroupCompletedField: string, isCompleted: boolean) {

--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { TemplateFieldService } from "../../components/template/services/template-field.service";
 import { AppDataService } from "../data/app-data.service";
+import { CampaignService } from "src/app/feature/campaign/campaign.service";
 import { arrayToHashmap } from "../../utils";
 import { AsyncServiceBase } from "../asyncService.base";
 
@@ -16,7 +17,8 @@ export class TaskService extends AsyncServiceBase {
   taskGroupsHashmap: Record<string, any> = {};
   constructor(
     private templateFieldService: TemplateFieldService,
-    private appDataService: AppDataService
+    private appDataService: AppDataService,
+    private campaignService: CampaignService
   ) {
     super("Task");
     this.registerInitFunction(this.initialise);
@@ -73,6 +75,9 @@ export class TaskService extends AsyncServiceBase {
           this.highlightedTaskFieldName,
           highestPriorityTaskGroup.id
         );
+        // HACK - reschedule campaign notifications when the highlighted task group has changed,
+        // in order to handle any that are conditional on the highlighted task group
+        this.campaignService.scheduleCampaignNotifications();
       }
       console.log("[HIGHLIGHTED TASK GROUP] - ", highestPriorityTaskGroup.id);
     }

--- a/src/app/shared/services/task/task.service.ts
+++ b/src/app/shared/services/task/task.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from "@angular/core";
 import { TemplateFieldService } from "../../components/template/services/template-field.service";
 import { AppDataService } from "../data/app-data.service";
-import { CampaignService } from "src/app/feature/campaign/campaign.service";
 import { arrayToHashmap } from "../../utils";
 import { AsyncServiceBase } from "../asyncService.base";
 
@@ -17,8 +16,7 @@ export class TaskService extends AsyncServiceBase {
   taskGroupsHashmap: Record<string, any> = {};
   constructor(
     private templateFieldService: TemplateFieldService,
-    private appDataService: AppDataService,
-    private campaignService: CampaignService
+    private appDataService: AppDataService
   ) {
     super("Task");
     this.registerInitFunction(this.initialise);
@@ -70,16 +68,12 @@ export class TaskService extends AsyncServiceBase {
           return highestPriority.number < taskGroup.number ? highestPriority : taskGroup;
         }
       );
-      if (highestPriorityTaskGroup.id !== previousHighlightedTaskGroup) {
-        this.templateFieldService.setField(
-          this.highlightedTaskFieldName,
-          highestPriorityTaskGroup.id
-        );
-        // HACK - reschedule campaign notifications when the highlighted task group has changed,
-        // in order to handle any that are conditional on the highlighted task group
-        this.campaignService.scheduleCampaignNotifications();
+      const newHighlightedTaskGroup = highestPriorityTaskGroup.id;
+      if (newHighlightedTaskGroup !== previousHighlightedTaskGroup) {
+        this.templateFieldService.setField(this.highlightedTaskFieldName, newHighlightedTaskGroup);
       }
-      console.log("[HIGHLIGHTED TASK GROUP] - ", highestPriorityTaskGroup.id);
+      console.log("[HIGHLIGHTED TASK GROUP] - ", newHighlightedTaskGroup);
+      return [previousHighlightedTaskGroup, newHighlightedTaskGroup];
     }
   }
 
@@ -123,7 +117,7 @@ export class TaskService extends AsyncServiceBase {
       }
     });
     // Re-evaluate highlighted task group
-    this.evaluateHighlightedTaskGroup();
+    return this.evaluateHighlightedTaskGroup();
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Offers a workaround for #1799 – upon the highlighted task group (aka "highlighted module") changing, all campaign notifications will be re-evaluated. This ensures that the scheduled status of any campaign notifications that depend on the current highlighted task group is up to date.

## Git Issues

#1799 should be left open as the requested feature is still desirable
