### PR TITLE
fix: navigation not progressing after completing w_self_care_reward with tz override

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "international.idems.plh_teens_tz"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 16015
-        versionName "0.16.15"
+        versionCode 16016
+        versionName "0.16.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.16.15",
+  "version": "0.16.16",
   "author": "IDEMS International",
   "license": "See LICENSE",
   "homepage": "https://idems.international/",

--- a/packages/app-data/sheets/template/w_self_care_reward_tz.json
+++ b/packages/app-data/sheets/template/w_self_care_reward_tz.json
@@ -9,6 +9,26 @@
       "type": "template",
       "name": "w_self_care_reward",
       "value": "w_self_care_reward",
+      "action_list": [
+        {
+          "trigger": "completed",
+          "action_id": "emit",
+          "args": [
+            "completed"
+          ],
+          "_raw": "completed | emit:completed",
+          "_cleaned": "completed | emit:completed"
+        },
+        {
+          "trigger": "uncompleted",
+          "action_id": "emit",
+          "args": [
+            "uncompleted"
+          ],
+          "_raw": "uncompleted | emit:uncompleted",
+          "_cleaned": "uncompleted | emit:uncompleted"
+        }
+      ],
       "is_override_target": true,
       "rows": [
         {


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the final "next" button on the w_self_care_reward template wasn't working.

## Git Issues

Closes #1860
