### PR TITLE
feat: links open in a new tab

### DIFF
--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
@@ -3,7 +3,7 @@ import { TemplateBaseComponent } from "../base";
 import { ITemplateRowProps } from "../../models";
 import { getStringParamFromTemplateRow } from "../../../../utils";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
-import marked from "marked";
+import { parseMarkdown } from "../../../../utils";
 
 @Component({
   selector: "plh-dashed-box",
@@ -26,7 +26,7 @@ export class TmplDashedBoxComponent
     this.getParams();
     if (this._row.value) {
       this.innerHTML = this.domSanitizer.bypassSecurityTrustHtml(
-        marked(this._row.value.toString())
+        parseMarkdown(this._row.value.toString())
       );
     }
   }

--- a/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
+++ b/src/app/shared/components/template/components/dashed-box/dashed-box.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../base";
 import { ITemplateRowProps } from "../../models";
-import { getStringParamFromTemplateRow } from "../../../../utils";
+import { getStringParamFromTemplateRow, parseMarkdown } from "src/app/shared/utils";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
-import { parseMarkdown } from "../../../../utils";
 
 @Component({
   selector: "plh-dashed-box",

--- a/src/app/shared/components/template/pipes/markdown.pipe.ts
+++ b/src/app/shared/components/template/pipes/markdown.pipe.ts
@@ -1,12 +1,13 @@
 import { Pipe, PipeTransform } from "@angular/core";
-import marked from "marked";
+import { parseMarkdown } from "src/app/shared/utils";
+
 @Pipe({
   name: "markdown",
 })
 export class MarkdownPipe implements PipeTransform {
   transform(value: any, args?: any[]): any {
     if (value && typeof value === "string" && value.length >= 0) {
-      return marked(value);
+      return parseMarkdown(value);
     }
     return value;
   }

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -449,7 +449,7 @@ export function parseMarkdown(src: string, options?: marked.MarkedOptions) {
   const renderer = new marked.Renderer();
   renderer.link = function (href, title, text) {
     const link = marked.Renderer.prototype.link.apply(this, arguments);
-    return link.replace("<a", "<a target='_blank'");
+    return link.replace("<a", "<a target='_blank' rel='noopener noreferrer'");
   };
   marked.setOptions({
     renderer,

--- a/src/app/shared/utils/utils.ts
+++ b/src/app/shared/utils/utils.ts
@@ -4,6 +4,7 @@ import { Observable } from "rxjs";
 import { map, pairwise, filter, share } from "rxjs/operators";
 import { FlowTypes } from "../model";
 import { objectToArray } from "../components/template/utils";
+import marked from "marked";
 
 /**
  * Generate a random string of characters in base-36 (a-z and 0-9 characters)
@@ -437,4 +438,21 @@ function parseAnswerListItem(item: any) {
     return itemObj;
   }
   return item;
+}
+
+/**
+ * Compiles markdown to HTML synchronously.
+ * Extends the renderer of "marked" plugin to ensure that links open in new tags.
+ * Code from https://github.com/markedjs/marked/pull/1371#issuecomment-434320596
+ */
+export function parseMarkdown(src: string, options?: marked.MarkedOptions) {
+  const renderer = new marked.Renderer();
+  renderer.link = function (href, title, text) {
+    const link = marked.Renderer.prototype.link.apply(this, arguments);
+    return link.replace("<a", "<a target='_blank'");
+  };
+  marked.setOptions({
+    renderer,
+  });
+  return marked(src, options);
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Hyperlinks written in markdown are now interpreted such that the link always opens in a new tab when using the app in a browser.

There may be cases in the future where we do not want a link to open in a new tab. For example, as mentioned in the issue (#2099), if we implement links to other pages within the app, we would not necessarily want these to open in a new tab. However, handling that use case can be considered as part of #1504.

## Testing

Run the app locally from this feature branch and verify that the links on the templates [debug_markdown_links](https://docs.google.com/spreadsheets/d/1b0FK3Eggz76H_C9lRdFVVLUxUBEZPruoyaF0d6YeWSI/edit#gid=1510672503) and [debug_dashed_box](https://docs.google.com/spreadsheets/d/1_gnFbp23_wovBK5mtsppiHpYmqNfS3fvb0fYnP66qZI/edit#gid=669305399) open in a new browser tab.

I've also included an appetize build with this PR so that we can ensure that the behaviour when running the app natively is as expected.

## Git Issues

Closes #2099 

## Screenshots/Videos

[debug_markdown_links](https://docs.google.com/spreadsheets/d/1b0FK3Eggz76H_C9lRdFVVLUxUBEZPruoyaF0d6YeWSI/edit#gid=1510672503)
<img width="300" alt="Screenshot 2023-10-10 at 13 31 44" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/4beed467-6e39-4a36-857a-44264e36a204">

Updated [debug_dashed_box](https://docs.google.com/spreadsheets/d/1_gnFbp23_wovBK5mtsppiHpYmqNfS3fvb0fYnP66qZI/edit#gid=669305399)
<img width="300" alt="Screenshot 2023-10-10 at 13 34 05" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/fd12ad19-22e8-4373-bb93-eccf0fea12f9">

