### PR TITLE
fix: for all components that render child rows, filter out non-display rows

### DIFF
--- a/src/app/shared/components/template/components/accordion/accordion.component.html
+++ b/src/app/shared/components/template/components/accordion/accordion.component.html
@@ -5,7 +5,7 @@
 >
   <ion-accordion
     [value]="childRow.name"
-    *ngFor="let childRow of _row.rows; index as i"
+    *ngFor="let childRow of _row.rows | filterDisplayComponent; index as i"
     toggle-icon="arrow-down-circle"
     [style.z-index]="_row.rows.length - i"
   >

--- a/src/app/shared/components/template/components/animated-slides/animated-slides.component.html
+++ b/src/app/shared/components/template/components/animated-slides/animated-slides.component.html
@@ -5,7 +5,7 @@
   </ion-button>
   <div class="section-container">
     <section
-      *ngFor="let childRow of _row.rows; let idx = index"
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; let idx = index"
       [@fadeInOut]="slideParams[idx].animation === 'fade' ? fadeSection[idx] : null"
       [@noFade]="slideParams[idx].animation === 'none' ? fadeSection[idx] : null"
     >

--- a/src/app/shared/components/template/components/layout/accordion-section/accordion-section.component.html
+++ b/src/app/shared/components/template/components/layout/accordion-section/accordion-section.component.html
@@ -43,7 +43,7 @@
     >
       <plh-template-component
         style="z-index: 2"
-        *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+        *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
         [row]="childRow"
         [parent]="parent"
       >

--- a/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
+++ b/src/app/shared/components/template/components/layout/advanced-dashed-box/advanced-dashed-box.component.html
@@ -4,7 +4,7 @@
       <img [src]="icon_src | plhAsset" alt="" />
     </div>
     <plh-template-component
-      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
       style="width: 100%"

--- a/src/app/shared/components/template/components/layout/animated_section.ts
+++ b/src/app/shared/components/template/components/layout/animated_section.ts
@@ -6,7 +6,7 @@ import { TemplateLayoutComponent } from "./layout";
   selector: "plh-tmpl-animated-section",
   template: `
     <plh-template-component
-      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
       [@fadeSection]="_row?.hidden ? 'out' : 'in'"

--- a/src/app/shared/components/template/components/layout/animated_section_group.ts
+++ b/src/app/shared/components/template/components/layout/animated_section_group.ts
@@ -5,7 +5,7 @@ import { TemplateBaseComponent } from "../base";
   selector: "plh-tmpl-animated-section-group",
   template: `<div class="animated-section-group">
     <plh-template-component
-      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
     ></plh-template-component>

--- a/src/app/shared/components/template/components/layout/display-grid/display-grid.component.html
+++ b/src/app/shared/components/template/components/layout/display-grid/display-grid.component.html
@@ -1,6 +1,6 @@
 <div class="display-grid" [ngStyle]="gridStyle">
   <plh-template-component
-    *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+    *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
     [row]="childRow"
     [parent]="parent"
     [attr.data-rowname]="_row.name"

--- a/src/app/shared/components/template/components/layout/form.ts
+++ b/src/app/shared/components/template/components/layout/form.ts
@@ -12,7 +12,7 @@ import { Device } from "@capacitor/device";
   selector: "plh-tmpl-form",
   template: ` <div>
     <plh-template-component
-      *ngFor="let childRow of _row.rows; trackBy: trackByRow"
+      *ngFor="let childRow of _row.rows | filterDisplayComponent; trackBy: trackByRow"
       [row]="childRow"
       [parent]="parent"
     >


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Some components, e.g. `accordion`, loop over their child rows and render each one. Some rows, e.g. `set_variable` are not intended to be rendered, and so should be excluded from the iterable. A solution to filter out such rows from the list to be rendered was already applied to some components, notably `display_group`. This PR applies that solution to the accordion component, fixing #2083, as well as to all other remaining components that loop over their child rows (`animated-slides`, `accordion-section`, `advanced-dashed-box`, `animated-section`, `animated-section-group`, `display-grid` and `form`).

## Git Issues

Closes #2083

## Screenshots/Videos

[debug_accordion_variables](https://docs.google.com/spreadsheets/d/1AkNZZWGCCwU8olUaoLsAozmZ_7DJaOaEuHOa-LhGci8/edit#gid=1216295414)
<img width="400" alt="Screenshot 2023-09-15 at 16 12 13" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/cf187ae4-c8a1-4947-9c30-326c9713ef41">

<img width="250" alt="Screenshot 2023-09-15 at 15 56 19" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/3a847a1c-d288-423b-a8d5-f352f6eea0b1">
