### PR TITLE
fix: workflow-options

### DIFF
--- a/packages/data-models/workflows/sync.workflows.ts
+++ b/packages/data-models/workflows/sync.workflows.ts
@@ -27,14 +27,9 @@ const workflows: IDeploymentWorkflows = {
       },
       {
         name: "sync_watch",
-        condition: async ({ options }) => !!options.contentWatch,
-        function: async ({ tasks, workflow, options }) => {
-          if (options.contentWatch) {
-            tasks.workflow.runWorkflow({ name: "sync_watch", parent: workflow });
-          } else {
-            console.log('Use "--content-watch" or "-cw" to enable live sync\n');
-          }
-        },
+        condition: async ({ options }) => options.contentWatch === true,
+        function: async ({ tasks, workflow }) =>
+          tasks.workflow.runWorkflow({ name: "sync_watch", parent: workflow }),
       },
     ],
   },


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

While working on #1893 discovered content-watch mode no longer working as expected (possibly due to dependency upgrades or workflow name changes). Options set at the top level `sync` command were not filtering down to child commands

## Review Notes
Running `yarn workflow sync --content-watch` should now listen for keep connection alive and update on content updates

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
