### PR TITLE
style: remove excess top margin on text-box component

### DIFF
--- a/src/app/shared/components/template/components/text-box/text-box.component.html
+++ b/src/app/shared/components/template/components/text-box/text-box.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper margin-t-regular" [class]="params().style">
+<div class="wrapper" [class]="params().style">
   <ion-input
     #input
     class="text-box-input"


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Removes an unnecessary additional top margin applied to the `text_box` component. This improves visual consistency with other components (notable `combo_box`) by relying on the default component row margins to position the element.

## Git Issues

Closes #3051 
Addresses a check-point on https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/issues/125

## Screenshots/Videos

[debug_form_layout](https://docs.google.com/spreadsheets/d/1-SX-9_ns4DJXHZL7fe653cchnaj8cXKQoBL5gVF-J2w/edit?gid=2063929093#gid=2063929093) template. Note that in the `default` theme there is still some excess whitespace around the text component, which can be addressed in a separate PR.

| Theme | Before | After |
|---|---|---|
| Default | <img width="416" height="657" alt="Screenshot 2025-08-28 at 14 49 56" src="https://github.com/user-attachments/assets/a6948467-7506-4d56-aa35-aadbae3db696" /> | <img width="416" height="657" alt="Screenshot 2025-08-28 at 14 33 41" src="https://github.com/user-attachments/assets/0ed65f67-c467-40e4-9ea3-a1055b9b3675" /> |
| plh_kids_kw | <img width="415" height="656" alt="Screenshot 2025-08-28 at 14 51 58" src="https://github.com/user-attachments/assets/0aee9b22-acb6-4b64-8ddb-fb29b64ed877" /> | <img width="414" height="654" alt="Screenshot 2025-08-28 at 14 35 14" src="https://github.com/user-attachments/assets/351c8bf3-b29f-4436-9fa3-e1e04cdad1eb" /> |
