### PR TITLE
fix: ios button card style issue

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -48,6 +48,9 @@ ion-button[data-variant~="nested_color"] {
 ion-button[data-param-style~="card"],
 ion-button[data-variant~="card"] {
   --background: white;
+  // HACK: on iOS, the background does not always appear correctly without this additional rule,
+  // see https://github.com/IDEMSInternational/parenting-app-ui/issues/2287
+  background-color: white;
   --background-activated: var(--ion-color-gray-light);
   --padding-top: var(--tiny-padding);
   --padding-bottom: var(--tiny-padding);
@@ -56,7 +59,6 @@ ion-button[data-variant~="card"] {
   border: 1px solid var(--ion-color-gray-light);
   border-radius: var(--ion-border-radius-secondary);
   min-height: var(--buttons-short-height);
-  filter: drop-shadow(var(--ion-default-box-shadow));
 
   .text ::ng-deep {
     p {

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -48,9 +48,6 @@ ion-button[data-variant~="nested_color"] {
 ion-button[data-param-style~="card"],
 ion-button[data-variant~="card"] {
   --background: white;
-  // HACK: on iOS, the background does not always appear correctly without this additional rule,
-  // see https://github.com/IDEMSInternational/parenting-app-ui/issues/2287
-  background-color: white;
   --background-activated: var(--ion-color-gray-light);
   --padding-top: var(--tiny-padding);
   --padding-bottom: var(--tiny-padding);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the background of the button component with `variant: card` applied would turn transparent when scrolled off screen and back again.

This is a frustratingly simple solution to an issue that cause some headaches: the card variant of the button component had an extra drop-shadow filter applied, in addition to the `box-shadow` applied to the ionic button component. Removing this additional drop-shadow fixes the issue.

## Dev notes

Before I removed this filter, the behaviour was very strange (I've added some [brief notes](https://github.com/IDEMSInternational/parenting-app-ui/issues/2287#issuecomment-2077349271) to #2287 in case they're useful in future). I think there is possibly a genuine bug that could be reported to ionic (or even Apple), along the lines of "Setting both a CSS drop-shadow filter and a box-shadow on an element causes CSS variables to not be passed correctly to children", but I don't think I've managed to isolate the bug fully. And this is a pattern we can easily avoid.

## Git Issues

Closes #2287

## Screenshots/Videos

I've made a new template, [debug_card_styles](https://docs.google.com/spreadsheets/d/1QyFq6k9163Uh-WywA2fliV2tWrCor-kDsj9uhfcdOng/edit#gid=1054713933), for visually comparing all the components that have are styled as a "card". The fact that we have different components that look so similar is confusing, but I think still justified as they are functionally fundamentally different (a `task-card` necessarily has an associated task or task group, which has a completion status, whereas a button has no such association). Comparing these elements before and after the changes made by this PR, we can see that in the "before", the button with `variant: card` stands out as having a darker shadow than the other elements. In the "after" the drop-shadows for all elements match. I don't think there is any reason for this other than an error made when duplicating some CSS code (the `card-portrait` variant of the button does not use an `ion-button` as its base, so deliberately has this filter applied).

| Before | After |
|--------|-------|
| <img width="240" alt="Before" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/5fd90168-8da5-46be-84d5-8048d0dc3ecf">      | <img width="240" alt="After" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/9ec7390e-3740-4f03-bd9d-c1a63801b499">     |

### Working demo

Demo of [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit#gid=569531329) component showing bug not present (see [this comment](https://github.com/IDEMSInternational/parenting-app-ui/issues/2287#issuecomment-2047279077) on the issue for previous behaviour).

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/23a843a8-4744-4ed9-bfd4-feca274c2eb8



