### PR TITLE
Chore: add web preview for debug deployment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -28,6 +28,9 @@
         ],
         "pfr": [
           "parenting-for-respectability"
+        ],
+        "debug": [
+          "idems-debug"
         ]
       }
     }

--- a/documentation/docs/components/audio.md
+++ b/documentation/docs/components/audio.md
@@ -9,7 +9,7 @@
 ![](images/audio.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1ARbNRGDer5vj9qSpRMZFrMkYifGkH3TLtDVp72YbaqU/edit#gid=551506513)   
-[Live Preview Demo](https://plh-global.web.app/template/feature_audio)
+[Live Preview Demo](https://idems-debug.web.app/template/feature_audio)
 
 ## Parameters
 

--- a/documentation/docs/components/button.md
+++ b/documentation/docs/components/button.md
@@ -10,7 +10,7 @@
 ![](images/button.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_button)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_button)
 
 ## Parameters
 

--- a/documentation/docs/components/combo_box.md
+++ b/documentation/docs/components/combo_box.md
@@ -12,7 +12,7 @@
 [![combo_box](images/combo_box.png)](videos/combo_box.mp4 "combo_box")
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_combo_box)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_combo_box)
 
 ## Parameters
 

--- a/documentation/docs/components/html.md
+++ b/documentation/docs/components/html.md
@@ -24,7 +24,7 @@ Any valid html can be rendered in the value. This includes the full set of [Ioni
 ![](images/html.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1-M10SxkDXoLCj3nQxkRdCMjqu7FgLIP55OYgvh4Oa-M/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_html)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_html)
 
 ## Parameters
 

--- a/documentation/docs/components/pdf.md
+++ b/documentation/docs/components/pdf.md
@@ -12,7 +12,7 @@
 ![](images/pdf.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1VXM9zYgrsZIB4h8slC9mg3P9C-jsXuPScNaml-1qaOk/)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_pdf)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_pdf)
 
 ## Parameters
 

--- a/documentation/docs/components/radio_group.md
+++ b/documentation/docs/components/radio_group.md
@@ -12,7 +12,7 @@
 ![](images/radio_group.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1qfatsiHKJ8sCBcJ8oqo3InLrjzT_a2Qxvw6RyxVMTxY/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_radio_group)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_radio_group)
 
 ## Parameters
 

--- a/documentation/docs/components/round_button.md
+++ b/documentation/docs/components/round_button.md
@@ -10,7 +10,7 @@
 ![](images/round_button.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/161GZue4jkQNJzyfYvMWesMp2vwvbkJgpNqkDlVIGJDw/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_round_button)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_round_button)
 
 ## Parameters
 

--- a/documentation/docs/components/simple_checkbox.md
+++ b/documentation/docs/components/simple_checkbox.md
@@ -10,7 +10,7 @@
 ![](images/simple_checkbox.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/19t6lEBkVF0LV2dMD1yL6nbuUIFiiYNa0xLA1QQAyyxU/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_checkbox)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_checkbox)
 
 ## Parameters
 

--- a/documentation/docs/components/slider.md
+++ b/documentation/docs/components/slider.md
@@ -9,7 +9,7 @@
 ![](images/slider.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1oSJHE2gq_WqgQM6NAKWBfuxCXIjcJ1k4aIUl422QK60/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_slider)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_slider)
 
 ## Parameters
 

--- a/documentation/docs/components/square_button.md
+++ b/documentation/docs/components/square_button.md
@@ -10,7 +10,7 @@
 ![](images/square_button.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1ptSCtSDQ-_PrgLuZiJouHa9k1nUEjg7eMzx9rVOKBUE/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_square_button)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_square_button)
 
 ## Parameters
 

--- a/documentation/docs/components/timer.md
+++ b/documentation/docs/components/timer.md
@@ -9,7 +9,7 @@
 ![](images/timer.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1jQAvELG5EXj6zgj0bBQmVg7Iaa-66OpemdZzgOh2PP0/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_timer)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_timer)
 
 ## Parameters
 

--- a/documentation/docs/components/video.md
+++ b/documentation/docs/components/video.md
@@ -9,7 +9,7 @@
 ![](images/video.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1OjY24TnAWRxiiPT9vED59DLwz2Zb9RmUHw-Lym1pCXo/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_video)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_video)
 
 ## Parameters
 

--- a/documentation/docs/questions/positioning_components.md
+++ b/documentation/docs/questions/positioning_components.md
@@ -4,7 +4,7 @@
 
 _Asked on 14 February 2022_
 
-We don't exactly have a syntax to get text to wrap around an image. The system we use to get something similar (at least to get components to display side-by-side) is based on "display groups". To show you how these work I authored the template `example_dg`([sheet](https://docs.google.com/spreadsheets/d/1i6Th92RAkGfardxSJdJYWVoMtTkaNr-Xn2kIHDvtQoQ/edit#gid=1595229908) / [web preview](https://plh-global.web.app/template/example_dg)), which corresponds to the screenshot below. 
+We don't exactly have a syntax to get text to wrap around an image. The system we use to get something similar (at least to get components to display side-by-side) is based on "display groups". To show you how these work I authored the template `example_dg`([sheet](https://docs.google.com/spreadsheets/d/1i6Th92RAkGfardxSJdJYWVoMtTkaNr-Xn2kIHDvtQoQ/edit#gid=1595229908) / [web preview](https://idems-debug.web.app/template/example_dg)), which corresponds to the screenshot below. 
 
 ![](images/display_group.png)
 

--- a/firebase.json
+++ b/firebase.json
@@ -87,6 +87,17 @@
           "destination": "/index.html"
         }
       ]
+    },
+    {
+      "target": "debug",
+      "public": "www",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
     }
   ]
 }

--- a/src/app/shared/components/template/components/button/button.component.md
+++ b/src/app/shared/components/template/components/button/button.component.md
@@ -10,7 +10,7 @@
 ![button example](../assets/images/button.png)
 
 [Google Sheet Demo](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit#gid=569531329)   
-[Live Preview Demo](https://plh-global.web.app/template/comp_button)
+[Live Preview Demo](https://idems-debug.web.app/template/comp_button)
 
 ## Parameters
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

With the contents for the debug deployment now in [its own repo](https://github.com/IDEMSInternational/app-debug-content), the debug components are no longer available in the [plh_global web preview](https://plh-global.web.app/). This PR configures a new Firebase hosting site for a web preview of the debug deployment, available at [https://idems-debug.web.app/](https://idems-debug.web.app/).

Additionally, the components documentation files typically link to the live preview of the respective component demo. These links were broken and have been updated to point to the debug site.

Whilst we will eventually enable git actions on content repos that can generate web previews, and likely move away from Firebase hosting, the changes in this PR are necessary in the interim.

## Screenshots/Videos

<img width="400" alt="Screenshot 2023-06-09 at 12 46 33" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/b6c4ac0e-198c-4044-ada9-0e890c95961b">

