### PR TITLE
Feature: Add reactive query component

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "intro.js": "^3.4.0",
     "jquery": "^3.7.1",
     "jquery-touchswipe": "^1.6.19",
+    "json5": "^2.2.3",
     "katex": "^0.16.21",
     "lottie-web": "^5.12.2",
     "marked": "^2.1.3",

--- a/packages/test-e2e/cypress/e2e/components/query.cy.ts
+++ b/packages/test-e2e/cypress/e2e/components/query.cy.ts
@@ -1,0 +1,55 @@
+describe("dropdown component", () => {
+  beforeEach(() => {
+    cy.visit("/template/test_query");
+  });
+
+  it("Queries with filter, sort & limit", () => {
+    cy.getDataTest("queriedDataDropdown").click();
+
+    cy.get("ion-popover")
+      .should("be.visible")
+      .last()
+      .find("ion-item")
+      .should(($items) => {
+        const texts = $items.map((i, el) => Cypress.$(el).text().trim()).get();
+        expect(texts).to.deep.equal(["Test 5 Name (B)", "Test 4 Name (B)", "Test 3 Name (A)"]);
+      });
+
+    cy.get("ion-popover").find("ion-item").contains("Test 5 Name (B)").click();
+
+    cy.getDataTest("queriedOption").contains("id5");
+  });
+
+  it("Queries with dynamic filter", () => {
+    cy.getDataTest("dynamicQueriedDataDropdown").click();
+
+    cy.get("ion-popover")
+      .should("be.visible")
+      .last()
+      .find("ion-item")
+      .should("have.length", 2)
+      .then(($items) => {
+        const texts = $items.map((i, el) => Cypress.$(el).text().trim()).get();
+        expect(texts).to.deep.equal(["Test 3 Name (A)", "Test 1 Name (A)"]);
+      });
+    cy.get("ion-popover").find("ion-item").contains("Test 3 Name (A)").click();
+
+    cy.getDataTest("categoryDropdown").click();
+
+    cy.get("ion-popover").last().find("ion-item").contains("B").click();
+
+    cy.getDataTest("dynamicQueriedDataDropdown").click();
+    cy.get("ion-popover:visible")
+      .last()
+      .find("ion-item")
+      .should("have.length", 3)
+      .then(($items) => {
+        const texts = $items.map((i, el) => Cypress.$(el).text().trim()).get();
+        expect(texts).to.deep.equal(["Test 5 Name (B)", "Test 4 Name (B)", "Test 2 Name (B)"]);
+      });
+
+    cy.get("ion-popover").last().find("ion-item").contains("Test 2 Name (B)").click();
+
+    cy.getDataTest("dynamicQueriedOption").contains("id2");
+  });
+});

--- a/src/app/reactive-templates/reactive-components/components/index.ts
+++ b/src/app/reactive-templates/reactive-components/components/index.ts
@@ -6,6 +6,7 @@ import { TextBoxComponent } from "./text-box/text-box.component";
 import { TextComponent } from "./text/text.component";
 import { TitleComponent } from "./title/title.component";
 import { ToggleBarComponent } from "./toggle-bar/toggle-bar";
+import { QueryComponent } from "./query/query.component";
 
 export const REACTIVE_COMPONENT_MAP = {
   button: ButtonComponent,
@@ -16,4 +17,5 @@ export const REACTIVE_COMPONENT_MAP = {
   text_box: TextBoxComponent,
   title: TitleComponent,
   toggle_bar: ToggleBarComponent,
+  query: QueryComponent,
 };

--- a/src/app/reactive-templates/reactive-components/components/nested-template/nested-template.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/nested-template/nested-template.component.ts
@@ -39,7 +39,7 @@ export class NestedTemplateComponent extends RowBaseComponent<null> implements O
 
   private onTemplateInitialised() {
     for (const row of this.row().rows) {
-      this.setTemplateVariable(row);
+      this.setChildVariable(row);
     }
   }
 
@@ -51,13 +51,31 @@ export class NestedTemplateComponent extends RowBaseComponent<null> implements O
       let sub = this.variableStore
         .watchMultiple(this.evaluationService.getDependencies(row.value, this.namespace()))
         .subscribe(() => {
-          this.setTemplateVariable(row);
+          this.setChildVariable(row);
         });
       this.childDependencySubscriptions.push(sub);
     }
   }
 
-  private setTemplateVariable(row: FlowTypes.TemplateRow) {
+  private setChildVariable(row: FlowTypes.TemplateRow) {
+    const dependencies = this.evaluationService.getDependencies(row.value, this.namespace());
+    const isStaticValue = dependencies && dependencies.length === 0;
+
+    if (isStaticValue) {
+      this.setChildExpression(row);
+    } else {
+      this.setChildValue(row);
+    }
+  }
+
+  private setChildExpression(row: FlowTypes.TemplateRow) {
+    const rowFullName = this.namespaceService.getFullName(this.name(), row.name);
+    if (this.rowRegistry.has(rowFullName)) {
+      this.rowRegistry.get(rowFullName)?.setExpression(row.value);
+    }
+  }
+
+  private setChildValue(row: FlowTypes.TemplateRow) {
     this.variableStore.set(
       this.namespaceService.getFullName(this.name(), row.name),
       this.evaluationService.evaluateExpression(row.value, this.namespace())

--- a/src/app/reactive-templates/reactive-components/components/query/query.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/query/query.component.ts
@@ -1,0 +1,37 @@
+import { Component, inject } from "@angular/core";
+import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
+import { defineParameters, Parameter } from "../../parameters";
+import { ROW_PARAMETERS, RowBaseComponent } from "../../row-base.component";
+import json5 from "json5";
+import { firstValueFrom } from "rxjs";
+
+const parameters = () =>
+  defineParameters({
+    dataList: new Parameter("data_list", ""),
+  });
+
+@Component({
+  selector: "oab-query",
+  template: "", // template is not needed for this component
+  providers: [{ provide: ROW_PARAMETERS, useFactory: parameters }],
+})
+export class QueryComponent extends RowBaseComponent<ReturnType<typeof parameters>> {
+  private dynamicDataService = inject(DynamicDataService);
+
+  protected async computeStoredValue(value: any) {
+    try {
+      const queryString = `{${value as string}}`;
+      const mangoQuery = value ? json5.parse(queryString) : {};
+      const query = this.dynamicDataService.query$<any>(
+        "data_list",
+        this.params.dataList.value(),
+        mangoQuery
+      );
+
+      return await firstValueFrom(query);
+    } catch (error) {
+      console.error(`Failed to parse query for ${this.name()}:`, error);
+      return [];
+    }
+  }
+}

--- a/src/app/reactive-templates/reactive-components/parameters.ts
+++ b/src/app/reactive-templates/reactive-components/parameters.ts
@@ -1,4 +1,4 @@
-import { signal, WritableSignal } from "@angular/core";
+import { Signal, signal, WritableSignal } from "@angular/core";
 
 export function defineParameters<T extends Record<string, Parameter<any>>>(p: T) {
   return p;
@@ -7,16 +7,19 @@ export function defineParameters<T extends Record<string, Parameter<any>>>(p: T)
 export type Parameters = Record<string, Parameter<any>>;
 
 export class Parameter<T> {
+  private _value: WritableSignal<T>;
+  public value: Signal<T>;
+
   public name: string;
-  public value: WritableSignal<T>;
 
   constructor(name: string, defaultValue: T) {
     this.name = name;
-    this.value = signal(defaultValue);
+    this._value = signal(defaultValue);
+    this.value = this._value.asReadonly();
   }
 
   public setValue(value: T) {
-    this.value.set(this.cast(value));
+    this._value.set(this.cast(value));
   }
 
   private cast(value: any): T {

--- a/src/app/reactive-templates/reactive-components/row-base.component.ts
+++ b/src/app/reactive-templates/reactive-components/row-base.component.ts
@@ -42,7 +42,8 @@ export abstract class RowBaseComponent<TParams extends Parameters>
   );
 
   /**
-   * The current evaluated value of the row, as stored in the VariableStore.
+   * The current evaluated value of the row, based on its expression with tokens replaced.
+   * This may not be the same as the value stored in the variable store if further processing is needed (e.g. executing a data query).
    */
   public value: Signal<any>;
 
@@ -91,11 +92,9 @@ export abstract class RowBaseComponent<TParams extends Parameters>
     this.rowRegistry.register(this);
 
     // Set default value
-    this.variableStore.set(
-      this.name(),
-      this.evaluationService.evaluateExpression(this.expression(), this.namespace())
-    );
-    this.onInitialised()?.();
+    this.storeValue().then(() => {
+      this.onInitialised()?.();
+    });
   }
 
   /*
@@ -105,14 +104,25 @@ export abstract class RowBaseComponent<TParams extends Parameters>
     this._expression.set(expression);
     this.watchValueDependencies();
 
-    this.variableStore.set(
-      this.name(),
-      this.evaluationService.evaluateExpression(this.expression(), this.namespace())
-    );
+    this.storeValue();
   }
 
   public triggerActions(trigger: string) {
     this.actionService.handleActions(this, trigger, this.namespace());
+  }
+
+  // Override to transform the value before storing in variable store.
+  // e.g. To execute a data query and store the results as the value
+  protected async computeStoredValue(value: any): Promise<any> {
+    return value;
+  }
+
+  // Store the evaluated value of the row in the variable store.
+  private async storeValue() {
+    const value = this.evaluationService.evaluateExpression(this.expression(), this.namespace());
+    const computedValue = await this.computeStoredValue(value);
+
+    this.variableStore.set(this.name(), computedValue);
   }
 
   private setParams() {
@@ -134,11 +144,8 @@ export abstract class RowBaseComponent<TParams extends Parameters>
     this.unsubscribeValueDependencies();
     let sub = this.variableStore
       .watchMultiple(this.evaluationService.getDependencies(this.expression(), this.namespace()))
-      .subscribe(() => {
-        this.variableStore.set(
-          this.name(),
-          this.evaluationService.evaluateExpression(this.expression(), this.namespace())
-        );
+      .subscribe(async () => {
+        await this.storeValue();
       });
 
     this.valueDependencySubscriptions.push(sub);

--- a/src/app/reactive-templates/reactive-template/reactive-template.component.ts
+++ b/src/app/reactive-templates/reactive-template/reactive-template.component.ts
@@ -1,4 +1,13 @@
-import { Component, computed, forwardRef, input, OnInit, signal, viewChild } from "@angular/core";
+import {
+  Component,
+  computed,
+  effect,
+  forwardRef,
+  input,
+  OnInit,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { FlowTypes } from "packages/data-models";
 import { TemplateService } from "src/app/shared/components/template/services/template.service";
 import { RowListComponent } from "../reactive-components/row-list.component";
@@ -10,7 +19,7 @@ import { RowListComponent } from "../reactive-components/row-list.component";
   standalone: true,
   imports: [forwardRef(() => RowListComponent)],
 })
-export class ReactiveTemplateComponent implements OnInit {
+export class ReactiveTemplateComponent {
   public templateName = input.required<string>();
   public namespace = input("");
 
@@ -23,10 +32,12 @@ export class ReactiveTemplateComponent implements OnInit {
     return this.rowListComponent().initialised();
   });
 
-  constructor(private templateService: TemplateService) {}
-
-  async ngOnInit() {
-    const template = await this.templateService.getTemplateByName(this.templateName(), false);
-    this.template.set(template);
+  constructor(private templateService: TemplateService) {
+    effect(async () => {
+      if (this.templateName()) {
+        const template = await this.templateService.getTemplateByName(this.templateName(), false);
+        this.template.set(template);
+      }
+    });
   }
 }

--- a/src/app/reactive-templates/services/row.registry.ts
+++ b/src/app/reactive-templates/services/row.registry.ts
@@ -30,6 +30,10 @@ export class RowRegistry {
     return row;
   }
 
+  has(name: string): boolean {
+    return this.rows.has(name);
+  }
+
   unregister(name: string) {
     this.rows.delete(name);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18241,6 +18241,7 @@ __metadata:
     jasmine-spec-reporter: ~7.0.0
     jquery: ^3.7.1
     jquery-touchswipe: ^1.6.19
+    json5: ^2.2.3
     karma: ~6.4.0
     karma-chrome-launcher: ~3.1.0
     karma-coverage: ~2.2.0


### PR DESCRIPTION
Replaces #3181 

PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a 'query' component which allows execution of raw Mango queries.

<img width="1209" height="61" alt="image" src="https://github.com/user-attachments/assets/8fb64921-9594-4563-9884-113676f8e095" />

<img width="787" height="145" alt="image" src="https://github.com/user-attachments/assets/16bb090b-5fa7-4f2b-9d84-7383392aca5a" />

[example sheet](https://docs.google.com/spreadsheets/d/1cDndPmELXtmx65GfoBKVnp-JxD21wxMMVWGeJUryuL0/edit?gid=1343090831#gid=1343090831)

### JSEvaluator chages

I noticed an issue with javascript evaluation which I have fixed as part of this PR, specifically: "options_value: name" parameter value was compiling as valid javascript unintentionally.

<img width="1203" height="54" alt="image" src="https://github.com/user-attachments/assets/4b4f3cc7-025b-4939-8cd2-00842d86e030" />

The fixes mean that the following single words will longer compile as valid javascript and will return their string values. I couldn't find a way to remove these from the evaluation context entirely

    "window",
    "name",
    "globalThis",
    "self",
    "document",
    "parent",
    "top",
    "frames",
    "global",

### json5

Introduces [json5](https://json5.org/) so we can parse 

```
selector: {active: true},
sort: [ {name: 'desc'} ],
limit: 3
```
instead of having to do this this: 
```
"selector": {"active": true},
"sort": [ {"name": "desc"} ],
"limit": 3
```

### Content PR

https://github.com/IDEMSInternational/app-test-content/pull/7

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
