### PR TITLE
fix: set_item actions nested inside item loop

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
@@ -228,7 +228,7 @@ describe("DataItemsComponent", () => {
       TEST_ITEM_DATA,
       "test_data_list"
     );
-    // get rows at one level of nesting
+    // get rows at one level of nesting (e.g. those within a display group)
     const nestedRowsWithItemMeta = rowsWithItemMeta[0].rows;
     // get action args for a set_item action (args object is passed within an array)
     const setItemContext = nestedRowsWithItemMeta[0].action_list.find(

--- a/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.spec.ts
@@ -1,13 +1,200 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { TmplDataItemsComponent } from "./data-items.component";
+import { FlowTypes } from "../../models";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 
+const TEST_ITEM_DATA: FlowTypes.Data_listRow[] = [
+  {
+    id: "id_1",
+    completed: true,
+  },
+  {
+    id: "id_2",
+    completed: true,
+  },
+];
+
+// Template rows representing an item loop consisting of one button per item
+const TEST_ROWS: FlowTypes.TemplateRow[] = [
+  {
+    type: "button",
+    value: "Click here",
+    action_list: [
+      {
+        trigger: "click",
+        action_id: "set_item",
+        args: [],
+        _raw: "click | set_item | completed: true",
+        _cleaned: "click | set_item | completed: true",
+        params: {
+          completed: true,
+        },
+      },
+    ],
+    name: "button_1",
+    _nested_name: "data_items_3.button_1",
+    _evalContext: {
+      itemContext: {
+        id: "id_1",
+        label: "Task 1",
+        completed: true,
+        _index: 0,
+        _id: "id_1",
+        _first: true,
+        _last: false,
+      },
+    },
+  },
+  {
+    type: "button",
+    value: "Click here",
+    _translations: {
+      value: {},
+    },
+    action_list: [
+      {
+        trigger: "click",
+        action_id: "set_item",
+        args: [],
+        _raw: "click | set_item | completed: true",
+        _cleaned: "click | set_item | completed: true",
+        params: {
+          completed: true,
+        },
+      },
+    ],
+    name: "button_1",
+    _nested_name: "data_items_3.button_1",
+    _evalContext: {
+      itemContext: {
+        id: "id_2",
+        label: "Task 2",
+        completed: true,
+        _index: 1,
+        _id: "id_2",
+        _first: false,
+        _last: false,
+      },
+    },
+  },
+];
+
+// Template rows representing an item loop consisting of one button inside a display_group per item
+const TEST_ROWS_NESTED: FlowTypes.TemplateRow[] = [
+  {
+    type: "display_group",
+    name: "display_group_1",
+    _nested_name: "data_items_6.display_group_1",
+    _evalContext: {
+      itemContext: {
+        id: "id_1",
+        label: "Task 1",
+        completed: true,
+        _index: 0,
+        _id: "id_1",
+        _first: true,
+        _last: false,
+      },
+    },
+    rows: [
+      {
+        type: "button",
+        value: "Click here",
+        _translations: {
+          value: {},
+        },
+        action_list: [
+          {
+            trigger: "click",
+            action_id: "set_item",
+            args: [],
+            _raw: "click | set_item | completed: true",
+            _cleaned: "click | set_item | completed: true",
+            params: {
+              completed: true,
+            },
+          },
+        ],
+        name: "button_1",
+        _nested_name: "data_items_6.display_group_1.button_1",
+        _evalContext: {
+          itemContext: {
+            id: "id_1",
+            label: "Task 1",
+            completed: true,
+            _index: 0,
+            _id: "id_1",
+            _first: true,
+            _last: false,
+          },
+        },
+      },
+    ],
+  },
+  {
+    type: "display_group",
+    name: "display_group_1",
+    _nested_name: "data_items_6.display_group_1",
+    _evalContext: {
+      itemContext: {
+        id: "id_2",
+        label: "Task 2",
+        completed: true,
+        _index: 1,
+        _id: "id_2",
+        _first: false,
+        _last: false,
+      },
+    },
+    rows: [
+      {
+        type: "button",
+        value: "Click here",
+        _translations: {
+          value: {},
+        },
+        action_list: [
+          {
+            trigger: "click",
+            action_id: "set_item",
+            args: [],
+            _raw: "click | set_item | completed: true",
+            _cleaned: "click | set_item | completed: true",
+            params: {
+              completed: true,
+            },
+          },
+        ],
+        name: "button_1",
+        _nested_name: "data_items_6.display_group_1.button_1",
+        _evalContext: {
+          itemContext: {
+            id: "id_2",
+            label: "Task 2",
+            completed: true,
+            _index: 1,
+            _id: "id_2",
+            _first: false,
+            _last: false,
+          },
+        },
+      },
+    ],
+  },
+];
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/components/template/components/data-items/data-items.component.spec.ts
+ */
 describe("DataItemsComponent", () => {
   let component: TmplDataItemsComponent;
   let fixture: ComponentFixture<TmplDataItemsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       declarations: [TmplDataItemsComponent],
     }).compileComponents();
 
@@ -18,5 +205,35 @@ describe("DataItemsComponent", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("adds item meta to action arguments", () => {
+    // ID of original item
+    const rowItemId = TEST_ROWS[0]._evalContext.itemContext._id;
+    // add item meta
+    const rowsWithItemMeta = component["setItemMeta"](TEST_ROWS, TEST_ITEM_DATA, "test_data_list");
+    // get action args for a set_item action (setItemContext object is passed within an array)
+    const setItemContext = rowsWithItemMeta[0].action_list.find(
+      (action) => action.action_id === "set_item"
+    ).args[0];
+    expect(setItemContext.currentItemId).toBe(rowItemId);
+  });
+
+  it("adds item meta to action arguments nested inside child rows", () => {
+    // ID of original item
+    const rowItemId = TEST_ROWS_NESTED[0]._evalContext.itemContext._id;
+    // add item meta
+    const rowsWithItemMeta = component["setItemMeta"](
+      TEST_ROWS_NESTED,
+      TEST_ITEM_DATA,
+      "test_data_list"
+    );
+    // get rows at one level of nesting
+    const nestedRowsWithItemMeta = rowsWithItemMeta[0].rows;
+    // get action args for a set_item action (args object is passed within an array)
+    const setItemContext = nestedRowsWithItemMeta[0].action_list.find(
+      (action) => action.action_id === "set_item"
+    ).args[0];
+    expect(setItemContext.currentItemId).toBe(rowItemId);
   });
 });


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where `set_item` and `set_items` actions would not function as expected when the row was deeply nested within an item loop, e.g. within a `display_group` component inside an item loop.

This was due to the `setItemContext` meta only being applied to actions within the top-level `action_list` inside the items loop.

## Git Issues

Issue identified in [this mattermost thread](https://chat.idems.international/all/pl/spto5y6f53b4xfm1k6p8x91dpc).

## Screenshots/Videos

See new [debug_data_items_actions](https://docs.google.com/spreadsheets/d/1HvJOcbYGtrkPxwkPp8lvNW63ngsvworzz_jEUo5Swe0/edit#gid=1007541292) component. The buttons on all actions now function as expected – on `master`, the buttons in the second items loop, nested inside `display_group`s, do not trigger the action correctly and an error is thrown.

<img width="600" alt="Screenshot 2024-05-01 at 15 35 38" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/de309822-6563-4f6e-9e42-021adc01e13c">

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/a86caf98-8ad1-40dc-9d09-35f4dafb7c96


