### PR TITLE
style: add drop-shadow to radio button grid component items

### DIFF
--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.scss
@@ -19,6 +19,7 @@ $text-color: var(--radio-button-font-color, var(--ion-color-primary));
   padding: 8px;
   background: white;
   cursor: pointer;
+  box-shadow: var(--ion-default-box-shadow);
 }
 .item[data-selected="true"] {
   background: $background-selected;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a drop-shadow effect to the clickable items that appear within the radio button grid component, to match those of the radio group component.

This effect is hardcoded and editable at the theme level, as opposed to being exposed as an authorable parameter on the component.

## Git Issues

Closes #2231

## Screenshots/Videos

[comp_radio_button_grid](https://docs.google.com/spreadsheets/d/1yHLQHxZQuxs34gBU-ny95ZWs9e8-HybC4IAeFxwpcVw/edit#gid=569531329) template

| Before | After |
|-------|-------|
| <img width="300" alt="Screenshot 2024-03-12 at 15 25 25" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/ea460e8c-3b9d-40ee-ac3e-9e3916fed5b4"> | <img width="300" alt="Screenshot 2024-03-12 at 15 22 00" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/6bdd1b38-77d2-4878-9ae1-560756bdcde1"> |