### PR TITLE
feat: add asset core size

### DIFF
--- a/packages/scripts/src/commands/app-data/postProcess/assets.ts
+++ b/packages/scripts/src/commands/app-data/postProcess/assets.ts
@@ -25,6 +25,14 @@ import type { IAssetEntryHashmap, IContentsEntryMinimal } from "data-models/depl
  */
 const ASSETS_GLOBAL_FOLDER_NAME = "global";
 
+/** Approximate size of core build as populated to www folder (excluding assets) */
+const APP_CORE_BUILD_KB = 7 * 1024;
+/** Approximate size of core assets as populated to www folder (excluding assets/app_data) */
+const APP_CORE_ASSETS_KB = 0.5 * 1024;
+const APP_CORE_SIZE_KB = {
+  total: APP_CORE_BUILD_KB + APP_CORE_ASSETS_KB,
+};
+
 /***************************************************************************************
  * CLI
  * @example yarn
@@ -163,8 +171,11 @@ export class AssetsPostProcessor {
   }
 
   private checkTotalAssetSize(sourceAssets: IAssetEntriesByType) {
-    let totalSize = 0;
-    let themeAndLanguageSizes = { theme_default: { total: 0, global: 0 } };
+    let totalSize = APP_CORE_SIZE_KB.total;
+    let themeAndLanguageSizes = {
+      app_core: APP_CORE_SIZE_KB,
+      theme_default: { total: 0, global: 0 },
+    };
     Object.values(sourceAssets.tracked).forEach((entry) => {
       totalSize += entry.size_kb;
       themeAndLanguageSizes.theme_default.total += entry.size_kb;
@@ -193,7 +204,7 @@ export class AssetsPostProcessor {
       })
       .join("\n");
     const totalSizeMB = kbToMB(totalSize);
-    const maxWarningSize = 145;
+    const maxWarningSize = 150;
     if (totalSizeMB > maxWarningSize) {
       logWarning({
         msg1: `Asset files too large`,

--- a/packages/scripts/src/utils/string-utils.ts
+++ b/packages/scripts/src/utils/string-utils.ts
@@ -15,5 +15,6 @@ export function booleanStringToBoolean(str: string) {
 /** Convert size in KB to MB with specified number of decimal places */
 export function kbToMB(kb: number, decimalPlaces = 1) {
   const mb = kb / 1024;
-  return (Math.round((mb * 10) ^ decimalPlaces) / 10) ^ decimalPlaces;
+  const power = 10 ^ decimalPlaces;
+  return Math.round((mb * power) / power);
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Add `app_core` to asset breakdown (currently hardcoded as rough approximation of current app)
- Include core build in quota warning (and bump to 150MB)
- Fix rounding bug in size_mb calculations

## Dev Notes
In the future we will likely want to add a step to build/ci pipeline to automatically update core build, but for now would be good to just redo manually following pdf component pr or any other prs known to add sizeable assets

## Git Issues

Closes #

## Screenshots/Videos

![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/9ca58ed2-de96-465e-8c29-789d266a7fe8)
