### PR TITLE
fix: data-items underscore properties

### DIFF
--- a/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
+++ b/src/app/shared/services/dynamic-data/dynamic-data.service.spec.ts
@@ -7,7 +7,7 @@ import { AppDataService } from "../data/app-data.service";
 import { MockAppDataService } from "../data/app-data.service.spec";
 
 const TEST_DATA_ROWS = [
-  { id: "id1", number: 1, string: "hello", boolean: true },
+  { id: "id1", number: 1, string: "hello", boolean: true, _meta_field: { test: "hello" } },
   { id: "id2", number: 2, string: "goodbye", boolean: false },
 ];
 type ITestRow = (typeof TEST_DATA_ROWS)[number];
@@ -141,6 +141,22 @@ describe("DynamicDataService", () => {
     const data = await firstValueFrom(obs);
     expect(data[0].string).toEqual("hello");
     expect(data[1].string).toEqual("sets an item correctly for a given _index");
+  });
+
+  it("supports reading data with protected fields", async () => {
+    const obs = await service.query$("data_list", "test_flow");
+    const data = await firstValueFrom(obs);
+    expect(data[0]["_meta_field"]).toEqual({ test: "hello" });
+  });
+  it("ignores writes to protected fields", async () => {
+    await service.setItem({
+      context: SET_ITEM_CONTEXT,
+      writeableProps: { _meta_field: "updated", string: "updated" },
+    });
+    const obs = await service.query$("data_list", "test_flow");
+    const data = await firstValueFrom(obs);
+    expect(data[0]["string"]).toEqual("updated");
+    expect(data[0]["_meta_field"]).toEqual({ test: "hello" });
   });
 
   // QA


### PR DESCRIPTION
Add support for storing data-items with underscore properties (previously rejected by rxdb regex)

PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Update `dynamic-data` service to support using data lists that include `_` prefixed fields (e.g. `_translations`)
- Add tests

## Dev Notes
I looked at initially adding a new prefix to all `_` prefixed fields and then extracting back out but it seemed a little more efficient to just combine in a single top-level property. The only downside to doing things this way (that I'm aware of) is losing the rxdb ability to query on the field, although given these are mostly computed metadata fields I don't think that's overly useful anyways.

I've only added handling for populating the `_` fields as part of initial data list read, and not as part of dynamic data write operations. This means that authors won't be able to use `_` fields as part of `set_item` operations. Whilst we could do similar merging to support I'm assuming treating these more as readonly probably makes more sense for now anyways. 

The write operation will not show any error, just silently ignore the metadata field as it is not included as part of the rxdb schema. If we wanted to keep the values we would need to extract and include in deep-merge.

I can't remember what was agreed when discussing #2312 - do we also want to implement in a similar way or just leave as-is for now (would possibly involve another migration to revert back to an underscore prefix field)

## Author Notes
This shouldn't change much from an authoring perspective as everything is handled internally, just to be aware that there is a new `APP_META` prefix used to temporarily combine all other `_` fields and so should avoid using the same column name in any data lists.

It may be worth keeping an eye out for how the translated fields in data-items behave when swapping between translations (as this is the metadata field causing issues). I haven't included any explicit tests for this right now (more just making sure the data can be stored)

## Git Issues

Closes #2310

## Screenshots/Videos

**Before** - newly created test detects error as identified in issue
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/0b31b2fa-aa5d-4c20-96ef-5d07eae461a0)

**After** - 2 new tests added and passing to support reading data with `_` fields and ignoring writes
![image](https://github.com/IDEMSInternational/parenting-app-ui/assets/10515065/fdc79b4c-a201-4f58-b795-d0e056c9f034)
