### PR TITLE
Feat/flow generator

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -14,6 +14,8 @@ export namespace FlowTypes {
     | "data_list"
     // data_pipes are used to modify or generate new data_lists via processing methods
     | "data_pipe"
+    // generators can create any other flow type using a source datalist and flow skeleton
+    | "generator"
     // global data provides data to other modules, without namespacing (all top-level)
     | "global"
     | "template"
@@ -41,7 +43,10 @@ export namespace FlowTypes {
     override_target?: string;
     /** condition to evaluate for applying override */
     override_condition?: boolean | string; // dynamic references will be strings, but converted to boolean during evaluation
+    /** additional parameters passed to flows */
+    parameter_list?: Record<string, any>;
     /** computed list of all other templates with override conditions that targetthis template */
+
     _overrides?: {
       [templatename: string]: any; // override condition
     };
@@ -58,8 +63,8 @@ export namespace FlowTypes {
     rows: any[];
     /** Datalists populate rows as a hashmap instead to allow easier access to nested structures */
     rowsHashmap?: { [id: string]: any };
-    /** Datapipes store output from operations in a temporary field to allow data-list population */
-    _processed?: { [output_target: string]: any[] };
+    /** Additional flows generated during parsing, such as data pipe or generator flow outputs */
+    _generated?: { [flow_type in FlowType]?: { [flow_name: string]: FlowTypeWithData } };
   }
 
   /*********************************************************************************************
@@ -72,8 +77,14 @@ export namespace FlowTypes {
   export interface DataPipeFlow extends FlowTypeWithData {
     flow_type: "data_pipe";
     rows: IDataPipeOperation[];
-    /** Datapipes store output from operations in a temporary field to allow data-list population */
-    _processed?: { [output_target: string]: any[] };
+  }
+  export interface GeneratorFlow extends FlowTypeWithData {
+    flow_type: "generator";
+    parameter_list: {
+      input_data_list: string;
+      output_flow_name?: string;
+      output_flow_type?: FlowType;
+    };
   }
   export interface Translation_strings {
     [sourceText: string]: string;

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -1,18 +1,19 @@
 import { FlowTypes } from "data-models";
 import * as Parsers from "./parsers";
-import { IConverterPaths, IParsedWorkbookData } from "../../types";
+import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../types";
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
-  public cacheVersion = 20221026.1;
+  public cacheVersion = 20230508.0;
 
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {
-    template: new Parsers.TemplateParser(this),
     data_list: new Parsers.DataListParser(this),
-    global: new Parsers.DefaultParser(this),
-    tour: new Parsers.DefaultParser(this),
     data_pipe: new Parsers.DataPipeParser(this),
+    generator: new Parsers.GeneratorParser(this),
+    global: new Parsers.DefaultParser(this),
+    template: new Parsers.TemplateParser(this),
+    tour: new Parsers.DefaultParser(this),
   };
 
   /** Keep a track of all processed flows by type and name (used in data_pipes)*/
@@ -65,50 +66,60 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
    * Apply combined parser postProcess methods
    * @returns hashmap of flowtypes with postprocessed flows
    */
-  public async postProcess(flows: FlowTypes.FlowTypeWithData[]): Promise<IParsedWorkbookData> {
-    const flowsByType: IParsedWorkbookData = groupJsonByKey(flows, "flow_type");
+  public async postProcess(flows: FlowTypes.FlowTypeWithData[]) {
+    // post process flows by type
+    const flowArraysByType = groupJsonByKey(flows, "flow_type");
     for (const [flowType, parser] of Object.entries(this.parsers)) {
-      if (flowsByType[flowType]) {
-        flowsByType[flowType] = parser.postProcessFlows(flowsByType[flowType]);
+      if (flowArraysByType[flowType]) {
+        flowArraysByType[flowType] = parser.postProcessFlows(flowArraysByType[flowType]);
       }
     }
-    const flowTypesWithGenerated: IParsedWorkbookData =
-      this.populateDataPipeGeneratedFlows(flowsByType);
-    return flowTypesWithGenerated;
+    // convert to hashmap for easier processing of generated flows
+    const flowHashmapByType: IFlowHashmapByType = {};
+    for (const [type, typeFlows] of Object.entries(flowArraysByType)) {
+      flowHashmapByType[type] = arrayToHashmap(typeFlows, "flow_name", (k) => {
+        this.logger.error("Duplicate flows found", [type, k]);
+        return k;
+      });
+    }
+    // populate any generated flows to main list
+    const flowTypesWithGenerated = this.populateGeneratedFlows(flowHashmapByType);
+
+    // convert back from hashmap to hashArrays for final output
+    const outputData: IParsedWorkbookData = {};
+    for (const [type, typeHashmap] of Object.entries(flowTypesWithGenerated)) {
+      outputData[type] = Object.values(typeHashmap);
+    }
+    return outputData;
   }
 
   /**
-   * Data Pipes can return multiple generated flows from a single pipeline
-   * Extract these generated flows and populate as datalists
+   * Iterate over all flows to check for any that populate additional _generated flows
+   * that should be extracted to top-level
    */
-  private populateDataPipeGeneratedFlows(flowsByType: IParsedWorkbookData) {
-    if (flowsByType.data_pipe) {
-      const dataPipeHashmap = {};
-      const dataListHashmap = arrayToHashmap(flowsByType.data_list || [], "flow_name");
-      for (const flow of flowsByType.data_pipe) {
-        const { _processed, ...rest } = flow as FlowTypes.DataPipeFlow;
-        if (_processed) {
-          for (const [flow_name, rows] of Object.entries(_processed)) {
-            const datalist: FlowTypes.Data_list = {
-              flow_name,
-              flow_subtype: "generated",
-              flow_type: "data_list",
-              rows,
-            };
-            if (dataListHashmap[flow_name]) {
-              this.logger.error({
-                message: "Generated datalist will override existing datalist",
-                details: [flow_name],
-              });
+  private populateGeneratedFlows(flowsByType: IFlowHashmapByType) {
+    // handle any additional methods that operate on full list of processed flows,
+    // e.g. populating additional generated flows
+    for (const typeFlows of Object.values(flowsByType)) {
+      for (const { _generated, ...flow } of Object.values(typeFlows)) {
+        if (_generated) {
+          // remove _generated field from flow
+          flowsByType[flow.flow_type][flow.flow_name] = flow;
+          // populate generated to main list
+          for (const generatedFlows of Object.values(_generated)) {
+            for (const generatedFlow of Object.values(generatedFlows)) {
+              flowsByType[generatedFlow.flow_type] ??= {};
+              if (flowsByType[generatedFlow.flow_type][generatedFlow.flow_name]) {
+                this.logger.error({
+                  message: "Generated flow will override existing flow",
+                  details: [generatedFlow.flow_type, generatedFlow.flow_name],
+                });
+              }
+              flowsByType[generatedFlow.flow_type][generatedFlow.flow_name] = generatedFlow;
             }
-            dataListHashmap[flow_name] = datalist;
           }
         }
-        // Populate rest of data pipe (without _processed) to main flows list
-        dataPipeHashmap[flow.flow_name] = rest;
       }
-      flowsByType.data_pipe = Object.values(dataPipeHashmap);
-      flowsByType.data_list = Object.values(dataListHashmap);
     }
     return flowsByType;
   }

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
@@ -7,7 +7,7 @@ const testInputSources = {
 };
 
 describe("data_pipe Parser", () => {
-  it("Parses data pipes to flow _processed property", async () => {
+  it("Populates generated data lists", async () => {
     const parser = new DataPipeParser({ processedFlowHashmap: testInputSources } as any);
     const output = parser.run({
       flow_name: "test_pipe_parse",
@@ -27,9 +27,19 @@ describe("data_pipe Parser", () => {
         },
       ],
     }) as FlowTypes.DataPipeFlow;
-    expect(output._processed).toEqual({
-      test_output_1: [{ id: 2 }, { id: 3 }],
-      test_output_2: [{ id: 3 }],
+    expect(output._generated.data_list).toEqual({
+      test_output_1: {
+        flow_name: "test_output_1",
+        flow_type: "data_list",
+        flow_subtype: "generated",
+        rows: [{ id: 2 }, { id: 3 }],
+      },
+      test_output_2: {
+        flow_name: "test_output_2",
+        flow_type: "data_list",
+        flow_subtype: "generated",
+        rows: [{ id: 3 }],
+      },
     });
   });
 
@@ -61,7 +71,14 @@ describe("data_pipe Parser", () => {
       flow_type: "data_pipe",
       rows: ops2,
     }) as FlowTypes.DataPipeFlow;
-    expect(output._processed).toEqual({ test_output_2: [{ id: 3 }] });
+    expect(output._generated.data_list).toEqual({
+      test_output_2: {
+        flow_name: "test_output_2",
+        flow_type: "data_list",
+        flow_subtype: "generated",
+        rows: [{ id: 3 }],
+      },
+    });
   });
 
   it("Defers processing when inputs not available", async () => {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.ts
@@ -18,7 +18,7 @@ export class DataPipeParser extends DefaultParser<FlowTypes.DataPipeFlow> {
     }
     try {
       const outputs = pipe.run();
-      this.handleOutputs(outputs);
+      this.populateGeneratedFlows(outputs);
     } catch (error) {
       console.trace(error);
       throw error;
@@ -26,16 +26,21 @@ export class DataPipeParser extends DefaultParser<FlowTypes.DataPipeFlow> {
     return this.flow;
   }
 
-  private handleOutputs(outputs: { [output_name: string]: any[] }) {
-    // store generated outputs to flow
-    this.flow._processed = outputs;
-    // also populate generated outputs to be available for future input sources
-    if (!this.flowProcessor.processedFlowHashmap.data_list) {
-      this.flowProcessor.processedFlowHashmap.data_list = {};
-    }
+  private populateGeneratedFlows(outputs: { [output_name: string]: any[] }) {
+    const generated: FlowTypes.DataPipeFlow["_generated"] = { data_list: {} };
+    this.flowProcessor.processedFlowHashmap.data_list ??= {};
+
     for (const [flow_name, rows] of Object.entries(outputs)) {
+      generated.data_list[flow_name] = {
+        flow_name,
+        flow_type: "data_list",
+        flow_subtype: "generated",
+        rows,
+      };
+      // also populate generated outputs to be available for future input sources
       this.flowProcessor.processedFlowHashmap.data_list[flow_name] = rows;
     }
+    this.flow._generated = generated;
   }
 
   private loadInputSources() {

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/generator.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/generator.parser.spec.ts
@@ -1,0 +1,87 @@
+import { FlowTypes } from "data-models";
+import { GeneratorParser } from "./generator.parser";
+
+const dataListInputs = {
+  test_data_list: [
+    { id: 1, title: "Workshop 1", main_image: "img1", img_condition: "@fields.showImg1" },
+    { id: 2, title: "Workshop 2", main_image: "img2", img_condition: true },
+  ],
+};
+
+const generatorInput: FlowTypes.GeneratorFlow = {
+  flow_name: "test_pipe_parse",
+  flow_type: "generator",
+  parameter_list: {
+    input_data_list: "test_data_list",
+    output_flow_name: "generated_template_@gen.id",
+    output_flow_type: "template",
+  },
+  rows: [
+    {
+      name: "title",
+      value: "Welcome to @gen.title",
+    },
+    {
+      name: "image",
+      value: "@gen.main_image",
+      condition: "@gen.img_condition",
+    },
+    {
+      name: "text",
+      value: "End of workshop",
+    },
+  ],
+};
+
+describe("generator Parser", () => {
+  it("Parses generator flow", async () => {
+    const parser = new GeneratorParser({
+      processedFlowHashmap: { data_list: dataListInputs },
+    } as any);
+    const output = parser.run(generatorInput);
+    expect(output._generated).toEqual({
+      template: {
+        generated_template_1: {
+          flow_type: "template",
+          flow_subtype: "generated",
+          flow_name: "generated_template_1",
+          rows: [
+            {
+              name: "title",
+              value: "Welcome to Workshop 1",
+            },
+            {
+              name: "image",
+              value: "img1",
+              condition: "@fields.showImg1",
+            },
+            {
+              name: "text",
+              value: "End of workshop",
+            },
+          ],
+        },
+        generated_template_2: {
+          flow_type: "template",
+          flow_subtype: "generated",
+          flow_name: "generated_template_2",
+          rows: [
+            {
+              name: "title",
+              value: "Welcome to Workshop 2",
+            },
+            {
+              name: "image",
+              value: "img2",
+              condition: "true",
+            },
+            {
+              name: "text",
+              value: "End of workshop",
+            },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/generator.parser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/generator.parser.ts
@@ -1,0 +1,89 @@
+import { FlowTypes } from "data-models";
+import { DefaultParser } from "./default.parser";
+import { TemplatedData } from "shared";
+
+export class GeneratorParser extends DefaultParser<FlowTypes.GeneratorFlow> {
+  /**
+   * Method applied after all flow processing and processing methods to populate
+   * generated flows to main list
+   */
+  public static populateProcessedFlows() {}
+
+  public postProcessFlow(flow: FlowTypes.GeneratorFlow): FlowTypes.GeneratorFlow {
+    const parameterList = this.validateParameterList(flow);
+
+    const inputSources = this.loadInputSources();
+    const dataListRows: FlowTypes.Data_listRow[] = inputSources[parameterList.input_data_list];
+    // Try to defer processing if inputs are missing as they might be generated as part
+    // of another flow
+    if (!dataListRows) {
+      const deferId = `${flow.flow_type}.${flow.flow_name}`;
+      this.flowProcessor.deferInputProcess(flow, deferId);
+      return;
+    }
+    try {
+      this.flow._generated = this.generateFlows(flow, dataListRows);
+      // this.handleOutputs(generated);
+    } catch (error) {
+      console.trace(error);
+      throw error;
+    }
+    return this.flow;
+  }
+
+  private validateParameterList(
+    flow: FlowTypes.GeneratorFlow
+  ): FlowTypes.GeneratorFlow["parameter_list"] {
+    const { flow_name, parameter_list } = flow;
+    if (!parameter_list) {
+      throw new Error("No parameter list provided to generator");
+    }
+    let { input_data_list, output_flow_name, output_flow_type } = parameter_list;
+    if (!input_data_list) {
+      throw new Error('"input_data_list" required for generator');
+    }
+    if (!output_flow_type) {
+      output_flow_type = "template";
+    }
+    if (!output_flow_name) {
+      output_flow_name = `${flow_name}_{{@gen.id}}`;
+    }
+    return { input_data_list, output_flow_name, output_flow_type };
+  }
+
+  /** Iterate over provided data list rows and use to create a new generated flow from generator base flow  */
+  private generateFlows(
+    generator: FlowTypes.GeneratorFlow,
+    dataListRows: FlowTypes.Data_listRow[]
+  ) {
+    const generated: FlowTypes.FlowTypeWithData["_generated"] = {};
+
+    for (const listRow of dataListRows) {
+      const parser = new TemplatedData({
+        context: { gen: listRow },
+      });
+      const { output_flow_name, output_flow_type } = parser.parse(
+        // ensure original values used each parse
+        JSON.parse(JSON.stringify(generator.parameter_list))
+      );
+      const parsedRows = generator.rows.map((genRow) => {
+        const parsed = parser.parse(JSON.parse(JSON.stringify(genRow)));
+        return parsed;
+      });
+      // populate as generated flow
+      const generatedFlow: FlowTypes.FlowTypeWithData = {
+        flow_type: output_flow_type,
+        flow_subtype: "generated",
+        flow_name: output_flow_name,
+        rows: parsedRows,
+      };
+      generated[output_flow_type] ??= {};
+      generated[output_flow_type][output_flow_name] = generatedFlow;
+    }
+    return generated;
+  }
+
+  private loadInputSources() {
+    return this.flowProcessor?.processedFlowHashmap?.data_list || {};
+  }
+}

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/index.ts
@@ -1,4 +1,5 @@
 export * from "./data_list.parser";
 export * from "./data_pipe.parser";
 export * from "./default.parser";
+export * from "./generator.parser";
 export * from "./template.parser";

--- a/packages/scripts/src/commands/app-data/convert/types.ts
+++ b/packages/scripts/src/commands/app-data/convert/types.ts
@@ -2,6 +2,10 @@ import type { FlowTypes } from "data-models";
 
 export type IParsedWorkbookData = { [type in FlowTypes.FlowType]?: FlowTypes.FlowTypeWithData[] };
 
+export type IFlowHashmapByType = {
+  [type in FlowTypes.FlowType]?: { [flow_name: string]: FlowTypes.FlowTypeWithData };
+};
+
 export interface IGDriveContentsEntry {
   id: string;
   name: string;

--- a/packages/scripts/src/utils/file-utils.ts
+++ b/packages/scripts/src/utils/file-utils.ts
@@ -247,12 +247,22 @@ export function groupJsonByMultipleKeys<T>(json: T[], keys: string[], joinCharac
 /**
  * Convert an object array into a json object, with keys corresponding to array entries
  * @param keyfield any unique field which all array objects contain to use as hash keys (e.g. 'id')
+ * @param handleDuplicateKey optional function to trigger when duplicate hash key entry detected.
+ * Should return replacement key to populate instead
  */
-export function arrayToHashmap<T>(arr: T[], keyfield: string): { [key: string]: T } {
+export function arrayToHashmap<T extends object>(
+  arr: T[],
+  keyfield: keyof T,
+  handleDuplicateKey = (k: string) => k
+): { [key: string]: T } {
   const hashmap: { [key: string]: T } = {};
   for (const el of arr) {
     if (el.hasOwnProperty(keyfield)) {
-      hashmap[el[keyfield]] = el;
+      let hashKey = el[keyfield] as string;
+      if (hashKey in hashmap) {
+        hashKey = handleDuplicateKey(hashKey);
+      }
+      hashmap[hashKey] = el;
     }
   }
   return hashmap;

--- a/packages/shared/src/models/templatedData/templatedData.ts
+++ b/packages/shared/src/models/templatedData/templatedData.ts
@@ -62,7 +62,7 @@ export class TemplatedData {
    * Main data conversion method
    * Iterate over data, parse string values and nested objects and arrays recursively
    */
-  public parse(value = this.initialValue) {
+  public parse<T>(value: T = this.initialValue) {
     if (value) {
       if (typeof value === "string") {
         value = this.parseTemplatedString(value);
@@ -70,7 +70,7 @@ export class TemplatedData {
       // recurssively convert array and json-like objects
       if (typeof value === "object") {
         if (Array.isArray(value)) {
-          value = value.map((v) => this.parse(v));
+          value = value.map((v) => this.parse(v)) as any;
         }
         if (value.constructor === {}.constructor) {
           Object.keys(value).forEach((key) => (value[key] = this.parse(value[key])));


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

- [x] Add support for `generator` flow type as defined in [RFC](https://docs.google.com/document/d/1cK_Mk3nTZIKxux8bygKvujUFkVENMOE_xIgM6w9PlRw/edit#)
- [x] Add parser tests
- [ ] Add example sheets
- [ ] Add documentation (should migrate across RFC content)

**Additional Changes**
As generator flows produce additional flows to populate to main list when parsing (as opposed to just modifying themselves), additional methods were required for populating these. A similar method already existed for handling this case in data pipes, so this was refactored into a general method used by both data_pipe and generator flow types. Otherwise all other flow type parsers should remain unchanged

## Review Notes
The PR contains parser changes and has updated cache version accordingly. Recommend testing when content recently updated to make it easier to detect any knock-on changes. It only changes expected should be generated flows populated.

## Dev Notes


## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
