### PR TITLE
feat: expose favicon asset path to deployment config

### DIFF
--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -77,6 +77,7 @@ export interface IDeploymentConfig {
     translated_strings_path?: string;
   };
   web: {
+    /** Relative path of custom favicon asset to load from app_data assets */
     favicon_asset?: string;
   };
   workflows: {

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -56,6 +56,7 @@ export interface IDeploymentConfig {
     /** filter function that receives basic file info such as relativePath and size. Default `(fileEntry)=>true`*/
     assets_filter_function: (fileEntry: IContentsEntry) => boolean;
   };
+  favicon_asset?: string;
   git: {
     /** Url of external git repo to store content */
     content_repo?: string;
@@ -140,6 +141,7 @@ export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
     custom_ts_files: [],
     task_cache_path: "./tasks",
   },
+  favicon_asset: "",
   git: {},
   _validated: true,
   _parent_config: null,

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -56,7 +56,6 @@ export interface IDeploymentConfig {
     /** filter function that receives basic file info such as relativePath and size. Default `(fileEntry)=>true`*/
     assets_filter_function: (fileEntry: IContentsEntry) => boolean;
   };
-  favicon_asset?: string;
   git: {
     /** Url of external git repo to store content */
     content_repo?: string;
@@ -76,6 +75,9 @@ export interface IDeploymentConfig {
     source_strings_path?: string;
     /** translated string for import. Default `./app_data/translations_source/translated_strings */
     translated_strings_path?: string;
+  };
+  web: {
+    favicon_asset?: string;
   };
   workflows: {
     /** path to custom workflow files to include */
@@ -137,11 +139,11 @@ export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
     source_strings_path: "./app_data/translations_source/source_strings",
     translated_strings_path: "./app_data/translations_source/translated_strings",
   },
+  web: {},
   workflows: {
     custom_ts_files: [],
     task_cache_path: "./tasks",
   },
-  favicon_asset: "",
   git: {},
   _validated: true,
   _parent_config: null,

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -64,10 +64,13 @@ export class SeoService extends SyncServiceBase {
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
+    const faviconPath = environment.deploymentConfig.favicon_asset
+      ? "assets/app_data/assets/" + environment.deploymentConfig.favicon_asset
+      : "assets/icon/favicon.png";
     return {
       title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
       description: "",
-      faviconUrl: `${PUBLIC_URL}/assets/icon/favicon.png`,
+      faviconUrl: `${PUBLIC_URL}/${faviconPath}`,
       imageUrl: ``,
     };
   }

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -64,13 +64,13 @@ export class SeoService extends SyncServiceBase {
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
-    const faviconPath = environment.deploymentConfig.favicon_asset
-      ? "assets/app_data/assets/" + environment.deploymentConfig.favicon_asset
-      : "assets/icon/favicon.png";
+    const faviconUrl = environment.deploymentConfig.web?.favicon_asset
+      ? `${PUBLIC_URL}/assets/app_data/assets/` + environment.deploymentConfig.web.favicon_asset
+      : "";
     return {
       title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
       description: "",
-      faviconUrl: `${PUBLIC_URL}/${faviconPath}`,
+      faviconUrl,
       imageUrl: ``,
     };
   }

--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -64,11 +64,13 @@ export class SeoService extends SyncServiceBase {
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
-    const faviconUrl = environment.deploymentConfig.web?.favicon_asset
-      ? `${PUBLIC_URL}/assets/app_data/assets/` + environment.deploymentConfig.web.favicon_asset
-      : "";
+    let faviconUrl = `${PUBLIC_URL}/assets/icon/favicon.png`;
+    const { web, app_config } = environment.deploymentConfig;
+    if (web?.favicon_asset) {
+      faviconUrl = `${PUBLIC_URL}/assets/app_data/assets/${web.favicon_asset}`;
+    }
     return {
-      title: environment.deploymentConfig.app_config.APP_HEADER_DEFAULTS.title,
+      title: app_config.APP_HEADER_DEFAULTS.title,
       description: "",
       faviconUrl,
       imageUrl: ``,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a property for setting the path to a custom favicon icon from a deployment config, `config.favicon_asset`. The path should be relative to the gdrive assets folder, e.g. "images/icons/favicon.svg". (NB, the property is not named "favicon_path", as the values of properties whose names end with "_path" are converted to absolute paths when the deployment config is compiled, which is not desirable here).

If no custom favicon asset is set, then the default is used. This default icon has been changed from the ionic logomark to the IDEMS trefoil knot logomark.

## Testing

With this feature branch checked out, add the line `config.favicon_asset = "images/icons/favicon.svg"` to `.idems_app/deployments/debug/config.ts` and run `yarn workflow deployment set debug` to compile the config. Now run `yarn workflow sync assets` to ensure the debug favicon asset is downloaded. Upon running `yarn start`, the browser favicon should be the custom icon added [here](https://drive.google.com/file/d/1JL1ViLwJ5yNqsVGZb8MVaiGXBMm5RsAo/view?usp=drive_link).

## Git Issues

Closes #1773

## Screenshots/Videos

Browser tab showing the [custom favicon](https://drive.google.com/file/d/1JL1ViLwJ5yNqsVGZb8MVaiGXBMm5RsAo/view?usp=drive_link) icon:

<img width="240" alt="Screenshot 2024-01-31 at 16 46 29" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/29ef527c-ab33-46e6-a680-76a883cf3f60">

Browser tab showing the new default favicon:
<img width="251" alt="Screenshot 2024-02-13 at 10 35 43" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/bbbc201f-2a02-4dd6-b3f0-d211e7d0a9eb">

