### PR TITLE
feat: exclude uncompressed audio assets from plh deployments

### DIFF
--- a/.idems_app/deployments/plh/config.ts
+++ b/.idems_app/deployments/plh/config.ts
@@ -22,6 +22,8 @@ config.translations = {
   source_strings_path: "packages/app-data/translations_source/to_translate",
 };
 
+config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("uncompressed")
+
 config.app_config.APP_LANGUAGES.default = "gb_en";
 config.app_config.APP_SIDEMENU_DEFAULTS.title = "ParentApp";
 config.app_config.APP_HEADER_DEFAULTS.title = "ParentApp";

--- a/.idems_app/deployments/plh_tz/config.ts
+++ b/.idems_app/deployments/plh_tz/config.ts
@@ -8,6 +8,7 @@ config.app_data!.sheets_filter_function = (flow) =>
     flow.flow_subtype!
   );
 config.translations!.filter_language_codes = ["tz_en", "tz_sw"];
+config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("uncompressed")
 
 // Override constants
 config.app_config!.APP_LANGUAGES!.default = "tz_sw";

--- a/.idems_app/deployments/plh_tz/config.ts
+++ b/.idems_app/deployments/plh_tz/config.ts
@@ -8,7 +8,6 @@ config.app_data!.sheets_filter_function = (flow) =>
     flow.flow_subtype!
   );
 config.translations!.filter_language_codes = ["tz_en", "tz_sw"];
-config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("uncompressed")
 
 // Override constants
 config.app_config!.APP_LANGUAGES!.default = "tz_sw";


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

In order to reduce the size of the app bundle to under the 150MB Play Store limit, which the `plh_tz` deployment was in danger of exceeding, it was decided that we could compress the audio files that are included in the app. 

All audio files for the `global` and `tz_sw` languages have now been compressed, reducing their size by around 60%, and reducing the size of all assets included in the `plh_tz` deployment to around 98MB. We agreed that any loss in audio quality was very difficult to detect (see [this Mattermost thread](https://chat.idems.international/all/pl/ux8jhtkhcjfu88yyzbh7qyr19a) for discussion and description of the compression process).

In order to keep the original uncompressed audio files, in case there are any issues with the compressed versions and potentially to be included in future high-quality asset packs, I've put the original uncompressed files in folders called "uncompressed", which can be found in the original location of the files. The compressed files are to be found at the original locations of the uncompressed files, meaning that no authoring changes are required to use the compressed audio files in the app. See the folder [plh_assets > tz_sw > plh_audio > relax](https://drive.google.com/drive/u/1/folders/1ruwIDKzmxkDRlmvJL40443Q7pSzQO2Rd) for an example.

In order to exclude the original, uncompressed audio files from the build `plh` deployments, this PR adds an asset filter function to exclude any file whose path contains the substring "uncompressed".

We may want to revisit this approach in the future, but it should be sufficient for meeting our requirements for the imminent `plh_tz` release.

## Testing

With this feature branch checked out, set the active deployment to `plh_tz`. You may need to delete the file `.idems_app/deployments/plh/config.json` before setting the deployment to `plh_tz` in order to ensure that the config recompiles to include the changes made to the parent deployment config (issue #1884). Then run `yarn workflow sync`. You should see that the asset size summary matches that in the screenshot below.

It would be good to quickly check that the changes I have made to the asset folders in Google Drive look right: namely the subfolders of [plh_assets > tz_sw > plh_audio](https://drive.google.com/drive/u/1/folders/1HyNE8dBo4RoaqNh6NIquN-AHBFAPCE0J) and [plh_assets > global > plh_audio](https://drive.google.com/drive/u/1/folders/1IfXCZ4Cv4gCDayhdYhITPDJpiXxr2CzP). It would also be good to run some spot checks to ensure that the correct audio assets are being populated to the app correctly.

## Git Issues

Closes #

## Screenshots/Videos

The assets size summary generated for the `plh_tz` deployment when syncing assets:

<img width="369" alt="Screenshot 2023-07-26 at 17 23 56" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/cd71b309-4003-4e7d-8f48-f8617c44fb29">
