### PR TITLE
refactor: use version script in reusable actions

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -118,26 +118,9 @@ jobs:
             VERSION=$(grep 'content_tag_latest:' $FILE_PATH | sed 's/content_tag_latest: *"\(.*\)",/\1/')
             echo "Extracted Version: $VERSION"
       
-            # Split the version into major, minor, and patch components
-            IFS='.' read -ra VERSION_PARTS <<< "$VERSION"
-            
-            if [[ ${#VERSION_PARTS[@]} -ne 3 ]]; then
-               echo "Error: Version format is not as expected."
-               exit 1
-            fi
-                      
-            # Convert minor and patch segment to 3-digit representation
-            MINOR=$(printf "%03d" "${VERSION_PARTS[1]}")
-            PATCH=$(printf "%03d" "${VERSION_PARTS[2]}")
-                
-            # Construct the new version
-            VERSION_CODE="${VERSION_PARTS[0]}${MINOR}${PATCH}"
-            
-            echo "Version Code: $VERSION_CODE"
-            echo "Version: $VERSION"
-            # This will need to change currently looking for specific version and not place holder
-            sed -i -e "s/*version_code*/$VERSION_CODE/g" -e "s/*version_name*/$VERSION/g" ./android/app/build.gradle 
-            
+            # Run versioning script
+            yarn run version $VERSION
+             
         - name: Download Build Artifact
           uses: actions/download-artifact@v3
           with:

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -119,7 +119,7 @@ jobs:
             echo "Extracted Version: $VERSION"
       
             # Run versioning script
-            yarn run version $VERSION
+            yarn run version $VERSION --android
              
         - name: Download Build Artifact
           uses: actions/download-artifact@v3

--- a/documentation/docs/developers/in-app-updates.md
+++ b/documentation/docs/developers/in-app-updates.md
@@ -70,7 +70,7 @@ _Build -> Build Bundles / APKs -> Build Bundle_
 
 7. Increase version and repeat steps 1-4
 ```
-yarn scripts version
+yarn run version --android
 ```
 
 8. Follow link to new internal update but do not install (assume this makes device aware of potential update instead of waiting for store periodic check)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:e2e": "yarn workspace test-e2e start",
     "lint": "ng lint",
     "lint:docs": "cspell \"documentation/docs/**/*.md\" --config \"cspell.config.yml\"",
-    "analyse": "ng build --configuration=production --stats-json && npx webpack-bundle-analyzer www/stats.json"
+    "analyse": "ng build --configuration=production --stats-json && npx webpack-bundle-analyzer www/stats.json",
+    "version": "yarn workspace scripts start version"
   },
   "private": true,
   "dependencies": {
@@ -178,3 +179,4 @@
   },
   "packageManager": "yarn@3.3.1"
 }
+

--- a/packages/scripts/src/commands/version.ts
+++ b/packages/scripts/src/commands/version.ts
@@ -5,38 +5,81 @@ import * as fs from "fs-extra";
 import inquirer from "inquirer";
 import { APP_BUILD_GRADLE_PATH, MAIN_PACKAGE_PATH } from "../paths";
 
+interface IProgramOptions {
+  /** Set package.json version  */
+  package?: boolean;
+  /** Set android version  */
+  android?: boolean;
+}
+
 /***************************************************************************************
  * CLI
- * @example yarn
+ * @example yarn worksapce scripts run version --package --android 1.0.6
  *************************************************************************************/
 const program = new Command("version");
 export default program
   .description("Set app version")
-  .argument("[newVersion]", "newVersion")
-  .action(async (newVersion: string | undefined) => {
-    await version(newVersion);
+  .argument("[version]", "version number to apply")
+  .option("-p, --package", "apply versioning to package.json")
+  .option("-a, --android", "apply versioning to android build")
+  .action(async (version: string | undefined, options: IProgramOptions) => {
+    await setVersion(version, options);
   });
 
 /***************************************************************************************
  * Main Methods
  *************************************************************************************/
 
-/**
- * Set a consistent version number by incrementing the current
- * package.json version and also assigning to android version codes
- */
-async function version(newVersion?: string) {
-  const currentVersion = fs.readJSONSync(MAIN_PACKAGE_PATH).version;
-  if (!newVersion) newVersion = await promptNewVersion(currentVersion);
-  if (!isNextVersionValid(currentVersion, newVersion)) {
-    const heading = chalk.yellow(
-      `Version number must be increased\n${currentVersion} -> ${newVersion}`
-    );
-    console.log(boxen(heading, { padding: 1, borderColor: "red" }));
+async function setVersion(version: string | undefined, options: IProgramOptions) {
+  if (!options.package && !options.android) {
+    console.log(chalk.yellow(`Specify what to version, e.g. --android --package`));
     process.exit(1);
   }
-  updatePackageJson(newVersion);
-  updateGradleBuild(newVersion);
+  if (options.package) await setPackageVersion(version);
+  if (options.android) await setAndroidBuildVersion(version);
+}
+
+/** Update root package.json version, ensuring increment  */
+async function setPackageVersion(version?: string) {
+  const previousVersion = fs.readJSONSync(MAIN_PACKAGE_PATH).version;
+  if (!version) {
+    version = await promptVersion("Package", previousVersion);
+  }
+  // additional increment check in case version supplied directly (non prompt)
+  ensureVersionIncremented(previousVersion, version);
+  updatePackageJson(version);
+}
+
+async function setAndroidBuildVersion(version?: string) {
+  const previousVersion = getGradleBuildVersion();
+  if (!version) {
+    version = await promptVersion("Android", previousVersion);
+  }
+  // additional increment check in case version supplied directly (non prompt)
+  ensureVersionIncremented(previousVersion, version);
+  updateGradleBuild(version);
+}
+
+async function promptVersion(prefix: string, previousVersion: string) {
+  const message = `[${prefix}] Specify a version number (current: ${previousVersion})`;
+  const { input } = await inquirer.prompt([
+    {
+      message,
+      name: "input",
+      validate: (v: string) =>
+        isVersionIncremented(previousVersion, v) ? true : "Version number must be increased",
+    },
+  ]);
+  return input;
+}
+
+function getGradleBuildVersion() {
+  const gradleBuildFile = fs.readFileSync(APP_BUILD_GRADLE_PATH, {
+    encoding: "utf-8",
+  });
+  const match = gradleBuildFile.match(/versionName .*$/gm);
+  const code = match?.[0].replace("versionName", "").replace(/[^0-9.]/g, "");
+  return code || "0.0.0";
 }
 
 function updateGradleBuild(newVersionName: string) {
@@ -54,22 +97,20 @@ async function updatePackageJson(newVersion: string) {
   packageJson.version = newVersion;
   fs.writeJSONSync(MAIN_PACKAGE_PATH, packageJson, { spaces: 2 });
 }
-
-async function promptNewVersion(currentVersion: string) {
-  const { version } = await inquirer.prompt([
-    {
-      message: `Specify a version number (current: ${currentVersion})`,
-      name: "version",
-      validate: (v) =>
-        isNextVersionValid(currentVersion, version) ? true : "Version number must be increased",
-    },
-  ]);
-  return version;
+function ensureVersionIncremented(previousVersion: string, nextVersion: string) {
+  if (previousVersion && nextVersion && isVersionIncremented(previousVersion, nextVersion)) {
+    return true;
+  }
+  const heading = chalk.yellow(
+    `Version number must be increased\n${previousVersion} -> ${nextVersion}`
+  );
+  console.log(boxen(heading, { padding: 1, borderColor: "red" }));
+  process.exit(1);
 }
 
-function isNextVersionValid(currentVersion: string, newVersion: string) {
-  const nextCode = Number(_generateVersionCode(newVersion));
-  const currentCode = Number(_generateVersionCode(currentVersion));
+function isVersionIncremented(previousVersion: string, nextVersion: string) {
+  const nextCode = Number(_generateVersionCode(nextVersion));
+  const currentCode = Number(_generateVersionCode(previousVersion));
   return nextCode > currentCode;
 }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Targets #2198 

- Updates version script to be callable by `yarn run version` (alongside original `yarn scripts version`)
- Separates versioning for `package.json` and android `build.gradle`, using flags to specify (e.g. `yarn run version --android`)
- Add android build version check using existing value from `build.gradle`
- Adds support to existing version script to directly provide target version, e.g. `yarn run version 1.0.5 --package --android`, which will automatically populate android build and package.json version codes
- Improves regex to ensure android versionCode and versionName are replaced even if string value appears instead of number (e.g. current `*versionCode*` placeholder text)
- Improves version code generator to allow integer values if desired (e.g. `yarn run version 2` -> code `2000000`)

## Review Notes
Can test variations of setting package.json and android build.gradle versions via
```sh
yarn run version [number] --android --package
```
all args after `version` are optional, prompting input if no version code set and can be applied to android, package or both

Untested in github actions (not sure the best way to trigger a deployment to call)


## Git Issues

Closes #

## Screenshots/Videos
**Example** - if version code not specified input prompted with validation (allows re-editing version)
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/a985478e-64dc-4773-8278-7442f8eb0550)

**Example** - output if specifying number directly (with invalid code)
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/7277986e-52e4-4b51-8a3b-42e5d98a8a7f)
