### PR TITLE
refactor: data-pipe parse string

### DIFF
--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.spec.ts
@@ -16,13 +16,4 @@ describe("App String Evaluator", () => {
       "Hello Ada Lovelace"
     );
   });
-
-  it("Evaluates boolean strings as booleans", () => {
-    expect(evaluator.evaluate("false")).toEqual(false);
-    expect(evaluator.evaluate("FALSE")).toEqual(false);
-    expect(evaluator.evaluate("False")).toEqual(false);
-    expect(evaluator.evaluate("true")).toEqual(true);
-    expect(evaluator.evaluate("TRUE")).toEqual(true);
-    expect(evaluator.evaluate("True")).toEqual(true);
-  });
 });

--- a/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
+++ b/packages/shared/src/models/appStringEvaluator/appStringEvaluator.ts
@@ -1,6 +1,5 @@
 import { JSEvaluator } from "../jsEvaluator/jsEvaluator";
 import { TemplatedData } from "..";
-import { booleanStringToBoolean } from "../../utils/string-utils";
 
 /**
  * Utility class to allow evaluation of strings that contain a mix of context expressions,
@@ -48,7 +47,7 @@ export class AppStringEvaluator {
       const evaluated = this.evaluator.evaluate(parsed);
       return evaluated;
     } catch (error) {
-      return booleanStringToBoolean(parsed);
+      return parsed;
     }
   }
 }

--- a/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
+++ b/packages/shared/src/models/dataPipe/operators/appendColumns.spec.ts
@@ -19,10 +19,13 @@ describe("Append Columns Operator", () => {
     const output = new append_columns(testDf, [
       "full_name : Ada Lovelace",
       "boolean : FALSE",
+      "number : -3.75 ",
     ]).apply();
     const testOutputFullName = output.column("full_name").values[2];
     expect(testOutputFullName).toEqual("Ada Lovelace");
-    const testOutputGreeting = output.column("boolean").values[2];
-    expect(testOutputGreeting).toEqual(false);
+    const testOutputBoolean = output.column("boolean").values[2];
+    expect(testOutputBoolean).toEqual(false);
+    const testOutputNumber = output.column("number").values[2];
+    expect(testOutputNumber).toEqual(-3.75);
   });
 });

--- a/packages/shared/src/models/dataPipe/operators/appendColumns.ts
+++ b/packages/shared/src/models/dataPipe/operators/appendColumns.ts
@@ -15,7 +15,6 @@ class AppendColumnsOperator extends BaseOperator {
   constructor(df: DataFrame, args_list: any) {
     super(df, args_list);
   }
-  // args are simply evaluated as JS statements and do not require additional parsing
   parseArg(arg: string): IParsedArg {
     const [key, value] = arg.split(":").map((a) => a.trim());
     const valueExpression = parseStringValue(value);

--- a/packages/shared/src/models/dataPipe/operators/appendColumns.ts
+++ b/packages/shared/src/models/dataPipe/operators/appendColumns.ts
@@ -1,6 +1,7 @@
 import { DataFrame, toJSON } from "danfojs";
 import { AppStringEvaluator } from "../../appStringEvaluator/appStringEvaluator";
 import BaseOperator from "./base";
+import { parseStringValue } from "../../../utils";
 
 interface IParsedArg {
   key: string;
@@ -16,7 +17,8 @@ class AppendColumnsOperator extends BaseOperator {
   }
   // args are simply evaluated as JS statements and do not require additional parsing
   parseArg(arg: string): IParsedArg {
-    const [key, valueExpression] = arg.split(":").map((a) => a.trim());
+    const [key, value] = arg.split(":").map((a) => a.trim());
+    const valueExpression = parseStringValue(value);
     return { key, valueExpression };
   }
   validateArg(arg: IParsedArg): boolean {

--- a/packages/shared/src/utils/string-utils.spec.ts
+++ b/packages/shared/src/utils/string-utils.spec.ts
@@ -4,6 +4,8 @@ describe("string-utils", () => {
   it("parses string values", () => {
     const test_non_string = parseStringValue({ test: "hello" } as any);
     expect(test_non_string).toEqual({ test: "hello" });
+    const test_a_string = parseStringValue("My test string");
+    expect(test_a_string).toEqual("My test string");
     const test_empty_string = parseStringValue("");
     expect(test_empty_string).toEqual("");
     const test_float = parseStringValue("-5.25");

--- a/packages/shared/src/utils/string-utils.spec.ts
+++ b/packages/shared/src/utils/string-utils.spec.ts
@@ -1,0 +1,22 @@
+import { parseStringValue } from "./string-utils";
+
+describe("string-utils", () => {
+  it("parses string values", () => {
+    const test_non_string = parseStringValue({ test: "hello" } as any);
+    expect(test_non_string).toEqual({ test: "hello" });
+    const test_empty_string = parseStringValue("");
+    expect(test_empty_string).toEqual("");
+    const test_float = parseStringValue("-5.25");
+    expect(test_float).toEqual(-5.25);
+    const test_boolean = parseStringValue("TrUe");
+    expect(test_boolean).toEqual(true);
+    const test_null = parseStringValue("null");
+    expect(test_null).toEqual(null);
+    const test_undefined = parseStringValue("undefined");
+    expect(test_undefined).toEqual(undefined);
+    const test_whitespace = parseStringValue(" 2 ");
+    expect(test_whitespace).toEqual(2);
+    const test_quoted = parseStringValue('"2"');
+    expect(test_quoted).toEqual("2");
+  });
+});

--- a/packages/shared/src/utils/string-utils.ts
+++ b/packages/shared/src/utils/string-utils.ts
@@ -18,3 +18,26 @@ export function kbToMB(kb: number, decimalPlaces = 1) {
   const power = 10 ^ decimalPlaces;
   return Math.round((mb * power) / power);
 }
+
+/**
+ * Take an input string value and empty to parse as native data type, including
+ * numeric, boolean, null and undefined string representations
+ */
+export function parseStringValue(v: string): any {
+  // return non-string and empty string as-is
+  if (typeof v !== "string") return v;
+  if (!v) return v;
+  v = v.trim();
+  // attempt to parse as number if possible and return if valid
+  // https://stackoverflow.com/questions/175739/how-can-i-check-if-a-string-is-a-valid-number
+  if (!isNaN(v as any)) return Number(v);
+  // attempt to parse as boolean and return if matched
+  if (v.match(/^true$/gi)) return true;
+  if (v.match(/^false$/gi)) return false;
+  // attempt to parse null and undefined string representations and return if matched
+  if (v.match(/^null$/gi)) return null;
+  if (v.match(/^undefined$/gi)) return undefined;
+  // attempt to parse quoted (keep string representation)
+  if (v.match(/^"[a-z0-9.]*"$/gi)) return v.replace(/"/g, "");
+  return v;
+}

--- a/packages/shared/src/utils/string-utils.ts
+++ b/packages/shared/src/utils/string-utils.ts
@@ -20,7 +20,7 @@ export function kbToMB(kb: number, decimalPlaces = 1) {
 }
 
 /**
- * Take an input string value and empty to parse as native data type, including
+ * Take an input string value and attempt to parse as native data type, including
  * numeric, boolean, null and undefined string representations
  */
 export function parseStringValue(v: string): any {


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Targets branch of pr #2307

- add generic `parseStringValue` string util and tests to cover conversion of string to boolean, number, null or undefined
- update `appStringEvaluator` to no longer parse boolean strings, instead applying new method only to `appendColumns` operator

## Dev notes
I couldn't decide between making the conversion more specific to the `appendColumns` operator or generally to the `appStringEvaluator`, but in the end felt keeping it more specific for now might be better as fewer potential knock-ons and can consider making more general in a follow-up PR if useful.


## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
