### PR TITLE
Updated actions for content repos

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -93,7 +93,7 @@ jobs:
           run: yarn install --immutable
   
         - name: Set deployment
-          run: yarn workflow deployment set $DEPLOYMENT_NAME
+          run: yarn workflow deployment set $DEPLOYMENT_NAME --skip-refresh
   
         - name: Populate android assets
           run: yarn workflow populate_android_assets

--- a/.github/workflows/reusable-app-build.yml
+++ b/.github/workflows/reusable-app-build.yml
@@ -111,14 +111,8 @@ jobs:
           run: yarn install
   
         - name: Set deployment
-          run: yarn workflow deployment set $DEPLOYMENT_NAME
-
-        - name: Revert changes done by setting the deployment
-          run: |
-            git reset --hard
-          working-directory: .idems_app/deployments/${{ env.DEPLOYMENT_NAME }}
-
-  
+          run: yarn workflow deployment set $DEPLOYMENT_NAME --skip-refresh
+ 
         - name: Build
           run: yarn build ${{inputs.build-flags}}
   


### PR DESCRIPTION
## Description
Added skip refresh when calling set deployment from actions. This will stop data from being updated from the spreadsheets and use whats in the repository instead.

@esmeetewinkel This should fix the PR preview action.

