### PR TITLE
Improve contrast on background-tool shades

### DIFF
--- a/src/theme/deployment/components/_display-group.scss
+++ b/src/theme/deployment/components/_display-group.scss
@@ -1,13 +1,28 @@
-$background-banner-primary: var(--display-group-background-banner-primary, var(--gradient-primary-light-vertical));
-$background-banner-secondary: var(--display-group-background-banner-secondary, var(--gradient-yellow-vertical));
-$background-tool-1: var(--display-group-background-tool-1, var(--ion-color-secondary-400));
-$background-tool-2: var(--display-group-background-tool-2, var(--ion-color-secondary-500));
+$background-banner-primary: var(
+  --display-group-background-banner-primary,
+  var(--gradient-primary-light-vertical)
+);
+$background-banner-secondary: var(
+  --display-group-background-banner-secondary,
+  var(--gradient-yellow-vertical)
+);
+$background-tool-1: var(--display-group-background-tool-1, var(--ion-color-secondary-500));
+$background-tool-2: var(--display-group-background-tool-2, var(--ion-color-secondary-600));
 $background-tool-3: var(--display-group-background-tool-3, var(--ion-color-primary-600));
 $background-tool-4: var(--display-group-background-tool-4, var(--ion-color-primary-700));
 $background-tool-5: var(--display-group-background-tool-5, var(--ion-color-primary));
-$background-home-light: var(--display-group-background-home-light, var(--gradient-primary-light-horizontal));
-$background-home-mid: var(--display-group-background-home-mid, var(--gradient-primary-mid-horizontal));
-$background-home-dark: var(--display-group-background-home-dark, var(--gradient-primary-dark-horizontal));
+$background-home-light: var(
+  --display-group-background-home-light,
+  var(--gradient-primary-light-horizontal)
+);
+$background-home-mid: var(
+  --display-group-background-home-mid,
+  var(--gradient-primary-mid-horizontal)
+);
+$background-home-dark: var(
+  --display-group-background-home-dark,
+  var(--gradient-primary-dark-horizontal)
+);
 
 // background colours
 plh-tmpl-display-group .display-group-wrapper[data-param-style~="light"] {


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
The graphic designer requested the orange shades in the "Essential Tools" (which seem to use the background-tool" colours) to be a bit darker, to increase contrast with the white text and thereby improve legibility of the text. 

Before-and-after screenshot: 
<img width="958" alt="image" src="https://user-images.githubusercontent.com/74557272/220692185-5d7db51c-a746-45dc-aac2-6720e528b86f.png">

Specification from designer: 
<img width="958" alt="image" src="https://user-images.githubusercontent.com/74557272/220692367-a773bd1d-3c6c-4f54-b4be-b2e6e1e86c82.png">
