### PR TITLE
Style: Reduce height of no-background card button

### DIFF
--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -270,7 +270,7 @@
       background-color: transparent;
       background: transparent;
       color: var(--color-surface-black);
-      min-height: 64px;
+      // min-height: 64px;
       padding: 18px 24px;
       p {
         font-weight: var(--font-weight-standard);

--- a/src/theme/themes/plh_facilitator_my/overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/overrides.scss
@@ -291,7 +291,7 @@
       background-color: transparent;
       background: transparent;
       color: var(--color-surface-black);
-      min-height: 64px;
+      // min-height: 64px;
       padding: 18px 24px;
       p {
         font-weight: var(--font-weight-standard);

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -292,7 +292,7 @@
       background-color: transparent;
       background: transparent;
       color: var(--color-surface-black);
-      min-height: 64px;
+      // min-height: 64px;
       padding: 18px 24px;
       p {
         font-weight: var(--font-weight-standard);

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -82,7 +82,7 @@
       background-color: transparent;
       background: transparent;
       color: var(--color-surface-black);
-      min-height: 64px;
+      // min-height: 64px;
       padding: 18px 24px;
       p {
         font-weight: var(--font-weight-standard);

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -82,7 +82,7 @@
       background-color: transparent;
       background: transparent;
       color: var(--color-surface-black);
-      min-height: 64px;
+      // min-height: 64px;
       padding: 18px 24px;
       p {
         font-weight: var(--font-weight-standard);


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

Reduces min-height of button with params `variant: card` and `style: no-background`, which is overridden to be `64px` in various themes.

## Git Issues

Related to https://github.com/ParentingForLifelongHealth/plh-facilitator-app-cw-content/issues/38

## Screenshots/Videos

After vs Before on `plh_facilitator_my` theme
<img width="329" height="144" alt="image" src="https://github.com/user-attachments/assets/b98f5094-0c1d-434b-8029-00bb9031f7d2" />   <img width="331" height="164" alt="image" src="https://github.com/user-attachments/assets/1ff7a301-b828-44f7-9052-9d6d3489f1e3" />


