### PR TITLE
Fix: Too much padding on the dashed_box; handle case of no value

### DIFF
--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.scss
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.scss
@@ -12,7 +12,6 @@
     border-radius: var(--ion-border-radius-secondary);
     position: relative;
     .text {
-      white-space: pre-line;
       text-align: center;
       font-size: var(--font-size-text-medium);
       line-height: var(--line-height-text-largest);

--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
@@ -24,7 +24,11 @@ export class TmplDashedBoxComponent
 
   ngOnInit() {
     this.getParams();
-    this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(marked(this._row.value.toString()));
+    if (this._row.value) {
+      this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(
+        marked(this._row.value.toString())
+      );
+    }
   }
 
   getParams() {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

It fixes the error of too much padding in the dashed-box component, and handles the issue of there being a TypeError when no value is passed (see discussion under #2014).

## Git Issues

Closes #2017 

## Screenshots/Videos

![localhost_4200_template_home_screen(iPhone XR)](https://github.com/IDEMSInternational/parenting-app-ui/assets/88288104/12eb38ee-de55-48cd-8d9f-c5f0edf1c24f)

