### PR TITLE
chore: excluded ngx-extended-pdf-viewer assets from build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,12 +35,6 @@
                 "glob": "**/*.svg",
                 "input": "node_modules/ionicons/dist/ionicons/svg",
                 "output": "./svg"
-              },
-              {
-                "glob": "{*.min.js,op-chaining-support.js,cmaps/*,images/*,locale/en-GB/*,locale/locale.properties,standard_fonts/**}",
-                "input": "node_modules/ngx-extended-pdf-viewer/assets/",
-                "ignore": ["**/*-es5.min.js"],
-                "output": "/assets/comp-pdf"
               }
             ],
             "styles": [


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

As a temporary workaround to minimise the app bundle size for the plh_tz deployment, it was agreed in a 23/05/23 meeting that the assets required by the pdf viewer library used in the pdf viewer component introduced in #1918 should be excluded from the build on the plh_tz deployment branches. This means that the pdf viewer component will not work on builds created from these branches, which is acceptable in the short term as this deployment does not make use of that component.

## Git Issues

Closes #1940
