### PR TITLE
fix(git repos): specify branch to pull from when syncing remote content repo

### DIFF
--- a/packages/scripts/src/tasks/providers/git.ts
+++ b/packages/scripts/src/tasks/providers/git.ts
@@ -30,7 +30,7 @@ class GitProvider {
     console.log(chalk.gray("checkout [main]"));
     try {
       await this.git.checkout("main");
-      await this.git.pull();
+      await this.git.pull("origin", "main");
     } catch (error) {
       // If merge conflict prompt to discard local changes and retry
       console.log(chalk.red(error.message));


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

After #1755, and some additional changes to the the [app-debug-content repo](https://github.com/IDEMSInternational/app-debug-content), a git error was triggered when trying to refresh the remote content from that repo (e.g. when running `yarn workflow sync` from a local clone of the parenting-app-ui repo, with the `debug` deployment active).
<img width="500" alt="Screenshot 2023-06-05 at 15 36 31" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/7aeb596c-8e51-403c-a535-b74f1bf65d48">

Whilst we haven't found the exact cause, this PR fixes the issue by specifying the remote branch to pull from when running a programmatic `git pull`.