### PR TITLE
Fix: infinite errors thrown when entering the app through a notification

### DIFF
--- a/src/app/feature/notification/pages/notifications-debug/components/notification-debug-interacted-row.component.ts
+++ b/src/app/feature/notification/pages/notifications-debug/components/notification-debug-interacted-row.component.ts
@@ -10,9 +10,9 @@ import { ILocalNotificationInteractionDB } from "src/app/shared/services/notific
           <div style="flex:1">
             <div>
               <div>
-                {{ notification.notification_meta.title }}
+                {{ notification.notification_meta?.title }}
               </div>
-              <div class="info-text">{{ notification.notification_meta.id }}</div>
+              <div class="info-text">{{ notification.notification_meta?.id }}</div>
             </div>
           </div>
           <div>
@@ -31,7 +31,7 @@ import { ILocalNotificationInteractionDB } from "src/app/shared/services/notific
         <div class="row-content">
           <div style="flex: 1; margin-right: 8px">
             <div class="divider"></div>
-            <div>{{ notification.notification_meta.text }}</div>
+            <div>{{ notification.notification_meta?.text }}</div>
           </div>
           <div style="text-align: right">
             <div class="divider"></div>

--- a/src/app/shared/services/notification/local-notification-interaction.service.ts
+++ b/src/app/shared/services/notification/local-notification-interaction.service.ts
@@ -62,9 +62,11 @@ export class LocalNotificationInteractionService extends AsyncServiceBase {
       )
       .subscribe(async (action) => {
         const { actionId, notification, inputValue } = action;
+        const { id, text, title, campaign_id } = notification.extra;
         const update: Partial<ILocalNotificationInteraction> = {
           action_id: actionId,
           action_recorded_timestamp: generateTimestamp(),
+          notification_meta: { id, text, title, campaign_id },
         };
         if (inputValue) {
           update.action_meta = { inputValue };


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Interacting with a notification whilst on the `notifications` page of the app would cause an error to be thrown repeatedly and indefinitely. This was, I think, only an issue when running in browser, and only applies when the user has the notifications page open (which is only available in dev mode), so is not an important issue.

This PR provides a workaround so that sent notifications appear correctly when interacting with them from the `/notifications` page.

## Dev notes

I believe this is just an issue on web and that this is a workaround.

Previously, interacting with a notification caused the notification to be saved to the database, however the `notification_meta` was not saved, as the `sessionNotifications$` observable did not update to trigger the `notification_meta` being saved for all session notifications. This meant that the `notification_meta` could not be read off by the `notification-debug-interacted-row` component, throwing the errors.
In the `local-notification-service`, there's a note that the "triggers don't appear to be working on web", which I believe is the cause of the issue (line 363 should mean that the `notification_meta` is saved at the next notification defer cycle, i.e. every 5000ms or on refresh)
<img width="700" alt="Screenshot 2023-03-07 at 13 29 02" src="https://user-images.githubusercontent.com/64838927/223436035-75477175-ca40-4f55-b950-674cf26b5fe5.png">

Therefore this PR offers a workaround by saving the `notification_meta` at the time of interacting with the notification.

## Git Issues

Closes #1805 

## Screenshots/Videos

The notifications page showing an interacted notification under "Sent Notifications" immediately.
(My screen recorder suppresses notifications, so interacting with the notification happens off-screen in this recording, after 1 second)

https://user-images.githubusercontent.com/64838927/223440091-d611aec2-3a50-466b-8f3f-cc3d0b70747d.mov


