### PR TITLE
style: reduce footer nav bar height

### DIFF
--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
@@ -9,6 +9,6 @@
     <div class="image-wrapper">
       <img [src]="button.image | plhAsset" />
     </div>
-    <p>{{ button.text }}</p>
+    <p *ngIf="button.text">{{ button.text }}</p>
   </a>
 </div>

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
@@ -5,12 +5,12 @@ $navigation-bar-height: var(--navigation-bar-height);
 .navigation-bar-wrapper {
   @include mixins.flex-space-between;
   height: $navigation-bar-height;
-  padding: var(--tiny-margin) var(--tiny-margin);
+  padding: var(--tiny-padding);
 
   .button-wrapper {
     @include mixins.flex-centered;
     flex-direction: column;
-    height: 80%;
+    height: 100%;
     width: 30%;
     opacity: 50%;
     &.active-link {
@@ -19,8 +19,10 @@ $navigation-bar-height: var(--navigation-bar-height);
 
     .image-wrapper {
       @include mixins.flex-centered;
-      height: 50%;
-      width: 80%;
+      flex: 1;
+      padding: var(--tiny-padding) 0;
+      // Apply max-height to adapt to case where button has no text
+      max-height: calc($navigation-bar-height - var(--large-padding));
 
       img {
         height: 100%;
@@ -28,10 +30,11 @@ $navigation-bar-height: var(--navigation-bar-height);
     }
 
     p {
+      flex: 0 1 auto;
       color: var(--ion-color-primary-contrast);
       text-align: center;
       font-size: var(--font-size-text-tiny);
-      margin-bottom: 0;
+      margin: var(--tiny-margin) 0;
     }
   }
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -199,5 +199,6 @@
   --tile-button-style-height: 60px;
 
   --drawer-handle-height: 42px;
-  --navigation-bar-height: 90px;
+  // Odd number, but means that the icons inside will be 32px high (without text)
+  --navigation-bar-height: 67px;
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Reduces the height of the `navigation_bar` component, used in the footer.

In the future, we should expose options to authors to determine the footer height, as in follow-up issue #2225.

NB no deployment currently uses the option of icons and text together for the nav bar, only icons are used.

## Git Issues

Closes #2148 

## Screenshots/Videos

Updated [feat_footer](https://docs.google.com/spreadsheets/d/10iy1Vq-pfD2ERBX6xY66-GY87B8_srAnBKz9hOpRYIo/edit#gid=960980632) template:
<img width="800" alt="Screenshot 2024-03-07 at 14 33 43" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/350a4e07-9b4d-4b95-8e5a-79276261fa01">

| Before | After |
|--------|-------|
|   <img width="300" alt="Screenshot 2024-03-07 at 14 13 45" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/74bdceda-7581-4cf7-9ff1-34faa3c05d52">    | <img width="300" alt="Screenshot 2024-03-07 at 14 28 36" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/4b104a7b-57e5-429b-b7c9-3288d0a9b367">    |
|        | <img width="300" alt="Screenshot 2024-03-07 at 14 29 00" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/fb2c31d6-1959-4fee-9488-1f31cccb93cc">     |
|        | [comp_drawer](https://docs.google.com/spreadsheets/d/1NY-FwPH7AZNlBoaS3Oi0E5j20ppdZwt0zbnqh72D1Tk/edit#gid=569531329) component: <img width="300" alt="Screenshot 2024-03-07 at 14 41 24" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/d69e766d-9ed5-4ccc-bd91-535e0d2569ed">     |



