### PR TITLE
feat: sheets multiple folder ids

### DIFF
--- a/.idems_app/.gitignore
+++ b/.idems_app/.gitignore
@@ -9,3 +9,6 @@ deployments/*
 # Renamed to activeDeployment.json, include here so people can remove
 !/deployments/default.json
 !public.json
+
+# Temp deployments used for development purposes:
+!deployments/debug_gdrive_multiple

--- a/.idems_app/deployments/debug_gdrive_multiple/.gitignore
+++ b/.idems_app/deployments/debug_gdrive_multiple/.gitignore
@@ -1,0 +1,4 @@
+app_data
+cache
+tasks
+config.json

--- a/.idems_app/deployments/debug_gdrive_multiple/config.ts
+++ b/.idems_app/deployments/debug_gdrive_multiple/config.ts
@@ -1,0 +1,17 @@
+import { generateDeploymentConfig } from "scripts";
+
+const config = generateDeploymentConfig("debug_gdrive_multiple");
+
+config.google_drive = {
+  sheets_folder_ids: ["15pDlhePVpTt0XeVsqBrWYToDCK5j-T9F","1kaOxdi3OSNylOmS3YTzLwFnGgTZX9DrM"],
+  assets_folder_ids: ["1xy5z6PQmsrgwLpCCs6HCCUY1-u2H5KYR","1nlRfAkYfqxM-z_FAzt1WXyES_DyFTlmi"],
+};
+
+config.app_data.output_path = "./app_data";
+
+
+// Override any app constants here
+config.app_config.APP_HEADER_DEFAULTS.title = "Debug Data Sources";
+config.app_config.APP_SIDEMENU_DEFAULTS.title = "Debug Data Sources";
+
+export default config;

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -1,17 +1,21 @@
 import type { IAppConfig } from "./appConfig";
 
 /** Update version to force recompile next time deployment set (e.g. after default config update) */
-export const DEPLOYMENT_CONFIG_VERSION = 20230428;
+export const DEPLOYMENT_CONFIG_VERSION = 20230930;
 
 export interface IDeploymentConfig {
   /** Friendly name used to identify the deployment name */
   name: string;
 
   google_drive: {
+    /** @deprecated Use `sheets_folder_ids` array instead */
+    sheets_folder_id?: string;
     /** ID of folder containing app sheets, as seen in end of url */
-    sheets_folder_id: string;
+    sheets_folder_ids?: string[];
+    /** @deprecated Use `assets_folder_ids` array instead */
+    assets_folder_id?: string;
     /** ID of folder containing app assets, as seen in end of url */
-    assets_folder_id: string;
+    assets_folder_ids?: string[];
     /** generated gdrive access token. Default `packages/scripts/config/token.json` */
     auth_token_path?: string;
     /** filter function applied to sheets download that receives basic file info such as folder and id. Default `(gdriveEntry)=>true` */

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -10,11 +10,11 @@ export interface IDeploymentConfig {
   google_drive: {
     /** @deprecated Use `sheets_folder_ids` array instead */
     sheets_folder_id?: string;
-    /** ID of folder containing app sheets, as seen in end of url */
+    /** IDs of folders containing app sheets, as seen in end of url */
     sheets_folder_ids?: string[];
     /** @deprecated Use `assets_folder_ids` array instead */
     assets_folder_id?: string;
-    /** ID of folder containing app assets, as seen in end of url */
+    /** IDs of folders containing app assets, as seen in end of url */
     assets_folder_ids?: string[];
     /** generated gdrive access token. Default `packages/scripts/config/token.json` */
     auth_token_path?: string;

--- a/packages/scripts/src/commands/app-data/convert/index.ts
+++ b/packages/scripts/src/commands/app-data/convert/index.ts
@@ -61,7 +61,7 @@ export default program
  */
 export class AppDataConverter {
   /** Change version to invalidate all underlying caches */
-  public version = 20230406.1;
+  public version = 20231002.0;
 
   public activeDeployment = ActiveDeployment.get();
 

--- a/packages/scripts/src/commands/app-data/convert/processors/base.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/base.ts
@@ -10,7 +10,7 @@ import chalk from "chalk";
 
 class BaseProcessor<T = any, V = any> {
   /** Used to invalidate cache */
-  public cacheVersion = 20230818.0;
+  public cacheVersion = 20231001.0;
 
   public logger: Logger;
 

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.spec.ts
@@ -65,10 +65,12 @@ describe("FlowParser Processor", () => {
     await processor.process([invalidFlow]);
     const errorLogs = getLogs("error");
     expect(errorLogs.length).toEqual(1);
-    expect(errorLogs[0].message).toEqual("No parser available for flow_type: test_invalid_type");
+    const [{ message, details }] = errorLogs;
+    expect(message).toEqual("No parser available for flow_type: test_invalid_type");
+    expect(details.flow_type).toEqual("test_invalid_type");
+    expect(details.flow_name).toEqual("test_data_list");
   });
   it("Logs flow parse errors", async () => {
-    clearLogs();
     const brokenFlow: FlowTypes.FlowTypeWithData = {
       flow_name: "test_broken_flow",
       flow_type: "data_list",

--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -1,7 +1,7 @@
 import { FlowTypes } from "data-models";
 import * as Parsers from "./parsers";
 import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../types";
-import { arrayToHashmap, groupJsonByKey, IContentsEntry, Logger } from "../../utils";
+import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
@@ -67,13 +67,7 @@ export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithDat
       this.processedFlowHashmap[flow_type] = {};
       this.processedFlowHashmapWithMeta[flow_type] = {};
     }
-    const duplicateFlow = this.processedFlowHashmapWithMeta[flow_type][flow_name];
-    if (duplicateFlow) {
-      this.logger.error({
-        message: "Duplicate flow name",
-        details: { flow_name, flow_type, _xlsxPaths: [_xlsxPath, duplicateFlow._xlsxPath] },
-      });
-    }
+    // NOTE - duplicate flows are identified up during main converter
     this.processedFlowHashmap[flow_type][flow_name] = flow.rows;
     this.processedFlowHashmapWithMeta[flow_type][flow_name] = flow;
   }

--- a/packages/scripts/src/commands/deployment/templates/config.default.ts
+++ b/packages/scripts/src/commands/deployment/templates/config.default.ts
@@ -4,8 +4,8 @@ import { generateDeploymentConfig } from "scripts";
 const config = generateDeploymentConfig("${name}")
 
 config.google_drive = {
-  sheets_folder_id: "",
-  assets_folder_id: "",
+  sheets_folder_ids: [""],
+  assets_folder_ids: [""],
 }
 // Override any app constants here
 config.app_config.APP_HEADER_DEFAULTS.title = "${name}"

--- a/packages/scripts/src/tasks/providers/appData.ts
+++ b/packages/scripts/src/tasks/providers/appData.ts
@@ -6,9 +6,9 @@ import { SRC_ASSETS_PATH } from "../../paths";
 import { IContentsEntry, replicateDir } from "../../utils";
 
 /** Prepare sourcely cached assets for population to app */
-const postProcessAssets = async (options: { sourceAssetsFolder: string }) => {
-  const { sourceAssetsFolder } = options;
-  let args = `--source-assets-folder ${sourceAssetsFolder}`;
+const postProcessAssets = async (options: { sourceAssetsFolders: string[] }) => {
+  const { sourceAssetsFolders } = options;
+  let args = `--source-assets-folders ${sourceAssetsFolders.join(",")}`;
   let cmd = `app-data post-process assets ${args}`;
 
   await parseCommand(`${cmd}`);

--- a/packages/scripts/src/tasks/providers/template.ts
+++ b/packages/scripts/src/tasks/providers/template.ts
@@ -3,14 +3,14 @@ import { AppDataConverter } from "../../commands/app-data/convert";
 import { WorkflowRunner } from "../../commands/workflow/run";
 
 /** Process all templates within a folder */
-const process = async (options: { inputFolder: string }) => {
+const process = async (options: { inputFolders: string[] }) => {
   const { _workspace_path } = WorkflowRunner.config;
 
-  const { inputFolder } = options;
+  const { inputFolders } = options;
   const outputFolder = path.resolve(_workspace_path, "tasks", "template", "outputs");
   const cacheFolder = path.resolve(_workspace_path, "tasks", "template", "cache");
   const skipCache = false;
-  const converter = new AppDataConverter({ inputFolder, outputFolder, cacheFolder, skipCache });
+  const converter = new AppDataConverter({ inputFolders, outputFolder, cacheFolder, skipCache });
   await converter.run();
   return outputFolder;
 };

--- a/packages/scripts/test/data/input/sheets_additional/test_additional_input.xlsx
+++ b/packages/scripts/test/data/input/sheets_additional/test_additional_input.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24c0bfcc1de7b1d4f68d8e32c3e1ffe21694d99858687b6a6aa10eb7dab040a8
+size 73457

--- a/packages/scripts/test/helpers/utils.ts
+++ b/packages/scripts/test/helpers/utils.ts
@@ -5,16 +5,15 @@ import { Logger } from "shared/src/utils/logging/console-logger";
  *************************************************************/
 
 /** Mock function that will replace default `Logger` function to instead just record any invocations */
-export const mockErrorLogger = jasmine.createSpy("mockErrorLogger", Logger.error);
 export function useMockErrorLogger() {
+  const mockErrorLogger = jasmine.createSpy("mockErrorLogger", Logger.error);
   spyOn(Logger, "error").and.callFake(mockErrorLogger);
   return mockErrorLogger;
 }
 
 /** Mock function that will replace default `Logger` function to instead just record any invocations */
-export const mockWarningLogger = jasmine.createSpy("mockWarningLogger", Logger.warning);
-
 export function useMockWarningLogger() {
+  const mockWarningLogger = jasmine.createSpy("mockWarningLogger", Logger.warning);
   spyOn(Logger, "warning").and.callFake(mockWarningLogger);
   return mockWarningLogger;
 }

--- a/packages/shared/src/utils/file-utils.ts
+++ b/packages/shared/src/utils/file-utils.ts
@@ -504,16 +504,21 @@ export function mergeFoldersRecursively(
     const { relativePath, modifiedTime } = entry;
     const srcPath = path.resolve(src, relativePath);
     const targetPath = path.resolve(target, relativePath);
-    const mtime = new Date(modifiedTime);
-    fs.ensureDirSync(path.dirname(targetPath));
-    fs.copyFileSync(srcPath, targetPath);
-    fs.utimesSync(targetPath, mtime, mtime);
+    copyFileWithTimestamp(srcPath, targetPath, modifiedTime);
   }
   // Process entries
   Object.entries(srcFiles).forEach(([filepath, entry]) =>
     copySrcToTarget(filepath, entry as IContentsEntry)
   );
 }
+
+export function copyFileWithTimestamp(srcPath: string, targetPath: string, modifiedTime: string) {
+  const mtime = new Date(modifiedTime);
+  fs.ensureDirSync(path.dirname(targetPath));
+  fs.copyFileSync(srcPath, targetPath);
+  fs.utimesSync(targetPath, mtime, mtime);
+}
+
 export function createTempDir() {
   const dirName = randomUUID();
   const dirPath = path.join(os.tmpdir(), dirName);

--- a/packages/workflows/src/deployment.workflows.ts
+++ b/packages/workflows/src/deployment.workflows.ts
@@ -2,6 +2,7 @@ import type { IDeploymentWorkflows } from "./workflow.model";
 /** Default workflows made available to all deployments */
 const workflows: IDeploymentWorkflows = {
   deployment: {
+    label: "Manage deployments",
     steps: [
       {
         name: "",

--- a/packages/workflows/src/sync.workflows.ts
+++ b/packages/workflows/src/sync.workflows.ts
@@ -52,8 +52,8 @@ const workflows: IDeploymentWorkflows = {
       {
         name: "sheets_dl",
         function: async ({ tasks, config, options }) => {
-          // HACK - ensure drive id provided as array
-          let { sheets_folder_ids, sheets_folder_id } = config.google_drive;
+          // HACK - ensure drive id provided as array (can be removed once deprecation removed)
+          let { sheets_folder_ids, sheets_folder_id, sheets_filter_function } = config.google_drive;
           if (!sheets_folder_ids) {
             logWarning({
               msg1: "[sheets_folder_id] config property is deprecated",
@@ -68,7 +68,10 @@ const workflows: IDeploymentWorkflows = {
             outputs = sheets_folder_ids.map((folder_id) => tasks.gdrive.getOutputFolder(folder_id));
           } else {
             for (const folderId of sheets_folder_ids) {
-              const output = await tasks.gdrive.download({ folderId });
+              const output = await tasks.gdrive.download({
+                folderId,
+                filterFn: sheets_filter_function,
+              });
               outputs.push(output);
             }
           }
@@ -107,21 +110,37 @@ const workflows: IDeploymentWorkflows = {
       {
         name: "assets_dl",
         function: async ({ tasks, config, options }) => {
-          const folderId = config.google_drive.assets_folder_id;
-          const filterFn = config.google_drive.assets_filter_function;
+          // HACK - ensure drive id provided as array (can be removed once deprecation removed)
+          let { assets_folder_ids, assets_folder_id, assets_filter_function } = config.google_drive;
+          if (!assets_folder_ids) {
+            logWarning({
+              msg1: "[assets_folder_id] config property is deprecated",
+              msg2: "use [assets_folder_ids] instead",
+            });
+            assets_folder_ids = [assets_folder_id];
+          }
+          /** Return output of paths to downloaded assets */
+          let outputs: string[] = [];
           // If skipping download still need to return download folder for next step
           if (options.skipDownload) {
-            return tasks.gdrive.getOutputFolder(folderId);
+            outputs = assets_folder_ids.map((folder_id) => tasks.gdrive.getOutputFolder(folder_id));
           } else {
-            return tasks.gdrive.download({ folderId, filterFn });
+            for (const folderId of assets_folder_ids) {
+              const output = await tasks.gdrive.download({
+                folderId,
+                filterFn: assets_filter_function,
+              });
+              outputs.push(output);
+            }
           }
+          return outputs;
         },
       },
       {
         name: "assets_post_process",
         function: async ({ tasks, workflow }) =>
           tasks.appData.postProcessAssets({
-            sourceAssetsFolder: workflow.assets_dl.output,
+            sourceAssetsFolders: workflow.assets_dl.output,
           }),
       },
     ],


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Adds support for specifying multiple google drive sheet and asset `folder_ids`, to allow syncing content from multiple data sources.

## Author Notes
All deployment configs should now specify an array of google drive `sheets_folder_ids` instead of a single `sheets_folder_id`, and an array of `assets_folder_ids` instead of a single `assets_folder_id`. A warning will be displayed if not the case, but should still continue to work as before (functionality deprecated but not removed).

While working on code it appears that `google_drive.sheets_filter_function` wasn't being properly passed to google drive sync scripts. I'm not sure if any deployments were using this, but would be good to ensure everything working as intended if they are. This function filters based on google drive entry (e.g. folder/file names), and shouldn't be confused with the `app_data.sheets_filter_function`, which is in use and filters based on the flow data.

## Review Notes
The changes are designed to be backwards-compatible, so if syncing content from an existing repo there should be no changes to sheet or asset files and contents beyond a warning to update the config. Likely it would be good to functionally test on a repo with fully synced data

A separate config has been created as the `debug_gdrive_multiple` which is included in this PR.
```sh
yarn workflow deployment set debug_gdrive_multiple
```
Once PR merged this config can be removed

![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/aecd611e-303e-43aa-9974-1d4b1b9a1c4b)

The deployment contains a couple of the subfolders only from the debug google drive. When syncing it is expected that content from these subfolders should sync as expected. 
E.g. asset folders: [1xy5z6PQmsrgwLpCCs6HCCUY1-u2H5KYR](https://drive.google.com/drive/folders/1xy5z6PQmsrgwLpCCs6HCCUY1-u2H5KYR) and [1nlRfAkYfqxM-z_FAzt1WXyES_DyFTlmi](https://drive.google.com/drive/folders/1nlRfAkYfqxM-z_FAzt1WXyES_DyFTlmi).

**NOTE 1** - Although the input sources are both child folders of an existing deployment folder, in practice they will more likely be separated (e.g. main asset folder and minimal override asset folder). I haven't done this for now as would require setting up and sharing new google drive folders (but reviewers should feel free to do so if wished)

**NOTE 2** - In theory any identically named flows or assets in latter folders should override those in former, however there is no example use case of this in the demo (as would throw duplicate error within the parent debug config). An example is however included in the dev testing set of sheets located at `packages\scripts\test\data\input\sheets_additional`. Functional testers should feel free to add duplicate/override files to any of the test folders above as required (but remove after testing to preserve debug config build), or change the folder ids to use folders with more curated content

## Dev Notes
Decided for now easier to implement within existing google_drive config property instead of managing multiple data sources/provider syntax

In order to handle multiple input sources either workflow step task handlers would need to be able to handle arrays of inputs/outputs, or loop logic written into workflow itself (or a combination of both). I've opted to keep the google drive sync handler as a single input sources and add loop to sync workflow instead as this felt more natural to do. Conversely the appData processor has been refactored to support multiple inputs, as it needs to handle the additional json merging post convert.

Tests were a little fiddly due to required changes to whether duplicate flows are considered as error, and also because we use 2 different types of error loggers in the test suites (file-based logs and console-based logs). These could possibly be tidied up a bit more in the future, but for now tests are at least passing

## Git Issues

Closes #2081

## Screenshots/Videos
**Example assets contents.json** - contains merged subset of files from folders [1xy5z6PQmsrgwLpCCs6HCCUY1-u2H5KYR](https://drive.google.com/drive/folders/1xy5z6PQmsrgwLpCCs6HCCUY1-u2H5KYR) and [1nlRfAkYfqxM-z_FAzt1WXyES_DyFTlmi](https://drive.google.com/drive/folders/1nlRfAkYfqxM-z_FAzt1WXyES_DyFTlmi)
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/d68b9586-3e2a-4ebc-bc90-51c2ed26a5f4)
