### PR TITLE
feat: allow style_list to apply directly to text in text component

### DIFF
--- a/src/app/shared/components/template/components/text.ts
+++ b/src/app/shared/components/template/components/text.ts
@@ -10,6 +10,7 @@ import { getStringParamFromTemplateRow } from "../../../utils";
     [class]="style"
     [ngStyle]="isFalsy ? { display: 'none' } : { display: 'block' }"
     [innerHTML]="type === 'numbered' ? (_row.value | number) : (_row.value?.toString() | markdown)"
+    [style]="_row.style_list | styleList"
     [style.textAlign]="textAlign"
   ></div> `,
   styleUrls: ["./tmpl-components-common.scss"],


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

There has been an author request to change the colour of text that appears in a text component.

A thorough solution would involve expanding our WIP variant/style system (#1971), e.g. by adding a general style that can be applied via a parameter to any component, such as `style: color-secondary-500`. Currently, this is not a priority and we don't have the capacity to implement such a system properly at this time. Another option would be to add a new property on the component, e.g. `colour`(/`color`), that could take values such as `primary`, `secondary`, `white`, `black` (encouraged) and potentially also `green` and `#32a852` (discouraged/undocumented). But implementing that would be in conflict with our plan for a more general variant/style system.

This PR implements an alternative solution: the rules specified in the `style_list` are now applied such that they should be reflected in the appearance of the actual text itself (as opposed to the enclosing row container). This feature, or something like it, is included in our plans for the variant/style system, with this functionality rolled out to all components in a custom way.

## Git Issues

Closes #

## Screenshots/Videos

Updated comp_text component:

<img width="800" alt="Screenshot 2024-04-11 at 18 25 11" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/146b2aa2-7583-4b1e-a9ca-dff9c6ed8ebd">

<img width="300" alt="Screenshot 2024-04-11 at 18 24 32" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/452b3966-3c91-4ea9-b755-3236a275357a">


[debug_text_style_list](https://docs.google.com/spreadsheets/d/1b0FK3Eggz76H_C9lRdFVVLUxUBEZPruoyaF0d6YeWSI/edit#gid=1520315646) component demonstrating that applying a value for the `flex` property in the style list functions as expected (dev note: the style is applied both to the row container element as before, and additionally to the `<div>` that contains the text html. The latter has no effect since the div is not inside a flexbox)

<img width="500" alt="Screenshot 2024-04-11 at 18 25 47" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/610a8e0f-97b7-40a7-b1cc-cc32b40834ca">

<img width="300" alt="Screenshot 2024-04-11 at 18 09 49" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/cabb521a-da1e-4610-a398-a737f0be9410">

