### PR TITLE
fix: plh-function shared references

### DIFF
--- a/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
+++ b/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
@@ -38,10 +38,6 @@ export const PLH_CALC_FUNCTIONS: IFunctionHashmap = {
    * @returns Combined list [['Ada','Blaise'],['Charles'],['Daniel','Eva']]
    */
   plh_add_family: (familiesInput: any, ...members: string[]) => {
-    // NOTE - functions code below is minified on production build, however when evaluating
-    // within dynamic calc statements names are preserved, creating a mismatch between
-    // minified and non-minified reference. As a result the only (known) way to refer to one
-    // function from another is via the window.calc object which preserves name references
     const families = (window as any).calc.plh_parse_family_input(familiesInput);
     if (!families) return familiesInput;
 

--- a/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
+++ b/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
@@ -1,34 +1,35 @@
 import { IFunctionHashmap } from "packages/shared/src";
 
 /**
- * Handle case where families is passed as a string representation (assumed to be of string[][])
- * This will be a common function available to all the plh methods below
- * @returns parsed family array of string arrays, or undefined
- */
-function plh_parse_family_input(familiesInput: any): string[][] | null {
-  if (Array.isArray(familiesInput)) return familiesInput as string[][];
-  if (typeof familiesInput === "string") {
-    try {
-      const families = JSON.parse(familiesInput) as string[][];
-      return families;
-    } catch (error) {
-      console.warn(
-        "Skip adding family - 'families' input string is not a valid array representation:",
-        familiesInput
-      );
-    }
-  }
-  return null;
-}
-
-/**
  * Temporary functions used for plh sheets
  * Eventually this will be migrated to read from data_list instead (once able to define functions within list)
- *
- * NOTE - all functions also have access to common functions
  */
 export const PLH_CALC_FUNCTIONS: IFunctionHashmap = {
-  plh_parse_family_input,
+  /**
+   * Handle case where families is passed as a string representation (assumed to be of string[][])
+   * This will be a common function available to all the plh methods below
+   *
+   * NOTE - calc functions can't refer to each other by direct import, instead use `window.calc`, i.e.
+   * ```
+   * (window as any).calc.plh_parse_family_input(...)
+   * ```
+   * @returns parsed family array of string arrays, or undefined
+   */
+  plh_parse_family_input: (familiesInput: any): string[][] | null => {
+    if (Array.isArray(familiesInput)) return familiesInput as string[][];
+    if (typeof familiesInput === "string") {
+      try {
+        const families = JSON.parse(familiesInput) as string[][];
+        return families;
+      } catch (error) {
+        console.warn(
+          "Skip adding family - 'families' input string is not a valid array representation:",
+          familiesInput
+        );
+      }
+    }
+    return null;
+  },
   /**
    * Add a new family to the list of all families
    * Family members are identified uniquely by string id, avoiding duplication if already exists

--- a/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
+++ b/src/app/shared/components/template/services/template-calc-functions/plh-calc-functions.ts
@@ -37,7 +37,11 @@ export const PLH_CALC_FUNCTIONS: IFunctionHashmap = {
    * @returns Combined list [['Ada','Blaise'],['Charles'],['Daniel','Eva']]
    */
   plh_add_family: (familiesInput: any, ...members: string[]) => {
-    const families = plh_parse_family_input(familiesInput);
+    // NOTE - functions code below is minified on production build, however when evaluating
+    // within dynamic calc statements names are preserved, creating a mismatch between
+    // minified and non-minified reference. As a result the only (known) way to refer to one
+    // function from another is via the window.calc object which preserves name references
+    const families = (window as any).calc.plh_parse_family_input(familiesInput);
     if (!families) return familiesInput;
 
     // Generate a list of all unique family members to ensure duplicates not added
@@ -67,7 +71,7 @@ export const PLH_CALC_FUNCTIONS: IFunctionHashmap = {
    * ```
    */
   plh_merge_families: (familiesInput: any, sourceMemberRef: string, targetMemberRef: string) => {
-    const families = plh_parse_family_input(familiesInput);
+    const families = (window as any).calc.plh_parse_family_input(familiesInput);
     if (!families) return familiesInput;
 
     let sourceFamily: string[] = [];
@@ -109,7 +113,7 @@ export const PLH_CALC_FUNCTIONS: IFunctionHashmap = {
    * @returns
    */
   plh_remove_family_member: (familiesInput: any, sourceMemberRef: string) => {
-    const families = plh_parse_family_input(familiesInput);
+    const families = (window as any).calc.plh_parse_family_input(familiesInput);
     if (!families) return familiesInput;
     return families
       .map((members) => members.filter((member) => member !== sourceMemberRef))

--- a/src/app/shared/components/template/services/template-calc.service.ts
+++ b/src/app/shared/components/template/services/template-calc.service.ts
@@ -36,6 +36,8 @@ export class TemplateCalcService extends AsyncServiceBase {
       this.addWindowCalcFunctions();
       this.calcContext = this.generateCalcContext();
     }
+    // Assign all calc functions also to window object to allow calling between functions
+    (window as any).calc = this.calcFunctions;
     return this.calcContext;
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
When a calc function tries to refer to another calc function everything works fine in development, however in production there is a mismatch in the names of functions made available to evaluator context, and the names of the functions as minified by the angular compiler. 

This PR adds a small workaround so that all calc functions can also be accessed via a `window.calc` method, which preserves the names. 

## Review Notes
Create a production build
```sh
yarn build
```
Use npm `serve` module to serve the contents of the production build locally (reads from local `seve.json` for config)
```sh
npx serve
```

## Dev Notes
I've added to #2131 as a reminder to try and address this issue in a better way in the future if possible (currently still possible for developers to write functions that work locally but not production)

## Git Issues

Closes #

## Screenshots/Videos
Debug sheets working in production serve (port 5000). Previously was white-screen

![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/d1f536c4-7d1c-4d86-ac1a-ea7c80907323)
