### PR TITLE
fix: js-evaluator escape characters

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/parsers/data_pipe.parser.spec.ts
@@ -96,4 +96,33 @@ describe("data_pipe Parser", () => {
     });
     expect(deferred).toEqual(["data_pipe.test_pipe_defer"]);
   });
+
+  // QA - https://github.com/IDEMSInternational/parenting-app-ui/issues/2184
+  // NOTE - test case more explicitly handled by jsEvaluator.spec
+  it("Supports text with line break characters", async () => {
+    const parser = new DataPipeParser({
+      processedFlowHashmap: {
+        data_list: {
+          test_data_list: [{ id: 1, text: "normal" }, { id: 2, text: "line\nbreak" }, { id: 3 }],
+        },
+      },
+    } as any);
+    const ops: IDataPipeOperation[] = [
+      {
+        input_source: "test_data_list",
+        operation: "filter",
+        args_list: "id < 3" as any, // will be parsed during process
+        output_target: "test_output",
+      },
+    ];
+    const output = parser.run({
+      flow_name: "test_line_breaks",
+      flow_type: "data_pipe",
+      rows: ops,
+    });
+    expect(output._generated.data_list.test_output.rows).toEqual([
+      { id: 1, text: "normal" },
+      { id: 2, text: "line\nbreak" },
+    ]);
+  });
 });

--- a/packages/shared/src/models/jsEvaluator/jsEvaluator.spec.ts
+++ b/packages/shared/src/models/jsEvaluator/jsEvaluator.spec.ts
@@ -1,16 +1,21 @@
 import { JSEvaluator } from "./jsEvaluator";
 
+const constants = {
+  a: 1,
+  b: 2,
+  nestedConstant: { array: [1] },
+};
+const functions = {
+  isEven: (n) => n % 2 === 0,
+};
+
 describe("JS Evaluator", () => {
-  const constants = {
-    a: 1,
-    b: 2,
-    nestedConstant: { array: [1] },
-  };
-  const functions = {
-    isEven: (n) => n % 2 === 0,
-  };
-  const evaluator = new JSEvaluator();
-  evaluator.setGlobalContext({ constants, functions });
+  let evaluator: JSEvaluator;
+  beforeEach(() => {
+    evaluator = new JSEvaluator();
+    evaluator.setGlobalContext({ constants, functions });
+  });
+
   it("expression: Math.min(5,7)", () => {
     expect(evaluator.evaluate("Math.min(5,7)")).toEqual(5);
   });
@@ -34,5 +39,14 @@ describe("JS Evaluator", () => {
     const invalidConstants = { default: "hello", new: "test" };
     evaluator.setGlobalContext({ constants: { ...invalidConstants, ...constants } });
     expect(() => evaluator.evaluate("Math.min(a,b)")).toThrowError("Unexpected token 'default'");
+  });
+  it("handles escape characters", () => {
+    // Case 1 - evaluation string with linebreak
+    expect(evaluator.evaluate("'Hello\n'+this.name", { name: "Ada" })).toEqual("Hello\nAda");
+    // Case 2 - this context with linebreak
+    expect(evaluator.evaluate("'Hello'+this.name", { name: "\nAda" })).toEqual("Hello\nAda");
+    // Case 3 - global constant with linebreak
+    evaluator.setGlobalContext({ constants: { name: "\nAda" } });
+    expect(evaluator.evaluate("'Hello'+name", { name: "\nAda" })).toEqual("Hello\nAda");
   });
 });

--- a/packages/shared/src/models/jsEvaluator/jsEvaluator.ts
+++ b/packages/shared/src/models/jsEvaluator/jsEvaluator.ts
@@ -63,8 +63,9 @@ export class JSEvaluator {
    */
   evaluate(expression: string, executionContext = {}) {
     const funcString = `${this.evaluationContextBase} (${expression});`;
+    const cleanedFuncString = this.cleanFunctionString(funcString);
     try {
-      const func = new Function(funcString);
+      const func = new Function(cleanedFuncString);
       const evaluated = func.apply(executionContext);
       return evaluated;
     } catch (error) {
@@ -88,6 +89,11 @@ export class JSEvaluator {
       if (typeof value === "string") return `'${value}'`;
     }
     return value;
+  }
+
+  private cleanFunctionString(str: string) {
+    // Linebreak characters will break JS evaluator so add additional escape
+    return str.replace(/(?:\r)/g, "\\r").replace(/(?:\n)/g, "\\n");
   }
 }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fix JSEvaluator to handle javascript escape characters (`\n`, `\r`). These would throw an error if present in text when evaluating, now they should be correctly escaped and still be present in final output.

Add tests to JSEvaluator and affected `filter` data_pipe processes

## Git Issues

Closes #2184

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
