### PR TITLE
chore: Remove legacy images

### DIFF
--- a/src/assets/icon/shared/start.svg
+++ b/src/assets/icon/shared/start.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08cc133a3af50b2af60ddfdc98a1b6f24b511b118e1dae867d0ff97ea48bf318
-size 204

--- a/src/assets/images/github.png
+++ b/src/assets/images/github.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4c27448b5f97253b9a035a45a38d2266bffd94f790a843b2d62b6bdf05b5324
-size 21835

--- a/src/assets/images/splash-screen/0.svg
+++ b/src/assets/images/splash-screen/0.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed11a248ad212a679c2b216c7c3c7a562ea0e3a7af998e7ff15624969f99fae6
-size 42993

--- a/src/assets/images/splash-screen/1.svg
+++ b/src/assets/images/splash-screen/1.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cb84ef2c96a0f5244fad4c7c4e18c78998c7ce7ecfa5639b04894cacf9e0503
-size 10139

--- a/src/assets/images/splash-screen/2.svg
+++ b/src/assets/images/splash-screen/2.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1431fc4d8bbeb47fc8cefaa9f47d76dcbc8021c17e26ee97d0ba7a2f01d7d545
-size 14706

--- a/src/assets/images/star.svg
+++ b/src/assets/images/star.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43bdd998d0dda1382061cd554ff83ade2594c0a4dbbce3d4ecd1ab8b08cd6ea1
-size 781

--- a/src/assets/images/sync.svg
+++ b/src/assets/images/sync.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3bc4204dea5318b556e65a46997ba6292f8a63cdc80e082b72d6f238b622b314
-size 1879

--- a/src/assets/logos/PLH.svg
+++ b/src/assets/logos/PLH.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfcd849013d50db9a63624b488d26a4c3b10c43983acefb2facf3859cb891bb6
-size 102991

--- a/src/assets/logos/Unicef.svg
+++ b/src/assets/logos/Unicef.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6999218a81ae0b20cb32664b8020ca554b1f37fd0782ed33c9a648508decd1ed
-size 65563

--- a/src/assets/logos/WHO.svg
+++ b/src/assets/logos/WHO.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:472d4096e409707240abd1541ec98323b8dc491ab5d3ce1658358c5f32952f2b
-size 75549

--- a/src/assets/shapes.svg
+++ b/src/assets/shapes.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf1b68281716f452dd620f81fd31d98bfef7dd521b8098433710bda7a32918f2
-size 1176


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
As I was playing around with `favicon.png`, I discovered some legacy assets in the code repo under src > assets. This PR is removing the ones that I'm convinced are not used. 

## Review notes
1. Could you confirm I'm not breaking anything by removing these? 
2. Potentially some more images could be removed (remaining ones in screenshot below)

   <img width="218" alt="image" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/74557272/dde00ade-4638-4614-a6fd-d8db1d11260e">


