### PR TITLE
feat: tab variant of button

### DIFF
--- a/src/app/shared/components/template/components/button/button.component.html
+++ b/src/app/shared/components/template/components/button/button.component.html
@@ -7,6 +7,7 @@
     (click)="triggerActions('click')"
     [attr.data-param-style]="params().style"
     [attr.data-variant]="params().variant"
+    [attr.data-highlighted]="params().highlighted ? 'true' : null"
     [attr.data-has-children]="_row.rows ? true : null"
     [attr.data-language-direction]="templateTranslateService.languageDirection()"
     [attr.data-icon-align]="params().iconAlign"

--- a/src/app/shared/components/template/components/button/button.component.scss
+++ b/src/app/shared/components/template/components/button/button.component.scss
@@ -224,3 +224,24 @@ ion-button[data-variant~="card"] {
     max-width: 10rem;
   }
 }
+
+ion-button[data-variant~="tab"] {
+  --background: none;
+  color: var(--ion-color-primary);
+  font-weight: var(--font-weight-bold);
+  --border-radius: 8px 8px 0 0;
+  --padding-bottom: 8px;
+  --padding-top: 8px;
+  --padding-end: 8px;
+  --padding-start: 8px;
+  min-height: 48px;
+  --box-shadow: none;
+  border-bottom: 4px solid transparent;
+  --background-activated: none;
+
+  opacity: 0.5;
+  &[data-highlighted="true"] {
+    opacity: 1;
+    border-bottom: 4px solid var(--ion-color-primary);
+  }
+}

--- a/src/app/shared/components/template/components/button/button.component.ts
+++ b/src/app/shared/components/template/components/button/button.component.ts
@@ -18,11 +18,14 @@ interface IButtonParams {
     | "navigation"
     | "short"
     | "standard"
+    | "tab"
     | "tall";
   /** TEMPLATE PARAMETER: "style". Legacy, use "variant" instead. */
   style: string;
   /** TEMPLATE PARAMETER: "disabled". If true, button is disabled and greyed out */
   disabled: boolean;
+  /** TEMPLATE PARAMETER: "highlighted". Currently only used for the "tab" variant, but implementation could be extended */
+  highlighted: boolean;
   /** TEMPLATE PARAMETER: "text_align" */
   textAlign: "left" | "centre" | "right";
   /** TEMPLATE PARAMETER: "button_align" */
@@ -73,6 +76,7 @@ export class TmplButtonComponent extends TemplateBaseComponent {
   private getParams(authorParams: FlowTypes.TemplateRow["parameter_list"]): IButtonParams {
     return {
       disabled: parseBoolean(this.parameterList().disabled),
+      highlighted: parseBoolean(this.parameterList().highlighted),
       style: `${getStringParamFromTemplateRow(this._row, "style", "information")} ${
         this.isTwoColumns() ? "two_columns" : ""
       }` as any,

--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -336,6 +336,14 @@
       }
     }
 
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -312,6 +312,14 @@
       }
     }
 
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;

--- a/src/theme/themes/plh_facilitator_my/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/_overrides.scss
@@ -336,6 +336,14 @@
       }
     }
 
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -334,6 +334,14 @@
       }
     }
 
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -101,6 +101,15 @@
         }
       }
     }
+
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -101,6 +101,15 @@
         }
       }
     }
+
+    ion-button[data-variant~="tab"] {
+      --background: none;
+      color: var(--ion-color-primary);
+      &:hover {
+        --background: unset;
+      }
+    }
+
     ion-button[data-language-direction~="rtl"] .children {
       position: unset !important;
       align-self: unset !important;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Enables authoring "tab bar"/"tab group" functionality. This is primarily achieved through two updates to the `button` component:
- Adds a new variant, `tab`
- Adds a new param, `highlighted`, that takes a boolean value
  - Currently this only has significance for the tab variant of the button, but the implementation could be extended to support a "highlighted" state on other variants

## Git Issues

Closes #3212

## Screenshots/Videos

Example on [comp_button](https://docs.google.com/spreadsheets/d/1OmgZICjM5EMT1KgLOU_ovDljRF_SPlpQAgkKWPrNX0s/edit?gid=569531329#gid=569531329) template:
<img width="200" height="671" alt="Screenshot 2025-11-25 at 16 33 01" src="https://github.com/user-attachments/assets/0917ca38-75a4-4747-811e-546c5d54a4b4" />


[example_tab_group](https://docs.google.com/spreadsheets/d/1HTqpAEkwxFJPwh1ulKmAEuH1jcMiBZQU3rfSVTlVT5Y/edit?gid=569531329#gid=569531329) template:

<img width="800" height="406" alt="Screenshot 2025-11-25 at 16 37 41" src="https://github.com/user-attachments/assets/c861abe7-27f0-4cf6-b19d-3ecf01763d10" />

| theme | [example_tab_group](https://docs.google.com/spreadsheets/d/1HTqpAEkwxFJPwh1ulKmAEuH1jcMiBZQU3rfSVTlVT5Y/edit?gid=569531329#gid=569531329) |
|-|-|
| default | <img width="379" height="668" alt="Screenshot 2025-11-25 at 16 20 09" src="https://github.com/user-attachments/assets/46b29fcc-e868-44dd-9406-353e101dd7b6" /> |
| professional | <img width="376" height="668" alt="Screenshot 2025-11-25 at 16 21 37" src="https://github.com/user-attachments/assets/4203e97c-8f2d-4543-8b16-c1867870d66d" /> |
| pfr | <img width="377" height="669" alt="Screenshot 2025-11-25 at 16 21 50" src="https://github.com/user-attachments/assets/094e5aa4-6ce1-4582-a1ba-bf3d86d938f3" /> |
| plh_facilitator_mx | <img width="376" height="667" alt="Screenshot 2025-11-25 at 16 22 38" src="https://github.com/user-attachments/assets/c922b2ae-b552-4d01-995c-351d6b2df7da" /> |
| plh_facilitator_my | <img width="374" height="667" alt="Screenshot 2025-11-25 at 16 24 53" src="https://github.com/user-attachments/assets/11071812-139d-4b97-966f-d16dbf03c19a" /> |
| plh_facilitator_ph | <img width="376" height="668" alt="Screenshot 2025-11-25 at 16 25 41" src="https://github.com/user-attachments/assets/cf4b838d-fc2a-4f63-adf8-f045dd688126" /> |
| plh_facilitator_cw | <img width="375" height="667" alt="Screenshot 2025-11-25 at 16 25 58" src="https://github.com/user-attachments/assets/45335512-c7f6-4360-9e55-b94b7d5050b5" /> |
| early_family_math | <img width="377" height="667" alt="Screenshot 2025-11-25 at 16 26 09" src="https://github.com/user-attachments/assets/ea31261f-aaf5-4938-a175-4ef272f99af4" /> |
| plh_kids_kw | <img width="377" height="668" alt="Screenshot 2025-11-25 at 16 26 42" src="https://github.com/user-attachments/assets/ea1d6038-2f76-4c70-bdc0-4b67140581fc" /> |
| plh_kids_tz | <img width="376" height="669" alt="Screenshot 2025-11-25 at 16 26 57" src="https://github.com/user-attachments/assets/1c74bb33-1765-4c49-ac86-0c9260953909" /> |
| plh_kids_teens_za | <img width="376" height="669" alt="Screenshot 2025-11-25 at 16 27 44" src="https://github.com/user-attachments/assets/87292567-e85e-4069-bbe6-4f4b7e4b7683" /> |




