### PR TITLE
fix: remove github label requirement from deployment-hosting action

### DIFF
--- a/.github/workflows/deployment-hosting.yml
+++ b/.github/workflows/deployment-hosting.yml
@@ -15,7 +15,6 @@ concurrency:
 
 jobs:
   build:  
-    if: contains(github.event.pull_request.labels.*.name, 'Test - preview')
     uses: ./.github/workflows/web-build.yml
     secrets: inherit
     with:


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue in the reworked "Deployment Hosting" github action that was introduced in #2025, whereby pushes to `master` and `deployment/*` branches would not trigger the action unless the `test - preview` label was present on the PR.

See [this Mattermost thread](https://chat.idems.international/all/pl/1ep4h83ijjddprurhtuwcjcaeh) identifying the issue.

## Git Issues

Closes #
