### PR TITLE
hotfix: revert version number in build.gradle and reausable-android-build action

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -129,7 +129,7 @@ jobs:
             echo "Version Code: $VERSION_CODE"
             echo "Version: $VERSION"
             # This will need to change currently looking for specific version and not place holder
-            sed -i -e "s/16024/$VERSION_CODE/g" -e "s/0.16.24/$VERSION/g" ./android/app/build.gradle 
+            sed -i -e "s/16023/$VERSION_CODE/g" -e "s/0.16.23/$VERSION/g" ./android/app/build.gradle 
             
         - name: Download Build Artifact
           uses: actions/download-artifact@v3

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "international.idems.plh_teens"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 16024
-        versionName "0.16.24"
+        versionCode 16023
+        versionName "0.16.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

The [android_release action on the plh-facilitator-mx repo](https://github.com/IDEMSInternational/plh-facilitator-app-mx-content/actions/runs/7716921308/job/21035275279) is failing. This is likely due to the merging of #2170 – the plh-facilitator-mx repo targets release v0.16.23 of the code, but uses the `reusable-android-release` action from master. As this action looks for a specific release number string to be replaced, and as #2170 had updated the target number, the number was not being replaced correctly.

This is a temporary workaround: the action should be reworked to target a placeholder variable instead of a specific version number, or a more thorough improvement should be implemented, as suggested in #2136 

## Git Issues

Closes #
