### PR TITLE
Fix/web browser startup

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -147,6 +147,10 @@
             },
             "ci": {
               "progress": false
+            },
+            "external": {
+              "browserTarget": "app:build:development",
+              "host": "0.0.0.0"
             }
           }
         },

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -20,6 +20,15 @@ const config: CapacitorConfig = {
   },
   server: {
     androidScheme: "http",
+    /**
+     * NOTE - to support live-reload on external device (e.g. emulator)
+     * 1) Uncomment url and replace with local ip to serve live-reload on local device
+     * 2) Sync to capacitor `npx cap sync`
+     * 3) Serve via `yarn ng serve --configuration=external`
+     * 4) Run app from android studio `npx cap open android` and run
+     * Local browser (localhost:4000), device app and device browser ([ip]:4200) should all be able to access served app
+     **/
+    // url: "http://192.168.50.67:4200",
   },
 };
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Running web apps from android mobile fail as an error is thrown from the local notifications service which blocks app initialisation. This is due to a lack of support for the capacitor notifications api within android web (`https://github.com/ionic-team/capacitor/issues/3472`)

This PR provides a small fix by using a try-catch statement to avoid throwing the error (failing silently, like in cases where notifications are disabled by the user)

## Review Notes
Can try the preview link from a mobile browser and make sure the app loads as expected.

I've additionally added a new serve configuration so that the local live-reload app can be run on any device on the same wifi network via `yarn ng serve --configuration=external`. If serving like this then any device on local network should be able to connect to the app by typing in the local ip of the machine serving (on windows get via `ipconfig` command, various other methods exist on linux/mac - should be something like `192.168.x.x`.

I've also added some extra instructions within the `capacitor.config.ts` file for how to do a similar process but instead of live-reload from web app use live-reload on native app (e.g. parenting app running in an emulator). This is similar to above, with an additional step of defining the ip in the config file and syncing to the native build.

Feel free to document either of these methods in the app docs if you think useful to have (info likely also in capacitor docs)


## Git Issues

Closes #2126

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
