### PR TITLE
fix: completely hide data-items component in case of no child rows to render

### DIFF
--- a/src/app/shared/components/template/components/data-items/data-items.component.ts
+++ b/src/app/shared/components/template/components/data-items/data-items.component.ts
@@ -47,11 +47,7 @@ export class TmplDataItemsComponent extends TemplateBaseComponent {
     // If there are no child rows to render, hide the parent container (otherwise it will be visible as a blank row with default margins)
     effect(() => {
       const shouldHide = !this.rowSignal().rows?.length || !this.itemRows()?.length;
-      if (shouldHide) {
-        this.parent.elRef.nativeElement.setAttribute("data-hidden", "true");
-      } else {
-        this.parent.elRef.nativeElement.setAttribute("data-hidden", "false");
-      }
+      this._row.hidden = shouldHide;
     });
   }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Completely hides the `data_items` component in the case where there are no child rows to render – either because there are no child template rows or because there are no item rows returned for the specified data list. Previously, a row representing the data-items component would still render with no content, including default row margins, resulting in unexpected gaps between content.

## Git Issues

Follow-up to issue identified in https://github.com/ParentingForLifelongHealth/plh-facilitator-app-ph-content/issues/87#issuecomment-2930878961

## Screenshots/Videos

[comp_data_items_debug_3](https://docs.google.com/spreadsheets/d/1khGTrDekzqDQyW1r2x0ADqknanrlkmhOz1RRzhP6-7c/edit?gid=820434161#gid=820434161):

<img width="540" alt="Screenshot 2025-06-04 at 15 26 41" src="https://github.com/user-attachments/assets/faa788c4-bb6a-4ff5-97be-51e46e1ed3b2" />


| `master` | PR branch |
|---|---|
| <img width="160" alt="Screenshot 2025-06-04 at 15 24 45" src="https://github.com/user-attachments/assets/f472206f-a77b-476e-86ea-523df5f1831d" /> <img width="160" alt="Screenshot 2025-06-04 at 15 24 54" src="https://github.com/user-attachments/assets/854d9480-2821-425b-a636-a84b37bbc011" />| <img width="160" alt="Screenshot 2025-06-04 at 15 23 51" src="https://github.com/user-attachments/assets/9fbb9eb7-9a78-4ae1-8add-f4e1e83a2aaa" /> <img width="160" alt="Screenshot 2025-06-04 at 15 24 03" src="https://github.com/user-attachments/assets/462e065e-c885-4199-9b29-1f7dd07c5cad" /> |
