### PR TITLE
ci: add git sha to android deployment

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -36,16 +36,19 @@ jobs:
         run: |
           echo ${{github.event.inputs.build_branch}} | sed 's/.*\///'
           echo "DEPLOYMENT_NAME=$(echo ${{github.event.inputs.build_branch}} | sed 's/.*\///')" >> $GITHUB_ENV;
+          echo "SHA_SHORT=$(git rev-parse --short=6 HEAD)" >> $GITHUB_ENV
         shell: bash
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-      - name: Populate firebaseConfig.ts
+      - name: Populate environment config
         env:
           FIREBASE_CONFIG_TS: ${{ secrets.FIREBASE_CONFIG_TS }}
-        run: echo $FIREBASE_CONFIG_TS > src/environments/firebaseConfig.ts
+        run: |
+          echo "export const GIT_SHA = \"$SHA_SHORT\";" > src/environments/sha.ts
+          echo $FIREBASE_CONFIG_TS > src/environments/firebaseConfig.ts
       - name: Populate google-services.json
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}


### PR DESCRIPTION
PR Checklist

- [ ] - Latest `master` branch merged
- [ ] - PR title descriptive (can be used in release notes)

## Description
As seen in recent error logs, traces originating from android don't have stack traces containing source file mappings. This is because the deployments themselves are not tracking the github SHA on the version code as expected by the logging system (e.g. `plh_tz-0.16.16-` instead of `plh_tz-0.16.15-78f6cc`)

![image](https://user-images.githubusercontent.com/10515065/230067792-7353c88f-10ef-45a4-9c41-4ef767bbdfb3.png)

This PR attempts to fix to populate the SHA code as expected as part of CI build process. 

## Review Notes
The only question mark is whether it will assign the correct SHA for an action that has been triggered by a workflow dispatch event. Github actions can sometimes be funny with this, e.g. when triggering an action from a PR if it targets the SHA of the source branch or target branch. But should be easy enough to check post next android deployment

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
