### PR TITLE
hotfix: yarn scripts version also updates strings targeted by android build action

### DIFF
--- a/packages/scripts/src/commands/version.ts
+++ b/packages/scripts/src/commands/version.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs-extra";
 import { Command } from "commander";
 import inquirer from "inquirer";
-import { APP_BUILD_GRADLE_PATH, MAIN_PACKAGE_PATH } from "../paths";
+import { APP_BUILD_GRADLE_PATH, MAIN_PACKAGE_PATH, ANDROID_BUILD_ACTION_PATH } from "../paths";
 
 /***************************************************************************************
  * CLI
@@ -26,6 +26,7 @@ async function version(options: IProgramOptions) {
   const newVersion = await promptNewVersion(oldVersion);
   updatePackageJson(newVersion);
   updateGradleBuild(newVersion);
+  updateAndroidBuildAction(newVersion);
 }
 
 function updateGradleBuild(newVersionName: string) {
@@ -45,6 +46,20 @@ async function updatePackageJson(newVersion: string) {
   const packageJson = fs.readJSONSync(MAIN_PACKAGE_PATH);
   packageJson.version = newVersion;
   fs.writeJSONSync(MAIN_PACKAGE_PATH, packageJson, { spaces: 2 });
+}
+
+function updateAndroidBuildAction(newVersionName) {
+  let androidBuildAction = fs.readFileSync(ANDROID_BUILD_ACTION_PATH, { encoding: "utf-8" });
+  const newVersionCode = _generateVersionCode(newVersionName);
+  androidBuildAction = androidBuildAction.replace(
+    /[0-9]+\/\$VERSION_CODE\//g,
+    `${newVersionCode}/$VERSION_CODE/`
+  );
+  androidBuildAction = androidBuildAction.replace(
+    /[0-9]+\.[0-9]+\.[0-9]+\/\$VERSION\//g,
+    `${newVersionName}/$VERSION/`
+  );
+  fs.writeFileSync(ANDROID_BUILD_ACTION_PATH, androidBuildAction, { encoding: "utf-8" });
 }
 
 async function promptNewVersion(currentVersion: string) {

--- a/packages/shared/src/paths.ts
+++ b/packages/shared/src/paths.ts
@@ -22,3 +22,7 @@ export const RESOURCE_FOLDER_PATH = path.join(ROOT_DIR, "resources");
 
 export const ANDROID_RES_PATH = path.join(ROOT_DIR, "android/app/src/main/res");
 export const APP_BUILD_GRADLE_PATH = path.join(ROOT_DIR, "android/app/build.gradle");
+export const ANDROID_BUILD_ACTION_PATH = path.join(
+  ROOT_DIR,
+  ".github/workflows/reusable-android-build.yml"
+);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

As suggested in [this comment](https://github.com/IDEMSInternational/parenting-app-ui/pull/2170#discussion_r1428199826), adds an ugly workaround whereby running `yarn scripts version` updates the version values targeted for replacement by `.github/workflows/reusable-android-build.yml` to match the new values populated to `./android/app/build.gradle`.

As mentioned, this is a temporary workaround pending directly addressing #2136.

## Testing

With this PR branch checked out, run `yarn scripts version` with a sensible value, and ensure that the changes to all 3 files look correct

## Git Issues

Closes #

