### PR TITLE
docs: update deployment config format for multiple folder IDs; clarify deployment set in top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ Note - you may have to do this from time to time when content is updated)
 ### Set Deployment
 The app supports using different workspace or deployment configurations. These are stored in [.idems_app/deployments](./.idems_app/deployments)
 
-An initial deployment should be specified via the command
+To use an existing deployment, run the following script:
 ```
 yarn workflow deployment set
 ```
+This will present an interactive list of deployments to select from.
+
+See [Deployment Documentation](https://idemsinternational.github.io/parenting-app-ui/developers/deployments/) for information about creating and configuring deployments.
 
 ### Firebase
 To be able to run the full project a specific configuration file needs to be included to access

--- a/documentation/docs/developers/deployments.md
+++ b/documentation/docs/developers/deployments.md
@@ -43,8 +43,8 @@ const config = generateDeploymentConfig("example");
 
 // Main Deployment config
 config.google_drive = {
-    sheets_folder_id: "",
-    assets_folder_id: "",
+    sheets_folder_ids: [],
+    assets_folder_ids: [],
   }
 };
 
@@ -68,7 +68,7 @@ yarn workflow deployment set [name]
 The final processed config can be found in the local `config.json` file, e.g. `.idems_app/deployments/example/config.json`
 
 ## Google Drive Management
-The deployment configuration requires IDs for two created Google Drive folders, one for template sheets and one for global assets. 
+The deployment configuration requires IDs for at least two created Google Drive folders: one or more for template sheets and one or more for assets. 
 
 The folders should again be named without spaces or special characters, and once created their unique IDs can be found by looking at the end of the URL bar when navigating inside the folder on Google Drive.
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Updates the Deplyoments page of the docs with the new syntax for multiple gdrive folder_ids in deployment configs, introduced by #2088.

Adds clarification to the top-level Quickstart readme regarding setting a deployment, which had caused some confusion.

## Git Issues

Closes #

## Screenshots/Videos

Updated sections of [Deployments](http://127.0.0.1:8000/developers/deployments/) page:
<img width="624" alt="Screenshot 2023-10-04 at 11 46 26" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/219de393-509d-4f72-9741-70d8d0ed44c6">

<img width="623" alt="Screenshot 2023-10-04 at 11 46 44" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/b90f3250-742a-4d52-8997-2c2901a4ac59">

