### PR TITLE
chore: change github issue template 'crashlytics' -> 'glitchtip'

### DIFF
--- a/.github/ISSUE_TEMPLATE/crashlytics.md
+++ b/.github/ISSUE_TEMPLATE/crashlytics.md
@@ -1,13 +1,13 @@
 ---
-name: Crashlytics report
+name: GlitchTip report
 about: Complete the form below to report crash report data
-title: "[Crashlytics]"
-labels: crashlytics
+title: "[GlitchTip]"
+labels: GlitchTip
 assignees: ''
 
 ---
 
-**Crashlytics Link**
+**GlitchTip Link**
 _url_
 
 **Report txt**

--- a/.github/ISSUE_TEMPLATE/glitchtip.md
+++ b/.github/ISSUE_TEMPLATE/glitchtip.md
@@ -2,7 +2,7 @@
 name: GlitchTip report
 about: Complete the form below to report crash report data
 title: "[GlitchTip]"
-labels: GlitchTip
+labels: glitchtip
 assignees: ''
 
 ---


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Updates our github issue templates to reflect the move to using Glitchtip error tracker from Crashlytics

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
