### PR TITLE
refactor!: popup-nav-dismiss

### DIFF
--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -373,7 +373,6 @@ export namespace FlowTypes {
     "audio_end",
     "audio_play",
     "changed",
-    "close_pop_up",
     "emit",
     "feedback",
     "go_to",

--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -85,8 +85,8 @@ export class TemplateNavService extends SyncServiceBase {
     // handle direct page or template navigation
     const navTarget = templatename.startsWith("/") ? [templatename] : ["template", templatename];
 
-    // If "dismiss_on_return" is set to true for the go_to action, dismiss the current popup before navigating away
-    if (key === "dismiss_on_return" && parseBoolean(value)) {
+    // If "dismiss_pop_up" is set to true for the go_to action, dismiss the current popup before navigating away
+    if (key === "dismiss_pop_up" && parseBoolean(value)) {
       const { popup_child } = this.route.snapshot.queryParams;
       if (popup_child) {
         const popupDismissParams: INavQueryParams = {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Possible alternate implementation for behaviour in #2134

## Breaking changes
Added by @jfmcquade: Also renames the parameter passed to the `go_to` action: `dismiss_on_return` -> `dismiss_pop_up`. This more accurately describes the behaviour of the feature. This is a breaking change that will require changes to the templates that implement this feature, which appear to be [in_person_unreported](https://docs.google.com/spreadsheets/d/1S7q_hrEpSG-owuRC9oEwMHnTa-ywTJwT2_SEc1rNF1g/edit#gid=1606639158) and [virtual_unreported](https://docs.google.com/spreadsheets/d/1S7q_hrEpSG-owuRC9oEwMHnTa-ywTJwT2_SEc1rNF1g/edit#gid=1696774054). (Alternatively we could support both syntaxes to avoid deprecation, but it should be easy to make the changes at this stage and avoid including the deprecated syntax in the code).

## Git Issues

Closes #

## Screenshots/Videos

Updated [debug_pop_up_return](https://docs.google.com/spreadsheets/d/1XDugKSTqqEScibrWH0OkTTFf-lqsZREob37EeieQUWI/edit#gid=10879997) template:
<img width="660" alt="Screenshot 2023-11-07 at 15 38 28" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/d064df46-b096-475a-a210-b722f1142498">

Updated behaviour showing preservation of query params (previously all query params would have been removed on navigation away from to the pop-up):

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/11d1a1d1-3946-43a5-b4b3-e4a5c45044c5


