### PR TITLE
feat: store first app launch value in field

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -37,6 +37,7 @@ const FIELD_PREFIX = "rp-contact-field";
  * */
 const APP_FIELDS = {
   APP_AUTH_USER: `${FIELD_PREFIX}._app_auth_user`,
+  APP_FIRST_LAUNCH: `${FIELD_PREFIX}._app_first_launch`,
   APP_LANGUAGE: `${FIELD_PREFIX}._app_language`,
   APP_SKIN: `${FIELD_PREFIX}._app_skin`,
   APP_THEME: `${FIELD_PREFIX}._app_theme`,


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Whilst we already track the timestamp of a user's first launch of the app, this value is not synced tot he database. This PR stores the value of the app's first launch in a field, enabling it to be synced to the user database for analysis. 

The field name is `_app_first_launch`.

## Dev notes

Initially, I wrote the logic to use the template field service to set the field variable, see https://github.com/IDEMSInternational/parenting-app-ui/pull/2301/commits/ef7220f19a7e56816cebd5b0bf7835f18147fed2.
However that approach hardcodes the field name ("_app_first_launch") into the app-events service, without having it declared in the app config (i.e. as `appConfig.APP_FIELDS.APP_FIRST_LAUNCH`). Therefore it seemed sensible to use local storage service to set the field string directly, matching the pattern used to set most of the other protected variables throughout the app. However I don't think this pattern is ideal, as we're setting a field without using the field service and it requires an additional subscription to the app config service in order to get the field name. 

This system of setting protected fields could probably be rationalised across the code at some point. It may be that it's sensible to store the names of these protected fields a level up, in the deployment config defined in `deployment.model.ts`, but not in the `app_config` object, as it doesn't seem necessary to update these values at runtime. Then the values could be consumed by services without needing a subscription to the app config service. If these values were declared without the `FIELD_PREFIX` prefix, then the fields could be set via the `templateFieldService.setField()` method, which appends the prefix itself. It may be that the current pattern of bypassing the template field service is intentional in the case of protected fields in order to differentiate them from user-set fields, in which case perhaps there should be some protections on `templateFieldService.setField()` to prevent setting a protected field directly with this method.

## Git Issues

Closes #2295, assuming that having access to this value in the postgres database is deemed to be a satisfactory resolution of that issue

## Screenshots/Videos

<img width="800" alt="Screenshot 2024-04-23 at 12 01 22" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/68028b88-eeda-402c-864e-8c55d9fe0232">

