### PR TITLE
style(plh_facilitator_cw): make bottom nav background white for pill variant

### DIFF
--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -1145,6 +1145,10 @@
           color: var(--color-surface-white);
         }
       }
+
+      &[data-variant~="pill"] {
+        background-color: var(--ion-background-color);
+      }
     }
   }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds `plh_facilitator_cw` theme overrides to style the `pill` variant of the `plh_bottom_nav` component appropriately, namely setting the background colour of to match the page background.

## Notes

@esmeetewinkel please could you check whether this looks good on the `plh_facilitator_cw` deployment? Another tool we could potentially use is reducing the text size of these pill labels specifically for this deployment theme – the font is unusually wide.

## Git Issues

Addresses https://github.com/ParentingForLifelongHealth/plh-facilitator-app-content/issues/94 and https://github.com/ParentingForLifelongHealth/plh-facilitator-app-cw-content/issues/69, pending author changes

## Screenshots/Videos

[comp_plh_bottom_nav](https://docs.google.com/spreadsheets/d/1weQYXdg4McVzhM5d4p0-iqKgqNaXeVMjLp4Qwp-u6MI/edit?gid=3937162#gid=3937162)

| Before | After |
|--|--|
| <img width="268" height="634" alt="Screenshot 2025-10-30 at 16 48 48" src="https://github.com/user-attachments/assets/e8973d96-38d6-4284-9be4-7659aa3e0a46" /> | <img width="272" height="634" alt="Screenshot 2025-10-30 at 16 51 17" src="https://github.com/user-attachments/assets/1ec357f6-a465-44ea-9f82-d173df0aec1a" /> |


### `plh_facilitator_cw` deployment:

#### English:

https://github.com/user-attachments/assets/0c74615c-d59c-4da2-a3fc-f97bc7f44138

#### Papiamento:

https://github.com/user-attachments/assets/7e4491a3-a292-4ad3-858c-99df6df3d94f

