### PR TITLE
fix: data items are sorted according to original order by default

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -66,7 +66,7 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
       this.dataQuery$ = query.pipe(debounceTime(50)).subscribe(async (data) => {
         // By default, sort the items into the order they appeared in the original data list.
         // Can be overridden with a `sort` operator applied in the data-items component params
-        const sortedData = data.sort((a, b) => a.index_original - b.index_original);
+        const sortedData = data.sort((a, b) => a.row_index - b.row_index);
         await this.renderItems(sortedData, this._row.rows, this.parameterList);
       });
     } else {

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -64,7 +64,10 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
       await this.dynamicDataService.ready();
       const query = await this.dynamicDataService.query$("data_list", this.dataListName);
       this.dataQuery$ = query.pipe(debounceTime(50)).subscribe(async (data) => {
-        await this.renderItems(data, this._row.rows, this.parameterList);
+        // By default, sort the items into the order they appeared in the original data list.
+        // Can be overridden with a `sort` operator applied in the data-items component params
+        const sortedData = data.sort((a, b) => a.index_original - b.index_original);
+        await this.renderItems(sortedData, this._row.rows, this.parameterList);
       });
     } else {
       await this.renderItems([], [], {});
@@ -185,9 +188,8 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
       parsed[listKey] = listValue;
       for (const [itemKey, itemValue] of Object.entries(listValue)) {
         if (typeof itemValue === "string") {
-          parsed[listKey][itemKey] = await this.templateVariablesService.evaluateConditionString(
-            itemValue
-          );
+          parsed[listKey][itemKey] =
+            await this.templateVariablesService.evaluateConditionString(itemValue);
         }
       }
     }

--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -64,10 +64,7 @@ export class TmplDataItemsComponent extends TemplateBaseComponent implements OnD
       await this.dynamicDataService.ready();
       const query = await this.dynamicDataService.query$("data_list", this.dataListName);
       this.dataQuery$ = query.pipe(debounceTime(50)).subscribe(async (data) => {
-        // By default, sort the items into the order they appeared in the original data list.
-        // Can be overridden with a `sort` operator applied in the data-items component params
-        const sortedData = data.sort((a, b) => a.row_index - b.row_index);
-        await this.renderItems(sortedData, this._row.rows, this.parameterList);
+        await this.renderItems(data, this._row.rows, this.parameterList);
       });
     } else {
       await this.renderItems([], [], {});

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -48,7 +48,7 @@ const SCHEMA: RxJsonSchema<any> = {
     flow_name: { type: "string", maxLength: 64 },
     flow_type: { type: "string", maxLength: 64 },
     row_id: { type: "string", maxLength: 64 },
-    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1 },
+    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1, final: true },
     data: {
       type: "object",
     },

--- a/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/persistedMemory.ts
@@ -37,7 +37,7 @@ const SCHEMA: RxJsonSchema<any> = {
   title: "base schema for id-primary key data",
   // NOTE - important to start at 0 and not timestamp (e.g. 20221220) as will check
   // for migration strategies for each version which is hugely inefficient
-  version: 1,
+  version: 2,
   primaryKey: "id",
   type: "object",
   properties: {
@@ -48,17 +48,22 @@ const SCHEMA: RxJsonSchema<any> = {
     flow_name: { type: "string", maxLength: 64 },
     flow_type: { type: "string", maxLength: 64 },
     row_id: { type: "string", maxLength: 64 },
+    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1 },
     data: {
       type: "object",
     },
   },
-  required: ["id", "flow_type", "flow_name", "row_id", "data"],
-  indexes: ["flow_type", "flow_name", "row_id"],
+  required: ["id", "flow_type", "flow_name", "row_id", "data", "row_index"],
+  indexes: ["flow_type", "flow_name", "row_id", "row_index"],
 };
 const MIGRATIONS: MigrationStrategies = {
   // As part of RXDb v14 update all data requires migrating to change metadata fields (no doc data changes)
   // https://rxdb.info/releases/14.0.0.html
   1: (doc) => doc,
+  2: (oldDoc) => {
+    const newDoc = { ...oldDoc, row_index: 0 };
+    return newDoc;
+  },
 };
 
 interface IDataUpdate {

--- a/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
@@ -41,7 +41,7 @@ export const REACTIVE_SCHEMA_BASE: RxJsonSchema<any> = {
       type: "string",
       maxLength: 128, // <- the primary key must have set maxLength
     },
-    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1 },
+    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1, final: true },
   },
   required: ["id"],
   indexes: ["row_index"],

--- a/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
+++ b/src/app/shared/services/dynamic-data/adapters/reactiveMemory.ts
@@ -2,6 +2,7 @@ import {
   addRxPlugin,
   createRxDatabase,
   MangoQuery,
+  MigrationStrategies,
   RxCollection,
   RxCollectionCreator,
   RxDatabase,
@@ -32,7 +33,7 @@ export const REACTIVE_SCHEMA_BASE: RxJsonSchema<any> = {
   title: "base schema for id-primary key data",
   // NOTE - important to start at 0 and not timestamp (e.g. 20221220) as will check
   // for migration strategies for each version which is hugely inefficient
-  version: 0,
+  version: 1,
   primaryKey: "id",
   type: "object",
   properties: {
@@ -40,9 +41,16 @@ export const REACTIVE_SCHEMA_BASE: RxJsonSchema<any> = {
       type: "string",
       maxLength: 128, // <- the primary key must have set maxLength
     },
+    row_index: { type: "integer", minimum: 0, maximum: 10000, multipleOf: 1 },
   },
   required: ["id"],
-  indexes: [],
+  indexes: ["row_index"],
+};
+const MIGRATIONS: MigrationStrategies = {
+  1: (oldDoc) => {
+    const newDoc = { ...oldDoc, row_index: 0 };
+    return newDoc;
+  },
 };
 
 interface IDataUpdate {
@@ -97,7 +105,7 @@ export class ReactiveMemoryAdapater {
    */
   public async createCollection(name: string, schema: RxJsonSchema<any>) {
     const collections: { [x: string]: RxCollectionCreator<any> } = {};
-    collections[name] = { schema };
+    collections[name] = { schema, migrationStrategies: MIGRATIONS };
     await this.db.addCollections(collections);
     const collection = this.db.collections[name];
     // HACK - sometimes rxdb keeps data in memory during repeated create/delete cycles

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -146,8 +146,8 @@ describe("DynamicDataService", () => {
   it("adds metadata (original index) to docs", async () => {
     const obs = await service.query$<any>("data_list", "test_flow");
     const data = await firstValueFrom(obs);
-    expect(data[0].index_original).toEqual(0);
-    expect(data[1].index_original).toEqual(1);
+    expect(data[0].row_index).toEqual(0);
+    expect(data[1].row_index).toEqual(1);
   });
 
   // QA

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -143,6 +143,13 @@ describe("DynamicDataService", () => {
     expect(data[1].string).toEqual("sets an item correctly for a given _index");
   });
 
+  it("adds metadata (original index) to docs", async () => {
+    const obs = await service.query$<any>("data_list", "test_flow");
+    const data = await firstValueFrom(obs);
+    expect(data[0].index_original).toEqual(0);
+    expect(data[1].index_original).toEqual(1);
+  });
+
   // QA
   it("prevents query of non-existent data lists", async () => {
     let errMsg: string;

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -159,6 +159,12 @@ describe("DynamicDataService", () => {
     expect(data[2].id).toEqual("id0");
   });
 
+  it("does not allow manual updates to row_index property", async () => {
+    await expectAsync(
+      service.update("data_list", "test_flow", "id1", { row_index: 5 })
+    ).toBeRejectedWithError();
+  });
+
   // QA
   it("prevents query of non-existent data lists", async () => {
     let errMsg: string;

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -182,7 +182,7 @@ export class DynamicDataService extends AsyncServiceBase {
     const initialDataWithMeta = initialData.map((el) => {
       return {
         ...el,
-        index_original: initialData.indexOf(el),
+        row_index: initialData.indexOf(el),
       };
     });
 

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -209,10 +209,8 @@ export class DynamicDataService extends AsyncServiceBase {
   /** Retrive json sheet data and merge with any user writes */
   private async getInitialData(flow_type: FlowTypes.FlowType, flow_name: string) {
     const flowData = await this.appDataService.getSheet(flow_type, flow_name);
-    const writeData = this.writeCache.get(flow_type, flow_name);
-    const writeDataArray = Object.entries(writeData || {}).map(([id, v]) => ({ ...v, id })) as
-      | IDocWithID[]
-      | [];
+    const writeData = this.writeCache.get(flow_type, flow_name) || {};
+    const writeDataArray: IDocWithID[] = Object.entries(writeData).map(([id, v]) => ({ ...v, id }));
     const mergedData = this.mergeData(flowData?.rows, writeDataArray);
     return mergedData;
   }

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -97,6 +97,10 @@ export class DynamicDataService extends AsyncServiceBase {
     queryObj?: MangoQuery
   ) {
     const { collectionName } = await this.ensureCollection(flow_type, flow_name);
+
+    // by default, use `row_index` as query index to return results sorted on this property
+    const defaultQueryObj = { index: ["row_index", "id"] };
+    queryObj = { ...defaultQueryObj, ...queryObj };
     // use a live query to return all documents in the collection, converting
     // from reactive documents to json data instead
     let query = this.db.query(collectionName, queryObj);

--- a/src/app/shared/services/dynamic-data/dynamic-data.service.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.ts
@@ -12,7 +12,7 @@ import { ReactiveMemoryAdapater, REACTIVE_SCHEMA_BASE } from "./adapters/reactiv
 import { TemplateActionRegistry } from "../../components/template/services/instance/template-action.registry";
 import { TopLevelProperty } from "rxdb/dist/types/types";
 
-type IDocWithID = { id: string };
+type IDocWithID = { [key: string]: any; id: string };
 
 @Injectable({ providedIn: "root" })
 /**
@@ -178,9 +178,17 @@ export class DynamicDataService extends AsyncServiceBase {
     if (initialData.length === 0) {
       throw new Error(`No data exists for collection [${flow_name}], cannot initialise`);
     }
-    const schema = this.inferSchema(initialData[0]);
+    // add index property to each element before insert, for sorting queried data by original order
+    const initialDataWithMeta = initialData.map((el) => {
+      return {
+        ...el,
+        index_original: initialData.indexOf(el),
+      };
+    });
+
+    const schema = this.inferSchema(initialDataWithMeta[0]);
     await this.db.createCollection(collectionName, schema);
-    await this.db.bulkInsert(collectionName, initialData);
+    await this.db.bulkInsert(collectionName, initialDataWithMeta);
     // notify any observers that collection has been created
     this.collectionCreators[collectionName].next(collectionName);
     this.collectionCreators[collectionName].complete();
@@ -191,7 +199,9 @@ export class DynamicDataService extends AsyncServiceBase {
   private async getInitialData(flow_type: FlowTypes.FlowType, flow_name: string) {
     const flowData = await this.appDataService.getSheet(flow_type, flow_name);
     const writeData = this.writeCache.get(flow_type, flow_name);
-    const writeDataArray = Object.entries(writeData || {}).map(([id, v]) => ({ ...v, id }));
+    const writeDataArray = Object.entries(writeData || {}).map(([id, v]) => ({ ...v, id })) as
+      | IDocWithID[]
+      | [];
     const mergedData = this.mergeData(flowData?.rows, writeDataArray);
     return mergedData;
   }
@@ -201,7 +211,7 @@ export class DynamicDataService extends AsyncServiceBase {
     return `${flow_type}${flow_name}`.toLowerCase().replace(/[^a-z0-9]/g, "");
   }
 
-  private mergeData<T extends { id: string }>(flowData: T[] = [], dbData: T[] = []) {
+  private mergeData<T extends IDocWithID>(flowData: T[] = [], dbData: T[] = []) {
     const flowHashmap = arrayToHashmap(flowData, "id");
     const dbDataHashmap = arrayToHashmap(dbData, "id");
     const merged = deepMergeObjects(flowHashmap, dbDataHashmap);


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

As documented in #2311, item rows within a `data-items` loop are sorted according to their ID value by default. Whilst we do have a `sort` operation that can be applied to the items via the parameter list of the data-items component, which can be used to sort the list based on some property of the items, there is currently no way to reference the original order of the items in the data list.

This PR makes it the default that data-items render in the order that matches the original data list.

## Git Issues

Closes #2311

## Screenshots/Videos

Template [debug_data_items_order](https://docs.google.com/spreadsheets/d/1HvJOcbYGtrkPxwkPp8lvNW63ngsvworzz_jEUo5Swe0/edit#gid=1681985300), reading from [debug_data_list_order](https://docs.google.com/spreadsheets/d/1HvJOcbYGtrkPxwkPp8lvNW63ngsvworzz_jEUo5Swe0/edit#gid=275599747) showing items displayed in the expected order.

<img width="160" alt="Screenshot 2024-05-02 at 16 38 00" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/7b371c9c-3a4c-4acd-81b1-d1fc8ba27aaa">

<img width="300" alt="Screenshot 2024-05-02 at 16 38 16" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/c385ac14-5bdf-41d4-8875-d73caa5e2a02">


Passing tests:

<img width="500" alt="Screenshot 2024-05-09 at 12 29 47" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/8b3c5a7e-eff0-49c6-ac63-83421859c9d4">
