### PR TITLE
chore: bump glob version in env-replace package 9.0.0 -> 10.5.0

### DIFF
--- a/packages/@idemsInternational/env-replace/package.json
+++ b/packages/@idemsInternational/env-replace/package.json
@@ -8,7 +8,7 @@
     "test": "ts-mocha -p tsconfig.spec.json src/**/*.spec.ts"
   },
   "dependencies": {
-    "glob": "^9.0.0"
+    "glob": "^10.5.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6326,7 +6326,7 @@ __metadata:
     "@types/mocha": ^10.0.6
     "@types/node": ^16.18.9
     chai: ^4.3.4
-    glob: ^9.0.0
+    glob: ^10.5.0
     mocha: ^10.3.0
     ts-mocha: ^10.0.0
     typescript: 5.5.4
@@ -18803,6 +18803,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 4f2fe2511e157b5a3f525a54092169a5f92405f24d2aed3142f4411df328baca13059f4182f1db1bf933e2c69c0bd89e57ae87edd8950cba8c7ccbe84f721cf3
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^3.1.2
+    minimatch: ^9.0.4
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^1.11.1
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: cda96c074878abca9657bd984d2396945cf0d64283f6feeb40d738fe2da642be0010ad5210a1646244a5fc3511b0cab5a374569b3de5a12b8a63d392f18c6043
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue introduced by #3216, where the glob package version change led to a minor change in the API. By changing the package version (to the one referenced by dependabot), the issue is resolved without code changes.

I noticed the issue when trying to run tests from a specific spec file – it seemed a TypeScript compilation error in this env-replace package was blocking test discovery in src.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
