### PR TITLE
fix: data pipe append_columns operation can handle boolean strings

### DIFF
--- a/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
+++ b/packages/scripts/src/commands/app-data/convert/processors/flowParser/flowParser.ts
@@ -4,7 +4,7 @@ import { IConverterPaths, IFlowHashmapByType, IParsedWorkbookData } from "../../
 import { arrayToHashmap, groupJsonByKey, IContentsEntry } from "../../utils";
 import BaseProcessor from "../base";
 
-const cacheVersion = 20240412.3;
+const cacheVersion = 20240502.0;
 
 export class FlowParserProcessor extends BaseProcessor<FlowTypes.FlowTypeWithData> {
   public parsers: { [flowType in FlowTypes.FlowType]: Parsers.DefaultParser } = {

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
@@ -20,7 +20,9 @@ describe("App String Evaluator", () => {
   it("Evaluates boolean strings as booleans", () => {
     expect(evaluator.evaluate("false")).toEqual(false);
     expect(evaluator.evaluate("FALSE")).toEqual(false);
+    expect(evaluator.evaluate("False")).toEqual(false);
     expect(evaluator.evaluate("true")).toEqual(true);
     expect(evaluator.evaluate("TRUE")).toEqual(true);
+    expect(evaluator.evaluate("True")).toEqual(true);
   });
 });

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
@@ -16,4 +16,11 @@ describe("App String Evaluator", () => {
       "Hello Ada Lovelace"
     );
   });
+
+  it("Evaluates boolean strings as booleans", () => {
+    expect(evaluator.evaluate("false")).toEqual(false);
+    expect(evaluator.evaluate("FALSE")).toEqual(false);
+    expect(evaluator.evaluate("true")).toEqual(true);
+    expect(evaluator.evaluate("TRUE")).toEqual(true);
+  });
 });

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
@@ -1,5 +1,6 @@
 import { JSEvaluator } from "../jsEvaluator/jsEvaluator";
 import { TemplatedData } from "..";
+import { booleanStringToBoolean } from "../../utils";
 
 /**
  * Utility class to allow evaluation of strings that contain a mix of context expressions,
@@ -47,7 +48,7 @@ export class AppStringEvaluator {
       const evaluated = this.evaluator.evaluate(parsed);
       return evaluated;
     } catch (error) {
-      return parsed;
+      return booleanStringToBoolean(parsed);
     }
   }
 }

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
@@ -1,7 +1,6 @@
 import { JSEvaluator } from "../jsEvaluator/jsEvaluator";
 import { TemplatedData } from "..";
 import { booleanStringToBoolean } from "../../utils/string-utils";
-// import { booleanStringToBoolean } from "../../utils";
 
 /**
  * Utility class to allow evaluation of strings that contain a mix of context expressions,

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
@@ -1,6 +1,7 @@
 import { JSEvaluator } from "../jsEvaluator/jsEvaluator";
 import { TemplatedData } from "..";
-import { booleanStringToBoolean } from "../../utils";
+import { booleanStringToBoolean } from "../../utils/string-utils";
+// import { booleanStringToBoolean } from "../../utils";
 
 /**
  * Utility class to allow evaluation of strings that contain a mix of context expressions,

--- a/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
@@ -14,12 +14,13 @@ describe("Append Columns Operator", () => {
     const testOutputGreeting = output.column("greeting").values[2];
     expect(testOutputGreeting).toEqual("Hello Charles Babbage");
   });
-  it("appends columns with boolean values", () => {
+  it("appends columns with boolean, number and null values", () => {
     const testDf = new DataFrame(testData.names);
     const output = new append_columns(testDf, [
       "full_name : Ada Lovelace",
       "boolean : FALSE",
       "number : -3.75 ",
+      "null : null",
     ]).apply();
     const testOutputFullName = output.column("full_name").values[2];
     expect(testOutputFullName).toEqual("Ada Lovelace");
@@ -27,5 +28,7 @@ describe("Append Columns Operator", () => {
     expect(testOutputBoolean).toEqual(false);
     const testOutputNumber = output.column("number").values[2];
     expect(testOutputNumber).toEqual(-3.75);
+    const testOutputNull = output.column("null").values[2];
+    expect(testOutputNull).toEqual(null);
   });
 });

--- a/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
@@ -14,4 +14,15 @@ describe("Append Columns Operator", () => {
     const testOutputGreeting = output.column("greeting").values[2];
     expect(testOutputGreeting).toEqual("Hello Charles Babbage");
   });
+  it("appends columns with boolean values", () => {
+    const testDf = new DataFrame(testData.names);
+    const output = new append_columns(testDf, [
+      "full_name : Ada Lovelace",
+      "boolean : FALSE",
+    ]).apply();
+    const testOutputFullName = output.column("full_name").values[2];
+    expect(testOutputFullName).toEqual("Ada Lovelace");
+    const testOutputGreeting = output.column("boolean").values[2];
+    expect(testOutputGreeting).toEqual(false);
+  });
 });


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)
- [x] Merge https://github.com/IDEMSInternational/app-debug-content/pull/66 (for diff comparison of output data lists from data pipe)

## Description

Fixes an issue where values of data list columns added via the data pipe `append_columns` operation would not be parsed as boolean values as expected when the value is a boolean string (`"TRUE"`, `"false"` etc.)

Incorporates #2308:
- add generic `parseStringValue` string util and tests to cover conversion of string to boolean, number, null or undefined

## Testing

Run `yarn workspace shared test` and ensure tests are passing as expected:
<img width="300" alt="Screenshot 2024-05-01 at 16 05 01" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/16c3a6b0-1573-4feb-86fe-38d95b434a9c">
<img width="300" alt="Screenshot 2024-05-01 at 16 05 22" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/8034d152-f64e-42f1-83ac-f31dd0940973">


With this PR's branch checked out, and assuming https://github.com/IDEMSInternational/app-debug-content/pull/66 has been merged, set the active deployment to `debug`. Run `yarn workflow sync_sheets` and `yarn workflow repo open` to inspect the differences. There should just be one changed file, `app_data/sheets/data_list/generated/example_pipe_appended.json` with the diff showing that previous boolean strings have been replaced by boolean values.

<img width="800" alt="Screenshot 2024-04-30 at 14 48 29" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/4c747bb2-40cb-4946-a653-25da4c35c9b1">

## Dev notes

There are multiple places where this `booleanStringToBoolean()` parsing could be applied. Doing so in the `appStringEvaluator` seems appropriate (possibly correcting an oversight) and preserves the type safety of the `appendColumns` operator.

## Git Issues

Closes #

