### PR TITLE
feat: new 'card-portrait' variant for button component

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -1,42 +1,46 @@
-<ion-button
-  *ngIf="!variantIsCardPortrait"
-  [class]="'full standard medium' + ' ' + style + ' ' + buttonAlign"
-  [disabled]="disabled"
-  (click)="triggerActions('click')"
-  [attr.data-param-style]="style"
-  [attr.data-variant]="variant"
->
-  <ion-icon *ngIf="icon" slot="start" src="{{ icon | plhAsset }}"></ion-icon>
-  <span *ngIf="_row.value" [class]="'left ' + textAlign" [innerHTML]="_row.value | markdown">
-  </span>
-  <span *ngIf="_row.rows" class="children">
-    <plh-template-component
-      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
-      class="child"
-      [row]="childRow"
-      [parent]="parent"
-      [attr.data-rowname]="_row.name"
-    ></plh-template-component>
-  </span>
-</ion-button>
+<ng-container [ngSwitch]="variantMap.cardPortrait">
+  <!-- Default variant -->
+  <ion-button
+    *ngSwitchDefault
+    [class]="'full standard medium' + ' ' + style + ' ' + buttonAlign"
+    [disabled]="disabled"
+    (click)="triggerActions('click')"
+    [attr.data-param-style]="style"
+    [attr.data-variant]="variant"
+  >
+    <ion-icon *ngIf="icon" slot="start" src="{{ icon | plhAsset }}"></ion-icon>
+    <span *ngIf="_row.value" [class]="'left ' + textAlign" [innerHTML]="_row.value | markdown">
+    </span>
+    <span *ngIf="_row.rows" class="children">
+      <plh-template-component
+        *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+        class="child"
+        [row]="childRow"
+        [parent]="parent"
+        [attr.data-rowname]="_row.name"
+      ></plh-template-component>
+    </span>
+  </ion-button>
 
-<div
-  class="button-container"
-  *ngIf="variantIsCardPortrait"
-  (click)="triggerActions('click')"
-  [attr.data-variant]="variant"
->
-  <img *ngIf="image" src="{{ image | plhAsset }}" />
-  <div *ngIf="_row.value" [class]="'button-text ' + textAlign">
-    {{ _row.value }}
+  <!-- "card-portrait" variant. This variant is not achievable using an ion-button -->
+  <div
+    *ngSwitchCase="true"
+    class="button-container"
+    (click)="triggerActions('click')"
+    [attr.data-variant]="variant"
+  >
+    <img *ngIf="image" src="{{ image | plhAsset }}" />
+    <div *ngIf="_row.value" [class]="'button-text ' + textAlign">
+      {{ _row.value }}
+    </div>
+    <span *ngIf="_row.rows" class="children">
+      <plh-template-component
+        *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+        class="child"
+        [row]="childRow"
+        [parent]="parent"
+        [attr.data-rowname]="_row.name"
+      ></plh-template-component>
+    </span>
   </div>
-  <span *ngIf="_row.rows" class="children">
-    <plh-template-component
-      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
-      class="child"
-      [row]="childRow"
-      [parent]="parent"
-      [attr.data-rowname]="_row.name"
-    ></plh-template-component>
-  </span>
-</div>
+</ng-container>

--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -1,5 +1,5 @@
 <ion-button
-  *ngIf="!isCardPortrait"
+  *ngIf="!variantIsCardPortrait"
   [class]="'full standard medium' + ' ' + style + ' ' + buttonAlign"
   [disabled]="disabled"
   (click)="triggerActions('click')"
@@ -22,11 +22,11 @@
 
 <div
   class="button-container"
-  *ngIf="isCardPortrait"
+  *ngIf="variantIsCardPortrait"
   (click)="triggerActions('click')"
   [attr.data-variant]="variant"
 >
-  <img src="{{ image | plhAsset }}" />
+  <img *ngIf="image" src="{{ image | plhAsset }}" />
   <div *ngIf="_row.value" [class]="'button-text ' + textAlign">
     {{ _row.value }}
   </div>

--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -1,11 +1,14 @@
 <ion-button
+  *ngIf="!isCardPortrait"
   [class]="'full standard medium' + ' ' + style + ' ' + buttonAlign"
   [disabled]="disabled"
   (click)="triggerActions('click')"
   [attr.data-param-style]="style"
+  [attr.data-variant]="variant"
 >
   <ion-icon *ngIf="icon" slot="start" src="{{ icon | plhAsset }}"></ion-icon>
-  <span *ngIf="_row.value" [class]="textAlign" [innerHTML]="_row.value | markdown"> </span>
+  <span *ngIf="_row.value" [class]="'left ' + textAlign" [innerHTML]="_row.value | markdown">
+  </span>
   <span *ngIf="_row.rows" class="children">
     <plh-template-component
       *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
@@ -16,3 +19,24 @@
     ></plh-template-component>
   </span>
 </ion-button>
+
+<div
+  class="button-container"
+  *ngIf="isCardPortrait"
+  (click)="triggerActions('click')"
+  [attr.data-variant]="variant"
+>
+  <img src="{{ image | plhAsset }}" />
+  <div *ngIf="_row.value" [class]="'button-text ' + textAlign">
+    {{ _row.value }}
+  </div>
+  <span *ngIf="_row.rows" class="children">
+    <plh-template-component
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
+      class="child"
+      [row]="childRow"
+      [parent]="parent"
+      [attr.data-rowname]="_row.name"
+    ></plh-template-component>
+  </span>
+</div>

--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -2,14 +2,18 @@
   <!-- Default variant -->
   <ion-button
     *ngSwitchDefault
-    [class]="'full standard medium' + ' ' + style + ' ' + buttonAlign"
-    [disabled]="disabled"
+    [class]="'full standard medium' + ' ' + params.style + ' ' + params.buttonAlign"
+    [disabled]="params.disabled"
     (click)="triggerActions('click')"
-    [attr.data-param-style]="style"
-    [attr.data-variant]="variant"
+    [attr.data-param-style]="params.style"
+    [attr.data-variant]="params.variant"
   >
-    <ion-icon *ngIf="icon" slot="start" src="{{ icon | plhAsset }}"></ion-icon>
-    <span *ngIf="_row.value" [class]="'left ' + textAlign" [innerHTML]="_row.value | markdown">
+    <ion-icon *ngIf="params.icon" slot="start" src="{{ params.icon | plhAsset }}"></ion-icon>
+    <span
+      *ngIf="_row.value"
+      [class]="'left ' + params.textAlign"
+      [innerHTML]="_row.value | markdown"
+    >
     </span>
     <span *ngIf="_row.rows" class="children">
       <plh-template-component
@@ -27,10 +31,10 @@
     *ngSwitchCase="true"
     class="button-container"
     (click)="triggerActions('click')"
-    [attr.data-variant]="variant"
+    [attr.data-variant]="params.variant"
   >
-    <img *ngIf="image" src="{{ image | plhAsset }}" />
-    <div *ngIf="_row.value" [class]="'button-text ' + textAlign">
+    <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
+    <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">
       {{ _row.value }}
     </div>
     <span *ngIf="_row.rows" class="children">

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -36,12 +36,13 @@ ion-button[disabled] {
 }
 
 /// nested_color style applies semi-transparent background to match container
-ion-button[data-param-style~="nested_color"] {
+ion-button[data-param-style~="nested_color"],
+ion-button[data-variant~="nested_color"] {
   --background: linear-gradient(rgb(0 0 0 / 13%) 0%, rgb(0 0 0 / 20%) 100%);
 }
 
-// nested_color style applies semi-transparent background to match container
-ion-button[data-param-style~="card"] {
+ion-button[data-param-style~="card"],
+ion-button[data-variant~="card"] {
   --background: white;
   --background-activated: var(--ion-color-gray-light);
   --padding-top: 4px;
@@ -64,6 +65,52 @@ ion-button[data-param-style~="card"] {
     right: 0;
     display: flex;
     align-items: center;
+  }
+}
+
+.button-container[data-variant~="card-portrait"] {
+  background-color: white;
+  color: var(--ion-color-primary);
+  font-size: var(--buttons-font-size-small);
+  font-weight: var(--font-weight-bold);
+  border: 1px solid var(--ion-color-gray-light);
+  border-radius: var(--ion-border-radius-secondary);
+  min-height: var(--buttons-short-height);
+  filter: drop-shadow(var(--ion-default-box-shadow));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.5rem 0.5rem 0.5rem;
+  // TODO: make a variable, shared with task card
+  width: 165px;
+
+  &:active {
+    background-color: var(--ion-color-gray-light);
+  }
+
+  img {
+    width: 85%;
+  }
+
+  .button-text {
+    width: 100%;
+    padding: 1rem 1rem 0.2rem;
+    text-align: center;
+    &.right {
+      text-align: right;
+    }
+    &.left {
+      text-align: left;
+    }
+  }
+  .children {
+    position: absolute;
+    align-self: flex-end;
+    right: -4px;
+    top: -12px;
+    display: flex;
+    align-items: center;
+    padding: -8px;
   }
 }
 

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -82,7 +82,7 @@ ion-button[data-variant~="card"] {
   align-items: center;
   padding: 1.5rem 0.5rem 0.5rem;
   // TODO: make a variable, shared with task card
-  width: 165px;
+  width: 160px;
 
   &:active {
     background-color: var(--ion-color-gray-light);
@@ -94,7 +94,7 @@ ion-button[data-variant~="card"] {
 
   .button-text {
     width: 100%;
-    padding: 1rem 1rem 0.2rem;
+    padding: 1rem 0.5rem 0.5rem;
     text-align: center;
     &.right {
       text-align: right;

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -5,6 +5,34 @@ import {
 } from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 
+interface IButtonParams {
+  /** TEMPLATE PARAMETER: "variant" */
+  variant:
+    | "alternative"
+    | "card"
+    | "card-portrait"
+    | "flexible"
+    | "full"
+    | "information"
+    | "medium"
+    | "navigation"
+    | "short"
+    | "standard"
+    | "tall";
+  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
+  style: string;
+  /** TEMPLATE PARAMETER: "disabled". If true, button is disabled and greyed out */
+  disabled: boolean;
+  /** TEMPLATE PARAMETER: "text_align" */
+  textAlign: "left" | "centre" | "right";
+  /** TEMPLATE PARAMETER: "button_align" */
+  buttonAlign: "left" | "centre" | "right";
+  /** TEMPLATE PARAMETER: "icon". The path to an icon asset */
+  icon: string;
+  /** TEMPLATE PARAMETER: "image". The path to an image asset */
+  image: string;
+}
+
 /**
  * A general-purpose button component
  */
@@ -14,25 +42,22 @@ import { TemplateBaseComponent } from "../base";
   styleUrls: ["./button.component.scss"],
 })
 export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
-  /** TEMPLATE PARAMETER: "style" */
-  style:
-    | "information"
-    | "navigation"
-    | "full"
-    | "flexible"
-    | "medium"
-    | "short"
-    | "tall"
-    | "standard"
-    | "alternative" = "information";
+  /** TEMPLATE PARAMETER: "variant" */
+  variant: IButtonParams["variant"] = "information";
+  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
+  style: IButtonParams["style"];
   /** TEMPLATE PARAMETER: "disabled". If true, button is disabled and greyed out */
-  disabled: boolean = false;
+  disabled: IButtonParams["disabled"] = false;
   /** TEMPLATE PARAMETER: "text_align" */
-  textAlign: "left" | "centre" | "right" = "left";
+  textAlign: IButtonParams["textAlign"] = "left";
   /** TEMPLATE PARAMETER: "button_align" */
-  buttonAlign: "left" | "centre" | "right" = "centre";
+  buttonAlign: IButtonParams["buttonAlign"] = "centre";
   /** TEMPLATE PARAMETER: "icon". The path to an icon asset */
-  icon: string;
+  icon: IButtonParams["icon"];
+  /** TEMPLATE PARAMETER: "image". The path to an image asset */
+  image: IButtonParams["image"];
+  /** @ignore */
+  isCardPortrait: boolean = false;
 
   /** @ignore */
   constructor(private elRef: ElementRef) {
@@ -47,11 +72,16 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     this.style = `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
       this.isTwoColumns() ? "two_columns" : ""
     }` as any;
+    this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
+      .split(",")
+      .join(" ") as IButtonParams["variant"];
+    this.isCardPortrait = this.variant.split(" ").includes("card-portrait");
     this.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
+    this.image = getStringParamFromTemplateRow(this._row, "image", null);
     if (this._row.disabled) {
       this.disabled = true;
     }
-    this.textAlign = getStringParamFromTemplateRow(this._row, "text_align", "left") as any;
+    this.textAlign = getStringParamFromTemplateRow(this._row, "text_align", null) as any;
     this.buttonAlign = getStringParamFromTemplateRow(this._row, "button_align", "center") as any;
     this.icon = getStringParamFromTemplateRow(this._row, "icon", null);
   }

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -42,20 +42,7 @@ interface IButtonParams {
   styleUrls: ["./button.component.scss"],
 })
 export class TmplButtonComponent extends TemplateBaseComponent implements OnInit {
-  /** TEMPLATE PARAMETER: "variant" */
-  variant: IButtonParams["variant"] = "information";
-  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
-  style: IButtonParams["style"];
-  /** TEMPLATE PARAMETER: "disabled". If true, button is disabled and greyed out */
-  disabled: IButtonParams["disabled"] = false;
-  /** TEMPLATE PARAMETER: "text_align" */
-  textAlign: IButtonParams["textAlign"] = "left";
-  /** TEMPLATE PARAMETER: "button_align" */
-  buttonAlign: IButtonParams["buttonAlign"] = "centre";
-  /** TEMPLATE PARAMETER: "icon". The path to an icon asset */
-  icon: IButtonParams["icon"];
-  /** TEMPLATE PARAMETER: "image_asset". The path to an image asset */
-  image: IButtonParams["image"];
+  params: Partial<IButtonParams> = {};
   /** @ignore */
   variantMap: { cardPortrait: boolean };
 
@@ -69,21 +56,25 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
   }
 
   private getParams() {
-    this.style = `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
+    this.params.style = `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
       this.isTwoColumns() ? "two_columns" : ""
     }` as any;
-    this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
+    this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IButtonParams["variant"];
     this.populateVariantMap();
-    this.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
-    this.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
+    this.params.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
+    this.params.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
     if (this._row.disabled) {
-      this.disabled = true;
+      this.params.disabled = true;
     }
-    this.textAlign = getStringParamFromTemplateRow(this._row, "text_align", null) as any;
-    this.buttonAlign = getStringParamFromTemplateRow(this._row, "button_align", "center") as any;
-    this.icon = getStringParamFromTemplateRow(this._row, "icon", null);
+    this.params.textAlign = getStringParamFromTemplateRow(this._row, "text_align", null) as any;
+    this.params.buttonAlign = getStringParamFromTemplateRow(
+      this._row,
+      "button_align",
+      "center"
+    ) as any;
+    this.params.icon = getStringParamFromTemplateRow(this._row, "icon", null);
   }
 
   /** Determine if the button is inside a display group with the style "two_columns" */
@@ -97,7 +88,7 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
   }
 
   private populateVariantMap() {
-    const variantArray = this.variant.split(" ");
+    const variantArray = this.params.variant.split(" ");
     this.variantMap = {
       cardPortrait: variantArray.includes("card-portrait"),
     };

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -29,7 +29,7 @@ interface IButtonParams {
   buttonAlign: "left" | "centre" | "right";
   /** TEMPLATE PARAMETER: "icon". The path to an icon asset */
   icon: string;
-  /** TEMPLATE PARAMETER: "image". The path to an image asset */
+  /** TEMPLATE PARAMETER: "image_asset". The path to an image asset */
   image: string;
 }
 
@@ -54,10 +54,10 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
   buttonAlign: IButtonParams["buttonAlign"] = "centre";
   /** TEMPLATE PARAMETER: "icon". The path to an icon asset */
   icon: IButtonParams["icon"];
-  /** TEMPLATE PARAMETER: "image". The path to an image asset */
+  /** TEMPLATE PARAMETER: "image_asset". The path to an image asset */
   image: IButtonParams["image"];
   /** @ignore */
-  isCardPortrait: boolean = false;
+  variantIsCardPortrait: boolean = false;
 
   /** @ignore */
   constructor(private elRef: ElementRef) {
@@ -75,9 +75,9 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IButtonParams["variant"];
-    this.isCardPortrait = this.variant.split(" ").includes("card-portrait");
+    this.variantIsCardPortrait = this.variant.split(" ").includes("card-portrait");
     this.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
-    this.image = getStringParamFromTemplateRow(this._row, "image", null);
+    this.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
     if (this._row.disabled) {
       this.disabled = true;
     }

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -57,7 +57,7 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
   /** TEMPLATE PARAMETER: "image_asset". The path to an image asset */
   image: IButtonParams["image"];
   /** @ignore */
-  variantIsCardPortrait: boolean = false;
+  variantMap: { cardPortrait: boolean };
 
   /** @ignore */
   constructor(private elRef: ElementRef) {
@@ -75,7 +75,7 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IButtonParams["variant"];
-    this.variantIsCardPortrait = this.variant.split(" ").includes("card-portrait");
+    this.populateVariantMap();
     this.disabled = getBooleanParamFromTemplateRow(this._row, "disabled", false);
     this.image = getStringParamFromTemplateRow(this._row, "image_asset", null);
     if (this._row.disabled) {
@@ -94,5 +94,12 @@ export class TmplButtonComponent extends TemplateBaseComponent implements OnInit
     } else {
       return false;
     }
+  }
+
+  private populateVariantMap() {
+    const variantArray = this.variant.split(" ");
+    this.variantMap = {
+      cardPortrait: variantArray.includes("card-portrait"),
+    };
   }
 }

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
@@ -1,0 +1,16 @@
+<div
+  class="container"
+  [class]="position"
+  [attr.data-param-style]="style"
+  [attr.data-variant]="variant"
+>
+  <div *ngIf="!isVariantIcon" class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
+    <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
+  </div>
+  <div *ngIf="isVariantIcon" class="toggle_wrapper">
+    <div class="icon-wrapper" (click)="handleClick($event)">
+      <img [src]="(_row.value ? iconTrue : iconFalse) | plhAsset" />
+    </div>
+  </div>
+  <span class="label" *ngIf="trueText && falseText">{{ _row.value ? trueText : falseText }} </span>
+</div>

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
@@ -4,17 +4,19 @@
   [attr.data-param-style]="style"
   [attr.data-variant]="variant"
 >
-  <div
-    *ngIf="!variantIsCardPortrait"
-    class="toggle_wrapper"
-    [class.show-tick-cross]="showTickAndCross"
-  >
-    <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
-  </div>
-  <div *ngIf="variantIsCardPortrait" class="toggle_wrapper">
-    <div class="icon-wrapper" (click)="handleClick($event)">
-      <img [src]="(_row.value ? iconTrue : iconFalse) | plhAsset" />
+  <ng-container [ngSwitch]="variantMap.icon">
+    <!-- Default variant -->
+    <div *ngSwitchCase="false" class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
+      <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
     </div>
-  </div>
+
+    <!-- "icon" variant, replaces ion-toggle with alternating pair of icons -->
+    <div *ngSwitchCase="true" class="toggle_wrapper">
+      <div class="icon-wrapper" (click)="handleClick($event)">
+        <img [src]="(_row.value ? iconTrue : iconFalse) | plhAsset" />
+      </div>
+    </div>
+  </ng-container>
+
   <span class="label" *ngIf="trueText && falseText">{{ _row.value ? trueText : falseText }} </span>
 </div>

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
@@ -4,10 +4,14 @@
   [attr.data-param-style]="style"
   [attr.data-variant]="variant"
 >
-  <div *ngIf="!isVariantIcon" class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
+  <div
+    *ngIf="!variantIsCardPortrait"
+    class="toggle_wrapper"
+    [class.show-tick-cross]="showTickAndCross"
+  >
     <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
   </div>
-  <div *ngIf="isVariantIcon" class="toggle_wrapper">
+  <div *ngIf="variantIsCardPortrait" class="toggle_wrapper">
     <div class="icon-wrapper" (click)="handleClick($event)">
       <img [src]="(_row.value ? iconTrue : iconFalse) | plhAsset" />
     </div>

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.html
@@ -1,22 +1,28 @@
 <div
   class="container"
-  [class]="position"
-  [attr.data-param-style]="style"
-  [attr.data-variant]="variant"
+  [class]="params.position"
+  [attr.data-param-style]="params.style"
+  [attr.data-variant]="params.variant"
 >
   <ng-container [ngSwitch]="variantMap.icon">
     <!-- Default variant -->
-    <div *ngSwitchCase="false" class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
+    <div
+      *ngSwitchCase="false"
+      class="toggle_wrapper"
+      [class.show-tick-cross]="params.showTickAndCross"
+    >
       <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
     </div>
 
     <!-- "icon" variant, replaces ion-toggle with alternating pair of icons -->
     <div *ngSwitchCase="true" class="toggle_wrapper">
       <div class="icon-wrapper" (click)="handleClick($event)">
-        <img [src]="(_row.value ? iconTrue : iconFalse) | plhAsset" />
+        <img [src]="(_row.value ? params.iconTrue : params.iconFalse) | plhAsset" />
       </div>
     </div>
   </ng-container>
 
-  <span class="label" *ngIf="trueText && falseText">{{ _row.value ? trueText : falseText }} </span>
+  <span class="label" *ngIf="params.trueText && params.falseText"
+    >{{ _row.value ? params.trueText : params.falseText }}
+  </span>
 </div>

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.scss
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.scss
@@ -42,12 +42,23 @@ ion-toggle {
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
 
-.container[data-param-style~="in_button"] {
-  flex-direction: row-reverse;
-  ion-toggle {
-    transform: translate($togglePadding, $togglePadding);
+  &[data-param-style~="in_button"],
+  &[data-variant~="in_button"] {
+    flex-direction: row-reverse;
+    ion-toggle {
+      transform: translate($togglePadding, $togglePadding);
+    }
+  }
+
+  &[data-variant~="icon"] {
+    .icon-wrapper {
+      width: 24px;
+      margin: 12px;
+      img {
+        width: 100%;
+      }
+    }
   }
 }
 

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
@@ -6,32 +6,43 @@ import {
   getBooleanParamFromTemplateRow,
 } from "src/app/shared/utils";
 
+interface IToggleParams {
+  /** TEMPLATE PARAMETER: "variant" */
+  variant: "" | "icon" | "in_button";
+  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
+  style: string;
+  /** TEMPLATE PARAMETER: "show_tick_and_cross" */
+  showTickAndCross: boolean;
+  /** TEMPLATE PARAMETER: "position". Default "left" */
+  position: "left" | "center" | "right";
+  /** TEMPLATE PARAMETER: "false_text". Label text to display when value is false */
+  falseText: string;
+  /** TEMPLATE PARAMETER: "true_text". Label text to display when value is true */
+  trueText: string;
+  /** TEMPLATE PARAMETER: "icon_true". Clickable icon to display when value is true */
+  iconTrue: string;
+  /** TEMPLATE PARAMETER: "icon_false". Clickable icon to display when value is false */
+  iconFalse: string;
+}
+
 @Component({
   selector: "plh-tmpl-toggle-bar",
-  template: `
-    <div class="container" [class]="position" [attr.data-param-style]="style">
-      <div class="toggle_wrapper" [class.show-tick-cross]="showTickAndCross">
-        <ion-toggle mode="md" [checked]="_row.value" (click)="handleClick($event)"> </ion-toggle>
-      </div>
-      <span
-        class="label"
-        *ngIf="true_text && false_text"
-        [innerHTML]="true_text && false_text | markdown"
-        >{{ _row.value ? true_text : false_text }}</span
-      >
-    </div>
-  `,
+  templateUrl: "./toggle-bar.html",
   styleUrls: ["./toggle-bar.scss"],
 })
 export class TmplToggleBarComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit
 {
-  public false_text: string;
-  public true_text: string;
-  public position: string;
-  public showTickAndCross: boolean;
-  style: string;
+  public falseText: IToggleParams["falseText"];
+  public trueText: IToggleParams["trueText"];
+  public position: IToggleParams["position"];
+  public showTickAndCross: IToggleParams["showTickAndCross"];
+  public iconTrue: IToggleParams["iconTrue"];
+  public iconFalse: IToggleParams["iconFalse"];
+  style: IToggleParams["style"];
+  variant: IToggleParams["variant"];
+  isVariantIcon: boolean;
 
   ngOnInit() {
     this.getParams();
@@ -48,10 +59,20 @@ export class TmplToggleBarComponent
   }
 
   getParams() {
-    this.false_text = getStringParamFromTemplateRow(this._row, "false_text", "");
-    this.true_text = getStringParamFromTemplateRow(this._row, "true_text", "");
-    this.position = getStringParamFromTemplateRow(this._row, "position", "left");
+    this.falseText = getStringParamFromTemplateRow(this._row, "false_text", "");
+    this.trueText = getStringParamFromTemplateRow(this._row, "true_text", "");
+    this.position = getStringParamFromTemplateRow(
+      this._row,
+      "position",
+      "left"
+    ) as IToggleParams["position"];
     this.showTickAndCross = getBooleanParamFromTemplateRow(this._row, "show_tick_and_cross", true);
     this.style = getStringParamFromTemplateRow(this._row, "style", "");
+    this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
+      .split(",")
+      .join(" ") as IToggleParams["variant"];
+    this.isVariantIcon = this.variant.split(" ").includes("icon");
+    this.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true", "");
+    this.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false", "");
   }
 }

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
@@ -51,7 +51,7 @@ export class TmplToggleBarComponent
   /** TEMPLATE PARAMETER: "variant" */
   variant: IToggleParams["variant"];
   /** @ignore */
-  variantIsCardPortrait: boolean;
+  variantMap: { icon: boolean };
 
   ngOnInit() {
     this.getParams();
@@ -80,8 +80,15 @@ export class TmplToggleBarComponent
     this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IToggleParams["variant"];
-    this.variantIsCardPortrait = this.variant.split(" ").includes("icon");
+    this.populateVariantMap();
     this.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true_asset", "");
     this.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false_asset", "");
+  }
+
+  private populateVariantMap() {
+    const variantArray = this.variant.split(" ");
+    this.variantMap = {
+      icon: variantArray.includes("icon"),
+    };
   }
 }

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
@@ -34,22 +34,7 @@ export class TmplToggleBarComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit
 {
-  /** TEMPLATE PARAMETER: "false_text". Label text to display when value is false */
-  public falseText: IToggleParams["falseText"];
-  /** TEMPLATE PARAMETER: "true_text". Label text to display when value is true */
-  public trueText: IToggleParams["trueText"];
-  /** TEMPLATE PARAMETER: "position". Default "left" */
-  public position: IToggleParams["position"];
-  /** TEMPLATE PARAMETER: "show_tick_and_cross" */
-  public showTickAndCross: IToggleParams["showTickAndCross"];
-  /** TEMPLATE PARAMETER: "icon_true_asset". Clickable icon to display when value is true */
-  public iconTrue: IToggleParams["iconTrue"];
-  /** TEMPLATE PARAMETER: "icon_false_asset". Clickable icon to display when value is false */
-  public iconFalse: IToggleParams["iconFalse"];
-  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
-  style: IToggleParams["style"];
-  /** TEMPLATE PARAMETER: "variant" */
-  variant: IToggleParams["variant"];
+  params: Partial<IToggleParams> = {};
   /** @ignore */
   variantMap: { icon: boolean };
 
@@ -68,25 +53,29 @@ export class TmplToggleBarComponent
   }
 
   getParams() {
-    this.falseText = getStringParamFromTemplateRow(this._row, "false_text", "");
-    this.trueText = getStringParamFromTemplateRow(this._row, "true_text", "");
-    this.position = getStringParamFromTemplateRow(
+    this.params.falseText = getStringParamFromTemplateRow(this._row, "false_text", "");
+    this.params.trueText = getStringParamFromTemplateRow(this._row, "true_text", "");
+    this.params.position = getStringParamFromTemplateRow(
       this._row,
       "position",
       "left"
     ) as IToggleParams["position"];
-    this.showTickAndCross = getBooleanParamFromTemplateRow(this._row, "show_tick_and_cross", true);
-    this.style = getStringParamFromTemplateRow(this._row, "style", "");
-    this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
+    this.params.showTickAndCross = getBooleanParamFromTemplateRow(
+      this._row,
+      "show_tick_and_cross",
+      true
+    );
+    this.params.style = getStringParamFromTemplateRow(this._row, "style", "");
+    this.params.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IToggleParams["variant"];
     this.populateVariantMap();
-    this.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true_asset", "");
-    this.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false_asset", "");
+    this.params.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true_asset", "");
+    this.params.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false_asset", "");
   }
 
   private populateVariantMap() {
-    const variantArray = this.variant.split(" ");
+    const variantArray = this.params.variant.split(" ");
     this.variantMap = {
       icon: variantArray.includes("icon"),
     };

--- a/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
+++ b/src/app/shared/components/template/components/toggle-bar/toggle-bar.ts
@@ -19,9 +19,9 @@ interface IToggleParams {
   falseText: string;
   /** TEMPLATE PARAMETER: "true_text". Label text to display when value is true */
   trueText: string;
-  /** TEMPLATE PARAMETER: "icon_true". Clickable icon to display when value is true */
+  /** TEMPLATE PARAMETER: "icon_true_asset". Clickable icon to display when value is true */
   iconTrue: string;
-  /** TEMPLATE PARAMETER: "icon_false". Clickable icon to display when value is false */
+  /** TEMPLATE PARAMETER: "icon_false_asset". Clickable icon to display when value is false */
   iconFalse: string;
 }
 
@@ -34,15 +34,24 @@ export class TmplToggleBarComponent
   extends TemplateBaseComponent
   implements ITemplateRowProps, OnInit
 {
+  /** TEMPLATE PARAMETER: "false_text". Label text to display when value is false */
   public falseText: IToggleParams["falseText"];
+  /** TEMPLATE PARAMETER: "true_text". Label text to display when value is true */
   public trueText: IToggleParams["trueText"];
+  /** TEMPLATE PARAMETER: "position". Default "left" */
   public position: IToggleParams["position"];
+  /** TEMPLATE PARAMETER: "show_tick_and_cross" */
   public showTickAndCross: IToggleParams["showTickAndCross"];
+  /** TEMPLATE PARAMETER: "icon_true_asset". Clickable icon to display when value is true */
   public iconTrue: IToggleParams["iconTrue"];
+  /** TEMPLATE PARAMETER: "icon_false_asset". Clickable icon to display when value is false */
   public iconFalse: IToggleParams["iconFalse"];
+  /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
   style: IToggleParams["style"];
+  /** TEMPLATE PARAMETER: "variant" */
   variant: IToggleParams["variant"];
-  isVariantIcon: boolean;
+  /** @ignore */
+  variantIsCardPortrait: boolean;
 
   ngOnInit() {
     this.getParams();
@@ -71,8 +80,8 @@ export class TmplToggleBarComponent
     this.variant = getStringParamFromTemplateRow(this._row, "variant", "")
       .split(",")
       .join(" ") as IToggleParams["variant"];
-    this.isVariantIcon = this.variant.split(" ").includes("icon");
-    this.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true", "");
-    this.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false", "");
+    this.variantIsCardPortrait = this.variant.split(" ").includes("icon");
+    this.iconTrue = getStringParamFromTemplateRow(this._row, "icon_true_asset", "");
+    this.iconFalse = getStringParamFromTemplateRow(this._row, "icon_false_asset", "");
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Adds a new variant for the button component, `card-portrait`
  - Adds an additional parameter related to this variant: `image_asset` (NB, this uses the new `_asset` suffix convention as suggested in #1979)
- Adds a new variant for the toggle bar component, `icon`
  - Adds additional params related to this variant: `icon_true_asset` and `icon_false_asset`

This continues the "variant" convention introduced in #1970 . We may want to alter this convention according to changes we decide to make in relation to #1971 (e.g. "variant" may end up being a column rather than a component parameter). However, the convention followed in this PR would still represent a step in the right direction, and this component variant is needed urgently.

It seemed sensible to me to leave the inclusion of the toggle up to the authoring, as opposed to embedding it within the button component itself. This allows the author to access the value of the toggle bar directly, without needing to expose another parameter of the button, and allows them to set actions on the toggle bar directly. As a result of this decision, the icon representation of the toggle is a variant of the toggle bar component itself.


## Testing

In order to view the updates to the relevant debug sheets, with the `debug` deployment active, run `yarn workflow sync`. 
These changes are included in [this PR](https://github.com/IDEMSInternational/app-debug-content/pull/23) on the deployment repo.

It may be that the styling of the card portrait button variant needs some tweaks in response to interaction with actual images, and how the buttons look in a carousel.

## Dev notes

- In general, the button component makes use of an `ion-button` component
  - However, this doesn't allow for the customisation we want here: we can't set the height of the ionic element or make it portrait, and it only supports images in one of its designated "slots"
  - Therefore, this PR effectively renders a completely different component in the case of `variant: card-portrait`. This arguably leads to messy code, but hopefully it's still simple for authors, who don't need to understand the difference between using the ionic component and not.
  - It was discussed whether this component should be a variant of button or a variant of task-card, and it was agreed that fundamentally the difference lies in whether or not the component instance has an associated task. The component required for this use case is not related to tasks, and so it should be a variant of a button.

- I've employed the new convention of defining an interface that represents a component's parameters at the top of the component file (good for documentation, and code clarity in general). Let me know if this looks sensible.
  - Ultimately, we may want to rethink the util functions "getStringParamFromTemplateRow()" etc., as well as the manually written "getParams()" method that exists on all components that take parameters: should there be a way of just defining the params interface and feeding that into a util function to extract all the necessary params into properties of the appropriate type?

## Git Issues

Closes #1934 

## Screenshots/Videos

### Updates to [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit#gid=569531329)
<img width="800" alt="Screenshot 2023-07-18 at 16 26 37" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/00f7de64-5246-47fb-8e11-ce279e26b147">

<img width="367" alt="Screenshot 2023-07-18 at 16 27 39" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/ae6b6114-eb11-48b7-b984-edf28a5c7365">


### Updates to [comp_toggle_bar](https://docs.google.com/spreadsheets/d/17SbJITgQSdNs3PNusDJrkbmCLDutOH9jN_qiea8r0zo/edit#gid=569531329)
<img width="1349" alt="Screenshot 2023-07-18 at 16 44 52" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/19b43617-fa65-48f3-9ea3-e71aa4d8f9bf">

<img width="370" alt="Screenshot 2023-07-18 at 16 45 36" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/bfb0f8ea-7946-478d-a4ed-a17d3a335564">

