### PR TITLE
fix: dynamic data service multiple queries

### DIFF
--- a/packages/shared/src/utils/async-utils.ts
+++ b/packages/shared/src/utils/async-utils.ts
@@ -1,0 +1,8 @@
+/** helper function used for dev to wait a fixed amount of time */
+export function _wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/packages/shared/src/utils/cli-utils.ts
+++ b/packages/shared/src/utils/cli-utils.ts
@@ -39,11 +39,3 @@ export function pad(str: string | number, chars: number) {
   const padChars = Math.max(chars - str.length + 1, 0);
   return str + new Array(padChars).join(" ");
 }
-/** helper function used for dev to wait a fixed amount of time */
-export function _wait(ms: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./async-utils";
 export * from "./cli-utils";
 export * from "./delimiters";
 export * from "./file-utils";

--- a/packages/shared/src/utils/logging/console-logger.ts
+++ b/packages/shared/src/utils/logging/console-logger.ts
@@ -2,7 +2,7 @@ import boxen from "boxen";
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { _wait } from "../cli-utils";
+import { _wait } from "../async-utils";
 
 /**
  * HACK - export error within a Logger const to allow easier mocking in tests

--- a/packages/shared/src/utils/logging/file-logger.ts
+++ b/packages/shared/src/utils/logging/file-logger.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
 import path from "path";
 import { emptyDirSync, ensureDirSync, truncateSync } from "fs-extra";
-import { _wait } from "../cli-utils";
+import { _wait } from "../async-utils";
 import { Writable } from "stream";
 import { existsSync } from "fs";
 import { SCRIPTS_LOGS_DIR } from "../../paths";

--- a/src/app/shared/services/data/app-data.service.spec.ts
+++ b/src/app/shared/services/data/app-data.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 
 import { AppDataVariableService } from "./app-data-variable.service";
-import { AppDataService } from "./app-data.service";
+import { AppDataService, IAppDataCache } from "./app-data.service";
 import { FlowTypes } from "../../model";
 import { MockAppDataVariableService } from "./app-data-variable.service.spec";
 import { ErrorHandlerService } from "../error-handler/error-handler.service";
@@ -12,42 +12,57 @@ import { DbService } from "../db/db.service";
 import { MockDbService } from "../db/db.service.spec";
 import { Injectable } from "@angular/core";
 import { ISheetContents } from "src/app/data";
+import { _wait } from "packages/shared/src/utils/async-utils";
 
-const DATA_MOCK: { [flow_name: string]: FlowTypes.FlowTypeWithData } = {
-  flow_a: {
-    flow_name: "flow_a",
-    flow_type: "data_list",
-    rows: [
-      { id: "a_id1", number: 1, string: "a_hello", boolean: true },
-      { id: "a_id2", number: 2, string: "a_goodbye", boolean: false },
-    ],
-  },
-  flow_b: {
-    flow_name: "flow_b",
-    flow_type: "data_list",
-    rows: [
-      { id: "b_id1", number: 1, string: "b_hello", boolean: true },
-      { id: "b_id2", number: 2, string: "b_goodbye", boolean: false },
-    ],
-    _overrides: { flow_c: "true" },
-  },
-  flow_c: {
-    flow_name: "flow_c",
-    flow_type: "data_list",
-    rows: [
-      { id: "c_id1", number: 1, string: "c_hello", boolean: true },
-      { id: "c_id2", number: 2, string: "c_goodbye", boolean: false },
-    ],
-    _overrides: { flow_b: "true" },
-  },
-  flow_d: {
-    flow_name: "flow_d",
-    flow_type: "data_list",
-    rows: [
-      { id: "d_id1", number: 1, string: "d_hello", boolean: true },
-      { id: "d_id2", number: 2, string: "d_goodbye", boolean: false },
-    ],
-    _overrides: { flow_a: "true" },
+/** Base mock data for use with any services calling mock app-data handlers */
+const DATA_CACHE_CLEAN: IAppDataCache = {
+  asset_pack: {},
+  data_list: {},
+  data_pipe: {},
+  generator: {},
+  global: {},
+  template: {},
+  tour: {},
+};
+
+/** Mock data used specifically for the app-data service spec */
+const SPEC_MOCK_DATA: Partial<IAppDataCache> = {
+  data_list: {
+    flow_a: {
+      flow_name: "flow_a",
+      flow_type: "data_list",
+      rows: [
+        { id: "a_id1", number: 1, string: "a_hello", boolean: true },
+        { id: "a_id2", number: 2, string: "a_goodbye", boolean: false },
+      ],
+    },
+    flow_b: {
+      flow_name: "flow_b",
+      flow_type: "data_list",
+      rows: [
+        { id: "b_id1", number: 1, string: "b_hello", boolean: true },
+        { id: "b_id2", number: 2, string: "b_goodbye", boolean: false },
+      ],
+      _overrides: { flow_c: "true" },
+    },
+    flow_c: {
+      flow_name: "flow_c",
+      flow_type: "data_list",
+      rows: [
+        { id: "c_id1", number: 1, string: "c_hello", boolean: true },
+        { id: "c_id2", number: 2, string: "c_goodbye", boolean: false },
+      ],
+      _overrides: { flow_b: "true" },
+    },
+    flow_d: {
+      flow_name: "flow_d",
+      flow_type: "data_list",
+      rows: [
+        { id: "d_id1", number: 1, string: "d_hello", boolean: true },
+        { id: "d_id2", number: 2, string: "d_goodbye", boolean: false },
+      ],
+      _overrides: { flow_a: "true" },
+    },
   },
 };
 
@@ -83,12 +98,18 @@ const CONTENTS_MOCK: ISheetContents = {
 
 /** Mock calls for sheets from the appData service to return test data */
 export class MockAppDataService implements Partial<AppDataService> {
+  public appDataCache: IAppDataCache;
+
+  // allow additional specs implementing service to provide their own data if required
+  constructor(mockData: Partial<IAppDataCache> = {}) {
+    this.appDataCache = { ...DATA_CACHE_CLEAN, ...mockData };
+  }
   public async getSheet<T extends FlowTypes.FlowTypeWithData>(
     flow_type: FlowTypes.FlowType,
     flow_name: string
   ): Promise<T> {
-    const rows = DATA_MOCK[flow_name].rows || [];
-    return { flow_name, flow_type, rows } as any;
+    await _wait(50);
+    return this.appDataCache[flow_type]?.[flow_name] as T;
   }
 }
 
@@ -97,15 +118,7 @@ export class MockAppDataService implements Partial<AppDataService> {
 class AppDataServiceExtended extends AppDataService {
   protected sheetContents = CONTENTS_MOCK;
   protected translationContents = {};
-  public appDataCache = {
-    asset_pack: {},
-    data_list: { ...DATA_MOCK },
-    data_pipe: {},
-    generator: {},
-    global: {},
-    template: {},
-    tour: {},
-  };
+  public appDataCache = { ...DATA_CACHE_CLEAN, ...SPEC_MOCK_DATA };
 }
 
 /********************************************************************************

--- a/src/app/shared/services/data/app-data.service.ts
+++ b/src/app/shared/services/data/app-data.service.ts
@@ -193,6 +193,6 @@ export class AppDataService extends SyncServiceBase {
   }
 }
 
-type IAppDataCache = {
+export type IAppDataCache = {
   [flow_type in FlowTypes.FlowType]: { [flow_name: string]: FlowTypes.FlowTypeWithData };
 };


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Fix issue where calling multiple dynamic-data service queries in parallel could lead to multiple db collection creation requests throwing rxdb error. Specifically:

- Implement a queue-type system to prevent duplicate db create requests when creating multiple queries in parallel
- Add test case

## Dev Notes
Additional work is included to refactor the app-data mocks 56a749a, to fix a regression issue brought in by changes to the app-data mocks in #2107. Data had been copy-pasted from the app-data mock to the dynamic-data mock (which is super fragile), breaking tests when source app-data mock changed. Now mock services can specify their own data when implementing the app-data mock. 

This is also another good reminder why we should try to  fix up the rest of the ng test suite and integrate into ci (raised in #2080 and various messages on mattermost). Not sure if this is something still on your radar @jfmcquade ?

One other regression discovered (coming from #1989) was the breaking of a test previously designed to throw error when updating row that does not exist. I can see the code changes removed this behaviour (I'm assuming you decided this is no longer a desirable QA check @jfmcquade (?)), so I've removed the test (see updated spec). If we don't get the ng test suite integrated then it would be good to at least make a mental note to check existing tests when making changes to corresponding services for both dev and review.

## Review Notes
Tests can be run via `yarn ng test --include src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts`, also hoping will pass the case you raised in #2176 @jfmcquade (?)

## Git Issues

unblocks #2176

## Screenshots/Videos
**Before** - spec test for parallel requests added (failing)
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/24f6656b-1da9-4d5a-8f39-2c707feed4ce)

**After** - all tests passing (with one qa test removed)
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/5c2cd46f-dfc3-4174-b1d7-f12353be22db)

