### PR TITLE
style: 'break-word' wrapping for hyperlinks

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -39,6 +39,10 @@
 @import "~nouislider/distribute/nouislider.min.css";
 @import "~swiper/swiper.min.css";
 
+a {
+  word-break: break-word;
+}
+
 $tour-next-button-background: var(
   --tour-next-button-background,
   var(--gradient-secondary-mid-vertical)


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Sets the word-wrapping property for hyperlinks to "break-word" globally across the app. This will ensure that links for long URLs do not cause styling issues, as was observed for the `dashed_box` and `advanced_dashed_box` components in issue #2094.

## Git Issues

Closes #2094 

## Screenshots/Videos

[debug_long_link_dashed_box](https://docs.google.com/spreadsheets/d/14Fub-lf6xLc6nG3_Mnab1qAcfLK88yfYJzlJQGXi-2M/edit#gid=861085862)

<img width="300" alt="Screenshot 2023-11-03 at 11 25 18" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/810d66ba-095b-490d-94d6-7dcb199b1921">


