### PR TITLE
Server/updates 1.5.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "1.4.4",
+  "version": "1.5.1",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",

--- a/packages/api/src/db/index.ts
+++ b/packages/api/src/db/index.ts
@@ -32,6 +32,14 @@ export class DBInstance {
         database: this.dbName,
         // disable verbose migration logs in test
         logging: process.env.NODE_ENV === "test" ? false : true,
+        // Fix SSL issue
+        // https://dev.to/rodjosh/connectionerror-sequelizeconnectionerror-no-pghbaconf-entry-for-host-in-heroku-postgresql-using-sequelize-3icj
+        dialectOptions: {
+          ssl: {
+            require: true,
+            rejectUnauthorized: false,
+          },
+        },
       });
       await this.runMigrations(migrationClient);
       await migrationClient.close();

--- a/packages/server/docker/docker-compose.yml
+++ b/packages/server/docker/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     #   context: ../../api
     #   dockerfile: Dockerfile
     #   target: prod-env
-    image: idems/apps-api:1.4.4
+    image: idems/apps-api:1.5.1
     env_file:
       - ../../api/.env
     environment:


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Bump API version to `1.5.1`
- Fix issue where local api connection failing (SSL not enabled locally)

## Review Notes
The updates have already been deployed to the server along with updates from #2296, so this PR is more just for reference.

It should now at least be possible to check the updates from #2296 on a live server (if using a deployment that has user backup/restore and been recently updated to include code)

## Dev Notes
I'm assuming the reason now that errors were being seen is either changes to the auto-update on postgres (pinned as `v13` but could have included in minor patch), or to the API packages themselves (been a while since we've pushed server changes and remember a few non-deployed from #2270

The error message seen was `no pg_hba.conf entry for host` (with various ip/db name combinations following), as described in `https://github.com/docker-library/postgres/issues/482`. Most solutions seemed to suggest updating postgres data files to support connection from any source, however this wasn't easy to implement as the postgres data files are mapped to a docker volume and not easily editable (like example that maps to local disk). So instead I managed to find a fix that forces NestJS to connect to the database using SSL instead.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
