### PR TITLE
fix: button child layout positioning

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -7,6 +7,7 @@
     (click)="triggerActions('click')"
     [attr.data-param-style]="params.style"
     [attr.data-variant]="params.variant"
+    [attr.data-has-children]="_row.rows ? true : false"
   >
     <ion-icon *ngIf="params.icon" slot="start" src="{{ params.icon | plhAsset }}"></ion-icon>
     <span
@@ -32,6 +33,7 @@
     class="button-container"
     (click)="triggerActions('click')"
     [attr.data-variant]="params.variant"
+    [attr.data-has-children]="_row.rows ? true : false"
   >
     <img *ngIf="params.image" src="{{ params.image | plhAsset }}" />
     <div *ngIf="_row.value" [class]="'button-text ' + params.textAlign">

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -11,6 +11,10 @@ $background-secondary: var(--button-background-secondary, var(--gradient-seconda
     display: contents;
   }
 }
+// ensure relative position on parent if absolute position children nested inside
+[data-has-children] {
+  position: relative;
+}
 ion-button {
   font-size: var(--buttons-font-size-small);
   font-weight: var(--font-weight-standard);


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Inconsistencies have been noticed to the way different browsers handle toggle element nested inside button for `comp_button` template. This is likely due to different ways the `position: absolute` property of the rendered children span is interpreted (this should be nearest element that has relative positioning, it appears chrome stops if it doesn't find an element when reaching shadow-dom parent component whilst webkit continues further up dom root).

This PR explicitly sets relative positioning on the button container element to ensure children are rendered with correct positioning

## Review Notes
As the bug has only been noticed on ios/safari browser, testing on windows should be done via the playwright test framework, accessing the underlying webkit browser
```
npx playwright install
npx playwright wk http://localhost:4200/template/comp_button
```

## Git Issues

Closes #2262

## Screenshots/Videos

**Before** - Portrait card toggle positioned in absolute top-right of screen
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/07b46818-f1a3-40e4-8429-e7680c05e0eb)

**After** - Portrait card toggle positioned correctly
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/9c0eaf70-6701-4436-9048-382d88b99eec)

