### PR TITLE
test: fix issue with e2e-data parse script

### DIFF
--- a/packages/scripts/src/commands/e2e-data/parse.ts
+++ b/packages/scripts/src/commands/e2e-data/parse.ts
@@ -17,7 +17,7 @@ export default program
   .description("Parse worksheet into JS!")
   .requiredOption("-i --input <string>", "path to input xlsx file (relative to project root)")
   .requiredOption("-o --output <string>", "path to output spec file (relative to project root")
-  .action((options: IProgramOptions) => {
+  .action(async (options: IProgramOptions) => {
     // Setup Input and Outputs
     const { input, output } = options;
     const inputPath = path.resolve(ROOT_DIR, input);
@@ -54,7 +54,7 @@ export default program
       outputs.push(output);
     });
     const specData = outputs.join("\n");
-    const formattedOutput = prettier.format(specData, { parser: "babel" });
+    const formattedOutput = await prettier.format(specData, { parser: "babel" });
     fs.writeFileSync(outputPath, formattedOutput);
   });
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue with `e2e-data parse` script, introduced by #2299.

From the comment at the top of the file `.github/workflows/deprecated/test-e2e.yml`, I don't believe this script is actually in use, and so likely does not been to be maintained. However, this issue was throwing an error when running `yarn ng test` and as this fix was simple it seems desirable to add it for now.

## Git Issues

Closes #

## Screenshots/Videos

Error thrown when running `yarn ng test --include src/app/shared/components/template/services/template-variables.service.spec.ts`, no longer thrown on this feature branch

<img width="500" alt="Screenshot 2024-04-29 at 12 46 14" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/cd117432-7616-46a1-9eed-cd1afb31fd24">


