### PR TITLE
feat(scripts): add skip refresh flag to deployment set

### DIFF
--- a/packages/workflows/src/deployment.workflows.ts
+++ b/packages/workflows/src/deployment.workflows.ts
@@ -77,6 +77,12 @@ const workflows: IDeploymentWorkflows = {
         ],
       },
       set: {
+        options: [
+          {
+            flags: "--skip-refresh",
+            description: "Skip remote content refresh",
+          },
+        ],
         label: "Set active deployment",
         steps: [
           {
@@ -94,6 +100,7 @@ const workflows: IDeploymentWorkflows = {
           },
           {
             name: "refresh_remote_content",
+            condition: async ({ options }) => !options.skipRefresh,
             function: async ({ tasks, config }) => {
               if (config.git?.content_repo) {
                 await tasks.git().refreshRemoteRepo();


### PR DESCRIPTION
PR Checklist

- [x ] PR title descriptive (can be used in release notes)

## Description
Add flag to allow skipping auto remote content refresh when setting a deployment

## Review Notes
Set a deployment that has remote repo (e.g. debug), use the `--skip-refresh` flag to ensure updates not pulled from remote
`yarn workflow deployment set [name] --skip-refresh`

## Screenshots
**Refresh step shows as skipped**
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/a87045de-f4cf-458a-b434-f33db2217f69)

