### PR TITLE
fix: pop-ups dismiss on completed or uncompleted

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -304,6 +304,7 @@ export class TemplateNavService extends SyncServiceBase {
       templatename: popup_child,
       parent: container,
       showCloseButton: true,
+      dismissOnEmit: true,
     };
     // If trying to recreate a popup that already exists simply mark as visible
     const existingPopup = this.openPopupsByName[popup_child];


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Pop-ups will now dismiss when the child template emits "completed" or "uncompleted". This was already the case for full-screen pop-ups, but now extends to non-full-screen pop-ups.

This seems to be the expected behaviour, however it is possible that this may interfere with some existing functionality, so if necessary we could expose `dismissOnEmit` as an action parameter (and possibly default to `false`).

## Testing

See new [debug_pop_up_dismiss](https://docs.google.com/spreadsheets/d/1XDugKSTqqEScibrWH0OkTTFf-lqsZREob37EeieQUWI/edit#gid=963655109) template for testing functionality.

Previous [example_pop_ups](https://docs.google.com/spreadsheets/d/1K9JZ9Glnj73CFJmpfGIRa5dRA2TBxSsJmaguV6GL8Pc/edit#gid=402992224) seems to be out-of-date – the functionality described in the comments does not work as stated (see deprecated logic [here](https://github.com/IDEMSInternational/parenting-app-ui/pull/2117/files#diff-4ee811ea134405d45640bbcf1e83f030cb27921c99115381bd4889f7544d74d0L154)).

## Dev notes

With the current implementation, if we wanted to expose `dismissOnEmit` as an action parameter then it would need to be passed between methods via query params, which doesn't seem ideal and would only further complicate the pop-up and nav logic.

## Git Issues

Closes #2116

## Screenshots/Videos

[debug_pop_up_dismiss](https://docs.google.com/spreadsheets/d/1XDugKSTqqEScibrWH0OkTTFf-lqsZREob37EeieQUWI/edit#gid=963655109) template
<img width="600" alt="Screenshot 2023-10-31 at 15 40 09" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/5c982915-2d33-4cd3-b604-584781dd1105">


https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f559ca03-5fe8-47c6-b64f-1dbd5f01b139


