### PR TITLE
Feat: standalone task progress bar component

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -200,6 +200,14 @@ const ASSET_PACKS = {
   folderName: "asset_packs",
 };
 
+const TASKS = {
+  enabled: true,
+  // The name of the field that tracks the currently highlighted task group
+  highlightedTaskField: "_task_highlighted_group_id",
+  // The top-level list of task groups (e.g. modules)
+  taskGroupsListName: "workshop_tasks",
+};
+
 const APP_CONFIG = {
   APP_FIELDS,
   APP_HEADER_DEFAULTS,
@@ -220,6 +228,7 @@ const APP_CONFIG = {
   NOTIFICATIONS_SYNC_FREQUENCY_MS,
   NOTIFICATION_DEFAULTS,
   SERVER_SYNC_FREQUENCY_MS,
+  TASKS,
 };
 // Export as a clone to avoid risk one import could alter another
 export const getDefaultAppConfig = () => clone(APP_CONFIG);

--- a/src/app/shared/components/template/components/task-card/task-card.component.html
+++ b/src/app/shared/components/template/components/task-card/task-card.component.html
@@ -63,6 +63,7 @@
             [taskGroupCompletedField]="completedField"
             [highlighted]="highlighted"
             [progressUnitsName]="progressUnitsName"
+            [showText]="showProgressText"
             [(progressStatus)]="progressStatus"
             (newlyCompleted)="handleNewlyCompleted($event)"
           ></plh-task-progress-bar>

--- a/src/app/shared/components/template/components/task-card/task-card.component.ts
+++ b/src/app/shared/components/template/components/task-card/task-card.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from "@angular/core";
 import { TaskService } from "src/app/shared/services/task/task.service";
-import { getStringParamFromTemplateRow } from "src/app/shared/utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 import { IProgressStatus } from "src/app/shared/services/task/task.service";
 import { TemplateFieldService } from "../../services/template-field.service";
@@ -67,6 +70,12 @@ interface ITaskCardParams {
    * Default "sections"
    */
   progress_units_name: string;
+  /**
+   * Show the text associated with progress bar,
+   * e.g. "8 sections"
+   * Default true
+   */
+  show_progress_text: boolean;
 }
 
 @Component({
@@ -82,6 +91,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
   highlighted: boolean;
   highlightedText: string;
   progressUnitsName: string;
+  showProgressText: boolean;
   progressStatus: IProgressStatus = "notStarted";
   taskGroupId: string | null;
   taskGroupDataList: string | null;
@@ -135,6 +145,7 @@ export class TmplTaskCardComponent extends TemplateBaseComponent implements OnIn
       "progress_units_name",
       "sections"
     );
+    this.showProgressText = getBooleanParamFromTemplateRow(this._row, "show_progress_text", true);
   }
 
   checkProgressStatus() {

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.html
@@ -1,5 +1,12 @@
-<div class="progress-bar-wrapper" [class.highlighted]="highlighted" [class]="progressStatus">
-  <p *ngIf="showText" class="tiny progress-text">{{ subtasksTotal + " " + progressUnitsName }}</p>
+<div
+  class="progress-bar-wrapper"
+  [class.highlighted]="highlighted"
+  [class]="progressStatus"
+  [attr.data-variant]="params.variant"
+>
+  <p *ngIf="params.showText" class="tiny progress-text">
+    {{ subtasksTotal + " " + params.progressUnitsName }}
+  </p>
   <div class="progress-bar-background">
     <div class="progress-bar" [style.width]="progressPercentage + '%'"></div>
   </div>

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.scss
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.scss
@@ -18,12 +18,14 @@
     border-radius: var(--ion-border-radius-small);
     background-color: var(--ion-color-gray-400);
   }
-  &.completed {
+  &.completed,
+  &[data-variant~="green"] {
     .progress-bar {
       background-color: var(--ion-color-green);
     }
   }
-  &.highlighted {
+  &.highlighted,
+  &[data-variant~="secondary"] {
     .progress-bar-background {
       background-color: var(--ion-color-secondary-100);
     }

--- a/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
+++ b/src/app/shared/components/template/components/task-progress-bar/task-progress-bar.component.ts
@@ -1,6 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { TaskService } from "src/app/shared/services/task/task.service";
-import { getStringParamFromTemplateRow } from "src/app/shared/utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "src/app/shared/utils";
 import { TemplateBaseComponent } from "../base";
 import { TemplateFieldService } from "../../services/template-field.service";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
@@ -39,6 +42,8 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
   }
 
   getParams() {
+    // If component is being instantiated by a parent component (e.g. task-card), use Input() values for properties.
+    // If component is being explicitly instantiated from a template, get the params from the template row
     if (this._row) {
       this.taskGroupDataList = getStringParamFromTemplateRow(this._row, "task_group_data", null);
       this.taskGroupCompletedField = getStringParamFromTemplateRow(
@@ -51,6 +56,7 @@ export class TmplTaskProgressBarComponent extends TemplateBaseComponent implemen
         "progress_units_name",
         "sections"
       );
+      this.showText = getBooleanParamFromTemplateRow(this._row, "show_text", false);
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fleshes out the standalone version (as opposed to being instantiated by the `task-card` component) of the `task-progress-bar` component. The component is passed the following params:

`task_group_data`: The name of the task group for which to track the completion of its subtasks
`completed_field`: The name of the field that stores the completion status of the task group
`progress_units_name`: The displayed name of the units of progress associated with the constituent tasks of the task group. Default "sections".
`show_text`: Show the text associated with progress bar, e.g. "8 sections". Default false
`variant`: A list of named style variants of the component, separated by spaces or commas. Supported values: "green" | "secondary".
`dynamic`: Specify whether to use the dynamic data feature. Should be true if the task_group_data has a "completed" column, else should be false if the task_group_data has a "completed_field" column.

Task group data lists can store their completion status in one of two ways:
1. A "completed_field" column, referencing a field that stores the completion status
2. A "completed" column, with values updated dynamically

Support for 2. is a work in progress. See below.

### Case 1: static data list, completion status stored in fields

[comp_task_progress_bar](https://docs.google.com/spreadsheets/d/1KenOF4C7BjVmg07zONWQgRygVWMDaXCOGLOSfC5vx7g/edit#gid=603128459)

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/0911f489-fc07-4e9b-9988-0913a60cf434

### Case 2: dynamic data list, completion status stored in `completes` column

<img width="700" alt="Dynamic 1" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f8e196ca-90ae-431d-8ddb-3d16aeb7591e">

<img width="280" alt="Dynamic 2" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/601f19c6-92e0-48a6-a634-1f0acd749a88">


## Git Issues

Closes #2150

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
