### PR TITLE
feat: new go_to action argument: dismiss_on_return

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -5,7 +5,7 @@ import { ModalController } from "@ionic/angular";
 import { first } from "rxjs/operators";
 import { FlowTypes } from "src/app/shared/model";
 import { SyncServiceBase } from "src/app/shared/services/syncService.base";
-import { arrayToHashmapArray } from "src/app/shared/utils";
+import { arrayToHashmapArray, parseBoolean } from "src/app/shared/utils";
 import { ITemplatePopupComponentProps, TemplatePopupComponent } from "../components/layout/popup";
 import { ITemplateContainerProps } from "../models";
 import { TemplateContainerComponent } from "../template-container.component";
@@ -79,11 +79,16 @@ export class TemplateNavService extends SyncServiceBase {
   public handleNavAction(action: FlowTypes.TemplateRowAction) {
     // TODO: Find more elegant way to get current root level template name
     const parentName = location.pathname.replace("/template/", "");
-    const [templatename] = action.args;
+    const [templatename, key, value] = action.args;
     const nav_parent_triggered_by = action._triggeredBy?.name;
     const queryParams: INavQueryParams = { nav_parent: parentName, nav_parent_triggered_by };
     // handle direct page or template navigation
     const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
+
+    // If "dismiss_on_return" is set to true for the go_to action, dismiss the current popup before navigating away
+    if (key === "dismiss_on_return" && parseBoolean(value)) {
+      history.replaceState({}, "", location.pathname);
+    }
     return this.router.navigate(navTarget, {
       queryParams,
       queryParamsHandling: "merge",
@@ -160,8 +165,8 @@ export class TemplateNavService extends SyncServiceBase {
       // // if we have navigated from a popup we need to return to the popup parent template
       // // otherwise return to the template of the element that initiated the navigation
       // const navTargetTemplate = popup_parent || nav_parent;
-      // router.navigate(["../", navTargetTemplate], {
-      //   relativeTo: route,
+      // this.router.navigate(["../template/", navTargetTemplate], {
+      //   relativeTo: this.route,
       //   queryParams,
       //   replaceUrl: true,
       //   queryParamsHandling: "merge",


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Offers a workaround for #2120. Please see [this comment](https://github.com/IDEMSInternational/parenting-app-ui/issues/2120#issuecomment-1795487136) on that issue for context.

Adds a parameter to the `go_to` action, `dismiss_on_return`, to be used in the specific case of using a `go_to` from an active pop-up. If this parameter is passed `true`, then on returning to the parent template from which the pop-up was launched, the pop-up will be closed.

Whilst the `dismiss_on_return` action arg does what it says on the tin and so is potentially a legitimate feature, it is a workaround/hack for our current use case and doesn't fully demonstrate the desired functionality. The intermediary template (the pop-up) will dismiss on return to the parent template regardless of how the user navigates there. This is to say, it will not only dismiss when a `completed`/`uncompleted` action has been emitted by the child template, it will also dismiss, for example, when the user navigates back from the child template using the back button. A true fix for #2120 would pass information back from the child template and only dismiss the intermediary template in the case of a `completed`/`uncompleted` emission from the child template (see the comment on the issue).

## Git Issues

On merge, #2120 should probably be closed and a new issue should be made to capture the desired nav/pop-up functionality

## Screenshots/Videos

Updated [debug_pop_up_return](https://docs.google.com/spreadsheets/d/1XDugKSTqqEScibrWH0OkTTFf-lqsZREob37EeieQUWI/edit#gid=10879997) template:
<img width="600" alt="Screenshot 2023-11-06 at 16 58 18" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/a0ecd98a-007b-4a05-b967-fe0f2da2e1d8">

Demo

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f5987ee5-d419-4fae-9e32-6ad04ce3c86a


