### PR TITLE
chore: update default app data output path to reflect remote repos

### DIFF
--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -161,8 +161,7 @@ export const DEPLOYMENT_CONFIG_EXAMPLE_DEFAULTS: IDeploymentConfig = {
     sheets_path: "./sheets",
   },
   app_data: {
-    // TODO - change to local ./app-data folder once git repos in use
-    output_path: "packages/app-data",
+    output_path: "./app-data",
     sheets_filter_function: (flow) => true,
     assets_filter_function: (fileEntry) => true,
   },


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Previously, all deployment configs for remote repos needed to specify a config value for `app_data.output_path`, namely `"./app_data"`. Now that all deployments have associated remote repos, the default value should be updated so that such configs no longer need to specify the value explicitly.

## Git Issues

Closes #
