### PR TITLE
chore: enable in-app updates for plh and wash deployments

### DIFF
--- a/.idems_app/deployments/plh/config.ts
+++ b/.idems_app/deployments/plh/config.ts
@@ -30,5 +30,7 @@ config.app_config.NOTIFICATION_DEFAULTS.text = "You have a new message from Pare
 config.app_config.APP_SKINS.defaultSkinName = SKINS.modular.name;
 config.app_config.APP_SKINS.available = [SKINS.modular, SKINS.weekly_workshop];
 config.app_config.APP_THEMES.available = ["default", "professional"];
+config.app_config.APP_UPDATES.enabled = true
+config.app_config.APP_UPDATES.completeUpdateTemplate = "app_update_complete"
 
 export default config;

--- a/.idems_app/deployments/wash/config.ts
+++ b/.idems_app/deployments/wash/config.ts
@@ -31,5 +31,7 @@ config.app_config.APP_SIDEMENU_DEFAULTS!.title = "WASH App";
 config.app_config.APP_HEADER_DEFAULTS!.title = "WASH App";
 config.app_config.NOTIFICATION_DEFAULTS!.title = "New message from WASH App";
 config.app_config.NOTIFICATION_DEFAULTS!.text = "You have a new message from WASH App";
+config.app_config.APP_UPDATES.enabled = true
+config.app_config.APP_UPDATES.completeUpdateTemplate = "app_update_complete"
 
 export default config;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

This enables the opt-in "in-app updates" feature (introduced in PR #1803) for the deployments `plh` (and therefore its children) and `wash`.

I've also updated the respective `launch_actions` templates for [plh](https://docs.google.com/spreadsheets/d/1MJzzdTYDZg0VkS5zxrXY4lKV5Oi954pw1sIVJUOOzWM/edit#gid=1876097204) and [wash](https://docs.google.com/spreadsheets/d/1EBMsJnyEEbNZPwkwHzdjm3f5av8kNethAGMpTJ7HOC0/edit#gid=1876097204), but I have not included a content sync in this PR.

The template that will be shown as a pop-up when the user has finished downloading an update is [here for plh](https://docs.google.com/spreadsheets/d/1H6VhPmnxOIV5tw9p4XbVYS0tfNU3M7KZzgH9GmomNPI/edit#gid=1422144003) and [here for wash](https://docs.google.com/spreadsheets/d/1EBMsJnyEEbNZPwkwHzdjm3f5av8kNethAGMpTJ7HOC0/edit#gid=317581697).

NB, as noted in the comments on PR #1809, currently changes made to a parent config do not always trigger its children's configs to be recompiled. The simplest workaround for this is to delete the child deployments' `config.json` files before running `yarn workflow deployment set`, in order to force them to be recompiled.

## Git Issues

Closes #

## Screenshots/Videos

