### PR TITLE
refactor: deployment config recompile tracking

### DIFF
--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -1,5 +1,8 @@
 import type { IAppConfig } from "./appConfig";
 
+/** Update version to force recompile next time deployment set (e.g. after default config update) */
+export const DEPLOYMENT_CONFIG_VERSION = 20230413;
+
 export interface IDeploymentConfig {
   /** Friendly name used to identify the deployment name */
   name: string;

--- a/packages/data-models/index.ts
+++ b/packages/data-models/index.ts
@@ -2,6 +2,10 @@ export * from "./flowTypes";
 export * from "./functions";
 // NOTE - avoid exporting workflows as node-based can't be consumed by frontend src
 // export { IDeploymentWorkflows, IWorkflow, IWorkflowContext, WORKFLOW_DEFAULTS } from "./workflows";
-export { IDeploymentConfig, DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS } from "./deployment.model";
+export {
+  IDeploymentConfig,
+  DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS,
+  DEPLOYMENT_CONFIG_VERSION,
+} from "./deployment.model";
 export { IAppSkin } from "./skin.model";
 export { IAppConfig, IAppConfigOverride, getDefaultAppConfig } from "./appConfig";

--- a/packages/scripts/src/commands/deployment/common.ts
+++ b/packages/scripts/src/commands/deployment/common.ts
@@ -7,9 +7,6 @@ import path from "path";
 import { DEPLOYMENTS_PATH } from "../../paths";
 import { loadDeploymentJson } from "./utils";
 
-/** Adjust config version to force new config set */
-export const DEPLOYMENT_CONFIG_VERSION = 2.2;
-
 export interface IDeploymentConfigJson extends IDeploymentConfig {
   _workspace_path: string;
   _config_ts_path: string;

--- a/packages/scripts/src/commands/deployment/compile.ts
+++ b/packages/scripts/src/commands/deployment/compile.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { spawnSync } from "child_process";
 import { Command } from "commander";
-import { IDeploymentConfig } from "data-models";
+import { IDeploymentConfig, DEPLOYMENT_CONFIG_VERSION } from "data-models";
 import fs from "fs-extra";
 import path from "path";
 import { ROOT_DIR } from "../../paths";
 import { Logger } from "../../utils";
-import { DEPLOYMENT_CONFIG_VERSION, IDeploymentConfigJson } from "./common";
+import { IDeploymentConfigJson } from "./common";
 import { convertFunctionsToStrings } from "./utils";
 
 const program = new Command("compile");

--- a/packages/scripts/src/commands/deployment/utils.ts
+++ b/packages/scripts/src/commands/deployment/utils.ts
@@ -1,9 +1,12 @@
-import fs, { readdirSync, statSync } from "fs-extra";
-import path from "path";
-import { Logger } from "../../utils";
 import chalk from "chalk";
+import fs, { statSync } from "fs-extra";
+import path from "path";
+
+import { DEPLOYMENT_CONFIG_VERSION } from "data-models";
+
+import { Logger } from "../../utils";
 import { compileDeploymentTSSync } from "./compile";
-import { DEPLOYMENT_CONFIG_VERSION, IDeploymentConfigJson } from "./common";
+import { IDeploymentConfigJson } from "./common";
 
 /**
  * Retrieve compiled config json for a given folder path


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Changes to deployment config defaults can break local developer config if not recompiled. There is a versioning variable used to force recompile, however it's hidden away in script configuration file and so easily missed.

This PR moves the deployment config version variable to the config model file itself, and bumps to force recompile of developer configs following updates in #1873

## Review Notes
Check out branch and set deployment same as current. This should force config to recompile (previously would have remained the same)

## Git Issues

Closes #

## Screenshots/Videos
You can see if a config is being recompiled by the `Compiling:` console output

![image](https://user-images.githubusercontent.com/10515065/231827276-ebbacdd7-ac33-435c-b076-4ca6dc45ee8c.png)

