### PR TITLE
fix: data-items cdr

### DIFF
--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -59,6 +60,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   templateBreadcrumbs: string[] = [];
   private componentDestroyed$ = new Subject<boolean>();
   debugMode: boolean;
+  private cdr: ChangeDetectorRef;
 
   constructor(
     private templateService: TemplateService,
@@ -70,6 +72,7 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   ) {
     this.templateActionService = new TemplateActionService(injector, this);
     this.templateRowService = new TemplateRowService(injector, this);
+    this.cdr = injector.get(ChangeDetectorRef);
   }
   /** Assign the templatename as metdaata on the component for easier debugging and testing */
   @HostBinding("attr.data-templatename") get getTemplatename() {
@@ -191,6 +194,8 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
       this.parent.children[this.name] = this;
     }
     log_groupEnd();
+    // Ensure any parents using onPush are notified of changes (e.g. data-items)
+    this.cdr.markForCheck();
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description
Fix issue where templates rendered from data-items would not detect changes. All template container elements now include a call to mark changes when child content rendered.

I assume the issue is due to some way by which angular cdr limits change detection for child components from a parent with onPush strategy (haven't tracked down source reference for this, just a hunch).

We could also consider moving all components (notably template and container) to onPush strategy as well, although given the potential for highly breaking changes might make more sense to wait until we implement an alternative rendering system.

Issue discussion in #2215:
https://github.com/IDEMSInternational/parenting-app-ui/pull/2215#discussion_r1508967183

Debug sheet:
https://docs.google.com/spreadsheets/d/14XXwZ7R_7qIBo5xKYuxnPVQbQidI--PPJ7TVvZxwy1k/edit#gid=1422144003

## Git Issues

Closes #

## Screenshots/Videos

[Screenity video - Mar 5, 2024.webm](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/33a22a10-785b-46d9-b1eb-484a6ccf640c)

