### PR TITLE
docs: add docs for creating a new web preview for a deployment

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,7 +8,7 @@
 # words - list of words to be always considered correct
 "words":
   [
-    "firebaserc"
+    "firebaserc",
     "fontawesome",
     "gdrive",
     "glitchtip",

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,22 +8,23 @@
 # words - list of words to be always considered correct
 "words":
   [
-    "idems",
-    "quickstart",
-    "glitchtip",
-    "mkdocs",
-    "venv",
-    "linenums",
-    "sourcemaps",
-    "ionicons",
-    "nocheck",
-    "sidemenu",
-    "templatename",
+    "firebaserc"
     "fontawesome",
     "gdrive",
+    "glitchtip",
+    "idems",
+    "ionicons",
+    "linenums",
     "lottie",
+    "mkdocs",
+    "nocheck",
     "overidden",
+    "quickstart",
+    "sidemenu",
+    "sourcemaps",
+    "templatename",
     "tmpl",
+    "venv",
   ]
 # flagWords - list of words to be always considered incorrect
 # This is useful for offensive words and common spelling errors.

--- a/documentation/docs/developers/images/firebase-hosting-add-site.png
+++ b/documentation/docs/developers/images/firebase-hosting-add-site.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da7ae7d5a2c6cba1e01a6b10cce02e62e647aa2c8df3bfe3d30155cb76b8dd5c
+size 13730

--- a/documentation/docs/developers/web-previews.md
+++ b/documentation/docs/developers/web-previews.md
@@ -54,4 +54,4 @@ Creating a new web preview for a deployment must be done by a user with the rele
 ```
 If your firebase site does not match your deployment name, then instead use the format `"example_deployment": ["example_firebase_site_id"]`
 
-The web preview is now configured. You can make the first release by pushing to the `deployment/` branch for your deployment. It may take a few minutes for the 
+The web preview is now configured. You can make the first release by pushing to the `deployment/` branch for your deployment. It may take a few minutes for the site to update and display the content when making the first release.

--- a/documentation/docs/developers/web-previews.md
+++ b/documentation/docs/developers/web-previews.md
@@ -1,0 +1,57 @@
+# Web Previews
+
+A preview for a given app deployment, running in browser, can be generated via GitHub. The URL for this preview can then be shared. In general, these previews are accessible at `<deployment_name>.web.app`, e.g. [wash.web.app](https://wash.web.app/). When viewing a web preview, it is recommended to [enable device mode] in Chrome DevTools in order to simulate the mobile experience.
+
+## Updating an existing web preview
+By convention, a given deployment should have two branches in the repo associated with it: `deployment/<deployment_name>` and `deployment_dev/<deployment_name>`. GitHub actions are configured so that any changes pushed to the `deployment/` branch (e.g. on the merging of a pull request from `deployment_dev/<deployment_name>` into `deployment/<deployment_name>`), triggers the web preview associated with that deployment to be updated to reflect the state of the `deployment/` branch.
+
+## Configuring a new web preview for a deployment
+!!! note
+    This process may be changed and improved in the future
+
+Creating a new web preview for a deployment must be done by a user with the relevant Firebase permissions. Assuming that the desired [deployment](../deployments/#customise-configuration) already exists, along with its respective `deployment/` and `deployment_dev/` branches, the following steps should be followed in order to associate it with a web preview URL on Firebase hosting:
+
+1. In the Firebase console, navigate to Hosting and select "Add another site". For the site id, it is recommended to use the deployment name for simplicity.
+  ![](images/firebase-hosting-add-site.png)
+2. After adding the site to Firebase, two files within the repo must be edited in order to configure the deployment to use Firebase hosting. In `firebase.json`, append the `hosting` array to include the following entry, substituting the "example_deployment" target for the name of your deployment.
+``` json
+{
+  "hosting": [
+    ...
+    {
+      "target": "example_deployment",
+      "public": "www",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    ...
+  ]
+}
+```
+1. In the file `.firebaserc`, append the "hosting" object to include the following, substituting "example_deployment" for the name of your deployment in both instances.
+``` json
+{
+  "projects": {
+    "default": "plh-teens-app1"
+  },
+  "targets": {
+    "plh-teens-app1": {
+      "hosting": {
+        ...
+        "example_deployment": [
+          "example_deployment"
+        ],
+        ...
+      }
+    }
+  }
+}
+```
+If your firebase site does not match your deployment name, then instead use the format `"example_deployment": ["example_firebase_site_id"]`
+
+The web preview is now configured. You can make the first release by pushing to the `deployment/` branch for your deployment. It may take a few minutes for the 

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - developers/android-assets.md
       - developers/in-app-updates.md
       - developers/error-logs.md
+      - developers/web-previews.md
   - Display Components:
       - components/audio.md
       - components/html.md


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Documents the process required to create a new web preview for a given deployment (adding a Firebase Hosting site and associating that site with the deployment). This process may change once we have separate [git repos for deployments](https://github.com/IDEMSInternational/parenting-app-ui/milestone/5), however I wanted to document this proces for @esmeetewinkel, and I see no harm in including it in the public docs in the interim.

## Dev notes

It may be desirable to eventually have a workflow that handles making the changes to the files. However, using the Firebase CLI to generate the files would require the dev/author having the required permissions and logging in via the CLI. Additionally, I believe that creating the new Firebase Hosting site is not something that can currently be done via the CLI, so would still need to be done manually using Firebase's console GUI.

## Git Issues

Closes #

## Screenshots
<img width="900" alt="Screenshot 2023-05-02 at 15 50 05" src="https://user-images.githubusercontent.com/64838927/235702851-aebd89de-db83-4d1b-8bb7-8ae936bcfa2b.png">
<img width="900" alt="Screenshot 2023-05-02 at 15 50 13" src="https://user-images.githubusercontent.com/64838927/235702885-ce083a26-98dc-4cea-a21d-8dec29b51326.png">
