### PR TITLE
fix: cdr injection

### DIFF
--- a/src/app/shared/components/template/template-container.component.ts
+++ b/src/app/shared/components/template/template-container.component.ts
@@ -60,19 +60,21 @@ export class TemplateContainerComponent implements OnInit, OnDestroy, ITemplateC
   templateBreadcrumbs: string[] = [];
   private componentDestroyed$ = new Subject<boolean>();
   debugMode: boolean;
-  private cdr: ChangeDetectorRef;
+
+  private get cdr() {
+    return this.injector.get(ChangeDetectorRef);
+  }
 
   constructor(
     private templateService: TemplateService,
     private templateNavService: TemplateNavService,
-    injector: Injector,
+    private injector: Injector,
     // Containers created in headless context may not have specific injectors
     public elRef?: ElementRef,
     private route?: ActivatedRoute
   ) {
     this.templateActionService = new TemplateActionService(injector, this);
     this.templateRowService = new TemplateRowService(injector, this);
-    this.cdr = injector.get(ChangeDetectorRef);
   }
   /** Assign the templatename as metdaata on the component for easier debugging and testing */
   @HostBinding("attr.data-templatename") get getTemplatename() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "declaration": false,
     "module": "es2020",
     "moduleResolution": "node",
-    "emitDecoratorMetadata": false,
     "experimentalDecorators": true,
     "importHelpers": true,
     "esModuleInterop": true,


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Fix regression from #2221 where calls to change detection mechanisms fail for popup templates.

The likely reason for this is the changeDetector is being called during service constructor methods, which can happen before the app has had a chance to inject the changeDetector (likely happens after all other constructors). 

This fix defers retrieval until after explicitly required for a template, and changes the `emitDecoratorMetadata` tsconfig setting which has been linked to [similar issues](https://github.com/search?q=emitDecoratorMetadata+repo%3Aangular%2Fangular&type=issues&s=created&o=desc) and removed in default angular starter templates (although I think it now defaults to `false` anyway when using esbuild, but possibly not webpack compiler)

## Review Notes
Should check before/after running any deployment that processes startup templates

## Git Issues

Closes #2222 (previous fix attempt)

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
