### PR TITLE
Feat: PfR theme

### DIFF
--- a/src/theme/themes/_index.scss
+++ b/src/theme/themes/_index.scss
@@ -1,2 +1,3 @@
 @forward "./default.scss";
+@forward "./pfr.scss";
 @forward "./professional.scss";

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -5,53 +5,49 @@
   [data-theme="pfr"] {
     /** Authoring variables **/
     $color-primary: #174168;
-    $color-secondary: #edb135;
+    $color-secondary: #f8a530;
     $page-background: white;
     $green: #289b4c;
     $red: #e24000;
 
     /** Authoring component overrides **/
     $variable-overrides: (
-      // gradient-yellow-vertical:
-      //   linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
-      // gradient-yellow-horizontal:
-      //   linear-gradient(85deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
-      // button-background-primary: var(--gradient-primary-mid-vertical),
-      // button-background-secondary: var(--gradient-secondary-mid-vertical),
-      // button-background-option: var(--gradient-primary-dark-vertical),
-      // round-button-background-secondary-light: var(--ion-color-yellow),
+      button-background-primary: var(--ion-color-primary-500),
+      button-background-secondary: var(--ion-color-secondary),
+      button-background-option: var(--ion-color-primary-800),
+      round-button-background-secondary-light: var(--ion-color-yellow),
       // round-button-background-secondary-mid: #fa9529,
       // round-button-background-secondary-dark: #F87023,
       // tile-button-background-default: #a3d9fa,
-      // tile-button-background-primary: var(--gradient-primary-mid-vertical),
-      // tile-button-background-primary-light: var(--gradient-primary-light-vertical),
-      // tile-button-background-secondary: var(--gradient-secondary-mid-vertical),
-      // tile-button-background-secondary-light: var(--gradient-yellow-vertical),
+      tile-button-background-primary: var(--ion-color-primary-500),
+      tile-button-background-primary-light: var(--ion-color-primary-300),
+      tile-button-background-secondary: var(--ion-color-secondary),
+      tile-button-background-secondary-light: var(--ion-color-yellow),
       // audio-control-background: #1980d2,
-      // points-item-background: #bce3fb,
-      // points-item-background-complete: var(--ion-color-primary-contrast),
-      // points-item-border: none,
-      // display-group-background-banner-primary: var(--ion-banner-primary)
-      // display-group-background-banner-secondary: var(--gradient-yellow-vertical)
+      points-item-background: var(--ion-background-color),
+      points-item-background-complete: var(--ion-color-primary-200),
+      points-item-border: rgba(black, 0.07),
+      display-group-background-banner-primary: var(--ion-color-primary-200),
+      display-group-background-banner-secondary: var(--ion-color-secondary-300),
       // display-group-background-tool-1: #fa8e29,
       // display-group-background-tool-2: #ff7b00,
       // display-group-background-tool-3: #108ab2,
       // display-group-background-tool-4: #096a8b,
       // display-group-background-tool-5: $color-primary,
-      // display-group-background-home-light: var(--gradient-primary-light-horizontal),
-      // display-group-background-home-mid: linear-gradient(85deg, #1c87ca 30%, #044974),
-      // display-group-background-home-dark: var(--gradient-primary-dark-horizontal),
+      display-group-background-home-light: var(--ion-color-primary-300),
+      display-group-background-home-mid: var(--ion-color-primary-600),
+      display-group-background-home-dark: var(--ion-color-primary-800),
       // timer-button-background: #1985d2,
       // combo-box-placeholder-text: rgba(13, 64, 96, 0.5),
       // combo-box-background-no-value: transparent,
-      // combo-box-background-with-value: var(--gradient-primary-light-vertical),
+      combo-box-background-with-value: var(--ion-color-primary-300),
       // slider-ui-color: #096e90,
-      // accordion-background-highlight: var(--gradient-primary-light-vertical),
-      // tour-next-button-background: var(--gradient-secondary-mid-vertical),
-      // radio-group-background-selected: var(--gradient-primary-light-vertical),
+      accordion-background-highlight: var(--ion-color-primary-300),
+      tour-next-button-background: var(--ion-color-secondary),
+      radio-group-background-selected: var(--ion-color-primary-300),
       // radio-button-font-size: 1.25rem,
       // radio-button-font-color: var(--ion-color-primary),
-      // ion-item-background: var(--ion-color-gray-light),
+      ion-item-background: var(--ion-color-gray-light),
     );
     @include utils.generateTheme(
       $color-primary,

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -1,0 +1,67 @@
+@use "./utils";
+@use "sass:color";
+
+@mixin theme-pfr {
+  [data-theme="pfr"] {
+    /** Authoring variables **/
+    $color-primary: #174168;
+    $color-secondary: #edb135;
+    $page-background: white;
+    $green: #289b4c;
+    $red: #e24000;
+
+    /** Authoring component overrides **/
+    $variable-overrides: (
+      // gradient-yellow-vertical:
+      //   linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
+      // gradient-yellow-horizontal:
+      //   linear-gradient(85deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
+      // button-background-primary: var(--gradient-primary-mid-vertical),
+      // button-background-secondary: var(--gradient-secondary-mid-vertical),
+      // button-background-option: var(--gradient-primary-dark-vertical),
+      // round-button-background-secondary-light: var(--ion-color-yellow),
+      // round-button-background-secondary-mid: #fa9529,
+      // round-button-background-secondary-dark: #F87023,
+      // tile-button-background-default: #a3d9fa,
+      // tile-button-background-primary: var(--gradient-primary-mid-vertical),
+      // tile-button-background-primary-light: var(--gradient-primary-light-vertical),
+      // tile-button-background-secondary: var(--gradient-secondary-mid-vertical),
+      // tile-button-background-secondary-light: var(--gradient-yellow-vertical),
+      // audio-control-background: #1980d2,
+      // points-item-background: #bce3fb,
+      // points-item-background-complete: var(--ion-color-primary-contrast),
+      // points-item-border: none,
+      // display-group-background-banner-primary: var(--ion-banner-primary)
+      // display-group-background-banner-secondary: var(--gradient-yellow-vertical)
+      // display-group-background-tool-1: #fa8e29,
+      // display-group-background-tool-2: #ff7b00,
+      // display-group-background-tool-3: #108ab2,
+      // display-group-background-tool-4: #096a8b,
+      // display-group-background-tool-5: $color-primary,
+      // display-group-background-home-light: var(--gradient-primary-light-horizontal),
+      // display-group-background-home-mid: linear-gradient(85deg, #1c87ca 30%, #044974),
+      // display-group-background-home-dark: var(--gradient-primary-dark-horizontal),
+      // timer-button-background: #1985d2,
+      // combo-box-placeholder-text: rgba(13, 64, 96, 0.5),
+      // combo-box-background-no-value: transparent,
+      // combo-box-background-with-value: var(--gradient-primary-light-vertical),
+      // slider-ui-color: #096e90,
+      // accordion-background-highlight: var(--gradient-primary-light-vertical),
+      // tour-next-button-background: var(--gradient-secondary-mid-vertical),
+      // radio-group-background-selected: var(--gradient-primary-light-vertical),
+      // radio-button-font-size: 1.25rem,
+      // radio-button-font-color: var(--ion-color-primary),
+      // ion-item-background: var(--ion-color-gray-light),
+    );
+    @include utils.generateTheme(
+      $color-primary,
+      $color-secondary,
+      $page-background,
+      $g: $green,
+      $r: $red
+    );
+    @each $name, $value in $variable-overrides {
+      --#{$name}: #{$value};
+    }
+  }
+}

--- a/src/theme/themes/pfr.scss
+++ b/src/theme/themes/pfr.scss
@@ -4,11 +4,10 @@
 @mixin theme-pfr {
   [data-theme="pfr"] {
     /** Authoring variables **/
-    $color-primary: #174168;
-    $color-secondary: #f8a530;
+    $color-primary: black;
+    $color-secondary: #e24000;
     $page-background: white;
     $green: #289b4c;
-    $red: #e24000;
 
     /** Authoring component overrides **/
     $variable-overrides: (
@@ -49,13 +48,7 @@
       // radio-button-font-color: var(--ion-color-primary),
       ion-item-background: var(--ion-color-gray-light),
     );
-    @include utils.generateTheme(
-      $color-primary,
-      $color-secondary,
-      $page-background,
-      $g: $green,
-      $r: $red
-    );
+    @include utils.generateTheme($color-primary, $color-secondary, $page-background, $g: $green);
     @each $name, $value in $variable-overrides {
       --#{$name}: #{$value};
     }

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -10,6 +10,8 @@
   $secondary,
   $page-background: null,
   $weights: (50, 100, 200, 300, 400, 500, 600, 700, 800, 900),
+  $green: null,
+  $red: null,
   $yellow: #ffd333,
   $gray: hsl(0, 0%, 93%)
 ) {
@@ -37,8 +39,15 @@
   $result: map.merge($result, generateColourVariants($yellow, "yellow", $weights));
   $result: map.merge($result, generateColourVariants($gray, "gray", $weights));
 
+  // Handle default values for optional params
   @if ($page-background != null) {
     $result: map.set($result, "background-color", $page-background);
+  }
+  @if ($green != null) {
+    $result: map.set($result, "color-green", $green);
+  }
+  @if ($red != null) {
+    $result: map.set($result, "color-red", $red);
   }
   @return $result;
 }
@@ -98,8 +107,8 @@
   @return $gradientPalette;
 }
 
-@mixin generateTheme($p, $s, $bg: null) {
-  $colorPalette: getColorPalette($p, $s, $bg);
+@mixin generateTheme($p, $s, $bg: null, $r: null, $g: null) {
+  $colorPalette: getColorPalette($p, $s, $bg, $red: $r, $green: $g);
   $gradientPalette: getGradientPalette($colorPalette);
   @include colorVariables($colorPalette, $gradientPalette);
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -11,6 +11,7 @@
 
 @include themes.theme-default;
 @include themes.theme-professional;
+@include themes.theme-pfr;
 
 /** Ionic CSS Variables **/
 :root {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new theme specifically for the PfR deployment. 

The new theme uses the colours black and red as the two source colours from which the theme is generated. It also uses the specific shade of green, taken from the logo, as the "success" green colour used throughout the app (e.g. for the green ticks on completed modules). I did experiment with other combinations of the colour scheme, but these resulted in red and green being too prominent, which looks odd but also conflicts with the standard use of red and green as "success" and "warning" colours in apps (although currently we don't use red anywhere by default). See the screenshots at the very bottom of the PR description for the rejected colour schemes.

It may be that further tweaks are necessary as a follow-up, either to the theme override values for specific components, or to the authoring (for example, many of the icons used are blue).

## Dev notes

In the future, deployment-specific themes (or at least the minimal data required for their generation) should live in content repos, see new issue #2168. However this is a significant task that is not currently high priority. Adding a new theme to the code repo, whilst not ideal, does not cause any issues, but it does defy the separation of code from deployment-specific data to include a named "pfr" theme in the code repo. One way around this would be to rename the theme from "pfr" to something more general (e.g. "black-red"), as in theory another deployment may wish to use this theme. However, as we're specifically using the brand colours of PfR, that feels a bit like sleight of hand, and wouldn't solve the problem.

## Testing

[This PR](https://github.com/IDEMSInternational/pfr-app-content/pull/99) in the PfR repo should be merged before testing, as the config has been updated to target the `pfr` theme.

After checking out the PfR deployment and pulling the latest changes, run `yarn start` as usual. Initially, the theme changes will not be visible because the "default" theme, which is available as a fallback, will be applied if it has previously been set as the app's active theme. In order to update the theme, you will need to reset the app using the "Reset app" button in the main menu. This will clear any cached data in your browser associated with the PfR app, giving you the experience of someone running the app for the first time. You should then see the changes to the visual styles.

## Git Issues

Closes #2165

## Screenshots/Videos

### Before
<img width="300" alt="Screenshot 2023-12-13 at 16 44 45" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/c94498fa-3e10-44e4-8b19-9b42cff75ca6">

<img width="300" alt="Screenshot 2023-12-13 at 16 50 52" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/1cd27102-88ba-437d-86ac-e53183d760de">

### After
<img width="300" alt="Screenshot 2023-12-14 at 11 37 28" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/ed57f6f5-9068-4e2a-b095-ff79323f4d24">

<img width="300" alt="Screenshot 2023-12-14 at 11 38 44" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/dc98771a-28c9-43aa-8924-e175af8582ec">

### Rejected colour schemes

<img width="150" alt="Screenshot 2023-12-14 at 11 42 09" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/2bff13f9-60c2-4c92-b599-5c9abef7c40f">

<img width="150" alt="Screenshot 2023-12-14 at 11 41 12" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/4abb98a2-b4a0-4660-9e85-9b6f82bfb60d">
