### PR TITLE
feat: add support for RTL languages

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -51,6 +51,15 @@ const APP_LANGUAGES = {
   default: "gb_en",
 };
 
+export interface ILanguageMeta {
+  rtl?: boolean;
+}
+const APP_LANGUAGES_META: { [languageCode: string]: ILanguageMeta } = {
+  en_rtl: {
+    rtl: true,
+  },
+};
+
 /** Specifies the skins available to the current app build.
  * "defaultSkinName": the name of the skin used by default for a given build
  * "available": an array of all skins that are available to the current build */
@@ -221,6 +230,7 @@ const APP_CONFIG = {
   APP_INITIALISATION_DEFAULTS,
   APP_AUTHENTICATION_DEFAULTS,
   APP_LANGUAGES,
+  APP_LANGUAGES_META,
   APP_ROUTE_DEFAULTS,
   APP_SIDEMENU_DEFAULTS,
   APP_FOOTER_DEFAULTS,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<ion-app *ngIf="renderAppTemplates" contentId="main">
+<ion-app *ngIf="renderAppTemplates" contentId="main" [dir]="languageRtl ? 'rtl' : 'ltr'">
   <!-- Left Sidebar -->
   <ion-menu
     *ngIf="sideMenuDefaults.enabled"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,8 @@
-<ion-app *ngIf="renderAppTemplates" contentId="main" [dir]="languageRtl ? 'rtl' : 'ltr'">
+<ion-app
+  *ngIf="renderAppTemplates"
+  contentId="main"
+  [dir]="templateTranslateService.languageDirection()"
+>
   <!-- Left Sidebar -->
   <ion-menu
     *ngIf="sideMenuDefaults.enabled"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ import { AppDataService } from "./shared/services/data/app-data.service";
 import { AuthService } from "./shared/services/auth/auth.service";
 import { LifecycleActionsService } from "./shared/services/lifecycle-actions/lifecycle-actions.service";
 import { AppConfigService } from "./shared/services/app-config/app-config.service";
-import { IAppConfig } from "./shared/model";
+import { IAppConfig, ILanguageMeta } from "./shared/model";
 import { TaskService } from "./shared/services/task/task.service";
 import { AppUpdateService } from "./shared/services/app-update/app-update.service";
 import { RemoteAssetService } from "./shared/services/remote-asset/remote-asset.service";
@@ -57,6 +57,8 @@ export class AppComponent {
   footerDefaults: IAppConfig["APP_FOOTER_DEFAULTS"];
   /** Track when app ready to render sidebar and route templates */
   public renderAppTemplates = false;
+  languagesMeta: { [languageCode: string]: ILanguageMeta };
+  languageRtl: boolean;
 
   constructor(
     // 3rd Party Services
@@ -104,6 +106,8 @@ export class AppComponent {
   private async initializeApp() {
     this.platform.ready().then(async () => {
       this.subscribeToAppConfigChanges();
+      this.subscribeToLanguageChanges();
+
       // ensure deployment field set correctly for use in any startup services or templates
       localStorage.setItem(this.appFields.DEPLOYMENT_NAME, this.DEPLOYMENT_NAME);
       localStorage.setItem(this.appFields.APP_VERSION, this.APP_VERSION);
@@ -171,6 +175,14 @@ export class AppComponent {
       this.footerDefaults = this.appConfig.APP_FOOTER_DEFAULTS;
       this.appAuthenticationDefaults = this.appConfig.APP_AUTHENTICATION_DEFAULTS;
       this.appFields = this.appConfig.APP_FIELDS;
+      this.languagesMeta = this.appConfig.APP_LANGUAGES_META;
+    });
+  }
+
+  /** Update meta for current language */
+  private subscribeToLanguageChanges() {
+    this.templateTranslateService.app_language$.subscribe((lang) => {
+      this.languageRtl = this.languagesMeta?.[lang]?.rtl;
     });
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ import { AppDataService } from "./shared/services/data/app-data.service";
 import { AuthService } from "./shared/services/auth/auth.service";
 import { LifecycleActionsService } from "./shared/services/lifecycle-actions/lifecycle-actions.service";
 import { AppConfigService } from "./shared/services/app-config/app-config.service";
-import { IAppConfig, ILanguageMeta } from "./shared/model";
+import { IAppConfig } from "./shared/model";
 import { TaskService } from "./shared/services/task/task.service";
 import { AppUpdateService } from "./shared/services/app-update/app-update.service";
 import { RemoteAssetService } from "./shared/services/remote-asset/remote-asset.service";
@@ -57,8 +57,6 @@ export class AppComponent {
   footerDefaults: IAppConfig["APP_FOOTER_DEFAULTS"];
   /** Track when app ready to render sidebar and route templates */
   public renderAppTemplates = false;
-  languagesMeta: { [languageCode: string]: ILanguageMeta };
-  languageRtl: boolean;
 
   constructor(
     // 3rd Party Services
@@ -84,7 +82,8 @@ export class AppComponent {
     private analyticsService: AnalyticsService,
     private localNotificationService: LocalNotificationService,
     private localNotificationInteractionService: LocalNotificationInteractionService,
-    private templateTranslateService: TemplateTranslateService,
+    // make public so that language direction signal can be read directly in template
+    public templateTranslateService: TemplateTranslateService,
     private crashlyticsService: CrashlyticsService,
     private appDataService: AppDataService,
     private authService: AuthService,
@@ -106,7 +105,6 @@ export class AppComponent {
   private async initializeApp() {
     this.platform.ready().then(async () => {
       this.subscribeToAppConfigChanges();
-      this.subscribeToLanguageChanges();
 
       // ensure deployment field set correctly for use in any startup services or templates
       localStorage.setItem(this.appFields.DEPLOYMENT_NAME, this.DEPLOYMENT_NAME);
@@ -175,14 +173,6 @@ export class AppComponent {
       this.footerDefaults = this.appConfig.APP_FOOTER_DEFAULTS;
       this.appAuthenticationDefaults = this.appConfig.APP_AUTHENTICATION_DEFAULTS;
       this.appFields = this.appConfig.APP_FIELDS;
-      this.languagesMeta = this.appConfig.APP_LANGUAGES_META;
-    });
-  }
-
-  /** Update meta for current language */
-  private subscribeToLanguageChanges() {
-    this.templateTranslateService.app_language$.subscribe((lang) => {
-      this.languageRtl = this.languagesMeta?.[lang]?.rtl;
     });
   }
 

--- a/src/app/shared/components/template/services/template-translate.service.ts
+++ b/src/app/shared/components/template/services/template-translate.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { Injectable, WritableSignal, signal } from "@angular/core";
 import { IAppConfig } from "data-models";
 import { BehaviorSubject } from "rxjs";
 import { AppConfigService } from "src/app/shared/services/app-config/app-config.service";
@@ -21,6 +21,8 @@ export class TemplateTranslateService extends AsyncServiceBase {
   app_language$ = new BehaviorSubject<string>(null);
   appFields: IAppConfig["APP_FIELDS"];
   appLanguages: IAppConfig["APP_LANGUAGES"];
+  appLanguagesMeta: IAppConfig["APP_LANGUAGES_META"];
+  languageDirection: WritableSignal<"ltr" | "rtl"> = signal("ltr");
   translation_strings = {};
 
   constructor(
@@ -54,6 +56,7 @@ export class TemplateTranslateService extends AsyncServiceBase {
   /** Set the local storage variable that tracks the app language */
   async setLanguage(code: string, updateDB = true) {
     if (code) {
+      console.log("[SET LANGUAGE]", code);
       if (updateDB) {
         this.localStorageService.setString(this.appFields.APP_LANGUAGE, code);
       }
@@ -61,7 +64,8 @@ export class TemplateTranslateService extends AsyncServiceBase {
       this.translation_strings = translationStrings || {};
       // update observable for subscribers
       this.app_language$.next(code);
-      // console.log("[Language Set]", code);
+      // update language direction signal
+      this.languageDirection.set(this.appLanguagesMeta?.[code]?.rtl ? "rtl" : "ltr");
     }
   }
 
@@ -141,6 +145,7 @@ export class TemplateTranslateService extends AsyncServiceBase {
     this.appConfigService.appConfig$.subscribe((appConfig: IAppConfig) => {
       this.appFields = appConfig.APP_FIELDS;
       this.appLanguages = appConfig.APP_LANGUAGES;
+      this.appLanguagesMeta = appConfig.APP_LANGUAGES_META;
     });
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds minimal support for right-to-left languages. As identified in #2254, there are likely to be further changes required to address issues with the app when in RTL "mode" (the changes go beyond just the appearance of text). These could be added as follow-ups following user testing with someone who understands the expected behaviour of an RTL app.

The metadata for a language (currently just a boolean value for `rtl`, but could be expanded to include other properties in future) can be set at the level of the deployment config. For example, the debug deployment config has been updated in https://github.com/IDEMSInternational/app-debug-content/pull/69 to support an RTL language with the name "en_rtl" (the language can be set via the template [feature_rtl_language](https://docs.google.com/spreadsheets/d/1DkWnJrpR6pjHpPiNNfGXR4sJpCXiaRnElebeorh8sLY/edit#gid=569531329).

<img width="400" alt="Screenshot 2024-05-07 at 14 56 19" src="https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/295e0557-c68a-47ee-9029-7a3fa385de0e">

## Git Issues

Addresses #2254, but this issue should remain open for tracking

## Screenshots/Videos

[feature_rtl_language](https://docs.google.com/spreadsheets/d/1DkWnJrpR6pjHpPiNNfGXR4sJpCXiaRnElebeorh8sLY/edit#gid=569531329) template:

https://github.com/IDEMSInternational/parenting-app-ui/assets/64838927/f1d1db96-d28c-45cd-ad9f-6cd3eb5fa575


