### PR TITLE
fix: log of asset size breakdown

### DIFF
--- a/packages/scripts/src/commands/app-data/postProcess/assets.ts
+++ b/packages/scripts/src/commands/app-data/postProcess/assets.ts
@@ -164,10 +164,13 @@ export class AssetsPostProcessor {
 
   private checkTotalAssetSize(sourceAssets: IAssetEntriesByType) {
     let totalSize = 0;
-    let themeAndLanguageSizes = { default: { total: 0, global: 0 } };
-    Object.values(sourceAssets).forEach((assetEntryHashmap: IAssetEntryHashmap) => {
-      Object.values(assetEntryHashmap).forEach((entry) => {
-        Object.entries(entry.overrides || {}).forEach(([themeName, languageEntries]) => {
+    let themeAndLanguageSizes = { theme_default: { total: 0, global: 0 } };
+    Object.values(sourceAssets.tracked).forEach((entry) => {
+      totalSize += entry.size_kb;
+      themeAndLanguageSizes.theme_default.total += entry.size_kb;
+      themeAndLanguageSizes.theme_default.global += entry.size_kb;
+      if (entry.overrides) {
+        Object.entries(entry.overrides).forEach(([themeName, languageEntries]) => {
           Object.entries(languageEntries).forEach(([languageCode, languageEntry]) => {
             const assetSize = languageEntry.size_kb;
             totalSize += assetSize;
@@ -178,7 +181,7 @@ export class AssetsPostProcessor {
             themeAndLanguageSizes[themeName][languageCode] += assetSize;
           });
         });
-      });
+      }
     });
 
     const themeLangSizesMBSummary = Object.entries(themeAndLanguageSizes)
@@ -186,7 +189,7 @@ export class AssetsPostProcessor {
         const languageBreakdown = Object.entries(themeEntry)
           .map(([language, size]) => `${language}: ${kbToMB(size)} MB`)
           .join("\n    ");
-        return `${themeName} theme:\n  ${languageBreakdown}`;
+        return `${themeName}:\n  ${languageBreakdown}`;
       })
       .join("\n");
     const totalSizeMB = kbToMB(totalSize);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the asset sizes logged when running `yarn workflow sync` were incorrect. I believe this should have been picked up when testing #1874. 

## Testing

1. Checkout master, and set the active deployment to plh_global – `yarn workflow deployment set plh_global`
2. Run `yarn workflow sync_assets` and note the log of the asset size breakdown. It should be similar to the following screenshot. Note that, as well as "theme_default theme", there is an extra entry for "default theme" which will always display 1MB.
    <img width="300" alt="Screenshot 2023-05-16 at 12 54 39" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/a875b86a-1d12-49d5-8d7b-c616e8179aeb">

3. Now checkout the feature branch, `git checkout fix/asset-size-breakdown`
4. Run `yarn workflow sync_assets` again, and you should see the following. Note that the default global assets are now being included correctly in the total size.
    <img width="300" alt="Screenshot 2023-05-16 at 12 54 06" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/fe1e123a-6421-4205-b56d-26861ed31d76">


## Git Issues

Closes #

## Screenshots/Videos
The asset size breakdown logs for the `plh_global` deployment:

Before
<img width="300" alt="Screenshot 2023-05-16 at 12 54 39" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/8246dc10-8183-499d-b50c-2aedcccbe4f6">

After
<img width="300" alt="Screenshot 2023-05-16 at 12 54 06" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/db04d2a7-b5f2-41c9-b051-d80f68ef291c">
