### PR TITLE
style: use primary colour for icons and text in header when header colour is 'none'

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,5 +1,5 @@
 <ion-header [class.ion-no-border]="colour === 'none'" [style.marginTop]="marginTop">
-  <ion-toolbar [color]="colour">
+  <ion-toolbar [color]="colour" [attr.data-colour]="colour">
     <ion-buttons slot="start" style="position: absolute">
       <ion-menu-button *ngIf="showMenuButton" autoHide="false" menu="start"></ion-menu-button>
       <ion-button

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -1,5 +1,9 @@
 ion-toolbar {
   --min-height: var(--header-height);
+  &[data-colour~="none"] {
+    // Override default ionic settings to make icons and text appear as primary colour
+    --ion-color-contrast: var(--ion-color-primary);
+  }
 }
 ion-header {
   // animate header collapse animation as margin moves off-screen


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow up to #2216. As pointed out in [this comment](https://github.com/IDEMSInternational/parenting-app-ui/pull/2216#issuecomment-1986181000), when the header colour is `none`, the icons and text in the header should appear in the primary app colour.

## Git Issues

Closes #

## Screenshots/Videos

With deployment config:
```js
config.app_config.APP_HEADER_DEFAULTS.colour = "none";
```
<img width="300" alt="Screenshot 2024-03-11 at 13 06 21" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/43c772ef-3233-4cd1-8252-0bca354db670">

With deployment config:
```js
config.app_config.APP_HEADER_DEFAULTS.colour = "none";
config.app_config.APP_HEADER_DEFAULTS.variant = "compact";
```
<img width="200" alt="Screenshot 2024-03-11 at 13 00 28" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f1f062be-f767-4544-a77b-2747155d914d">



