### PR TITLE
fix: text-wrap on accordion titles

### DIFF
--- a/src/app/shared/components/template/components/accordion/accordion.component.html
+++ b/src/app/shared/components/template/components/accordion/accordion.component.html
@@ -10,7 +10,9 @@
     [style.z-index]="_row.rows.length - i"
   >
     <ion-item slot="header" class="accordion-header clear" lines="none">
-      <ion-label class="accordion-section-title">{{ childRow.value || "" }}</ion-label>
+      <ion-label class="accordion-section-title ion-text-wrap">{{
+        childRow.value || ""
+      }}</ion-label>
       <!-- If custom icon supplied override. Otherwise default will be arrow -->
       <ng-template [ngIf]="_row.parameter_list?.open_icon_src" let-open_icon_src="ngIf">
         <ng-container


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue whereby text in the titles of accordion sections would not wrap, meaning text would be cut off on smaller screens.

## Git Issues

Closes #2036

## Screenshots/Videos

[example_accordion](https://docs.google.com/spreadsheets/d/1gfnWmr59DF0ZsuSuBh0K1o9fMqEg-z6Qa7eJNsiB-rQ/edit#gid=63099847) template:

<img width="220" alt="Screenshot 2023-08-29 at 16 28 23" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f54913f4-bdad-4527-8d22-1f35c5218591">

[w_svp_learn_use_voice](https://docs.google.com/spreadsheets/d/1sW2Cx4JdLLFzy-2zn4syUiFcXJECku6nNtyo02EIM38/edit#gid=715202550) template
<img width="400" alt="Screenshot 2023-08-29 at 16 33 44" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/3b9962a9-1144-47b0-8345-72feea3a5cb7">
