### PR TITLE
feat: replace default favicon with IDEMS trefoil

### DIFF
--- a/src/app/shared/services/seo/seo.service.ts
+++ b/src/app/shared/services/seo/seo.service.ts
@@ -64,7 +64,7 @@ export class SeoService extends SyncServiceBase {
    */
   private getDefaultSEOTags(): ISEOMeta {
     const PUBLIC_URL = location.origin;
-    let faviconUrl = `${PUBLIC_URL}/assets/icon/favicon.png`;
+    let faviconUrl = `${PUBLIC_URL}/assets/icon/favicon.svg`;
     const { web, app_config } = environment.deploymentConfig;
     if (web?.favicon_asset) {
       faviconUrl = `${PUBLIC_URL}/assets/app_data/assets/${web.favicon_asset}`;

--- a/src/assets/icon/favicon.png
+++ b/src/assets/icon/favicon.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e820db45563316ad63b8557a3cb9a681a9f59faf899c250393113fcbe885d2cd
-size 930

--- a/src/assets/icon/favicon.svg
+++ b/src/assets/icon/favicon.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:638632bc6fbb1caf15a5bb3d89a95addaf44e9c08d1fd2b757b355772b5f4170
+size 5922

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
 
     <!-- SEO -->
     <title></title>
-    <link rel="icon" id="favicon" type="image/png" href="assets/icon/favicon.png" />
+    <link rel="icon" id="favicon" type="image/png" href="assets/icon/favicon.svg" />
     <meta name="description" content="" />
     <meta property="og:title" content="" />
     <meta property="og:description" content="" />


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Changes the default favicon, which is displayed in browsers when the `config.favicon_asset` value is not overridden as is possible since #2192, from the ionic logo to IDEMS's trefoil knot logomark

## Git Issues

Closes #

## Screenshots/Videos

Browser tab showing the new default favicon:
<img width="251" alt="Screenshot 2024-02-13 at 10 35 43" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/bbbc201f-2a02-4dd6-b3f0-d211e7d0a9eb">
