### PR TITLE
Feat: radio list component

### DIFF
--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -47,6 +47,7 @@ import { TmplProgressPathComponent } from "./progress-path/progress-path.compone
 import { TmplQRCodeComponent } from "./qr-code/qr-code.component";
 import { TmplRadioButtonGridComponent } from "./radio-button-grid/radio-button-grid.component";
 import { TmplRadioGroupComponent } from "./radio-group/radio-group.component";
+import { TmplRadioListComponent } from "./radio-list/radio-list.component";
 import { TmplSharedDataComponent } from "./shared-data/shared-data.component";
 import { TmplSimpleCheckboxComponent } from "./simple-checkbox/simple-checkbox.component";
 import { TmplSliderComponent } from "./slider/slider.component";
@@ -122,6 +123,7 @@ export const TEMPLATE_COMPONENTS = [
   TmplQRCodeComponent,
   TmplRadioButtonGridComponent,
   TmplRadioGroupComponent,
+  TmplRadioListComponent,
   TmplSharedDataComponent,
   TmplSimpleCheckboxComponent,
   TmplSliderComponent,
@@ -196,6 +198,7 @@ const COMMON_COMPONENT_MAPPING = {
   qr_code: TmplQRCodeComponent,
   radio_button_grid: TmplRadioButtonGridComponent,
   radio_group: TmplRadioGroupComponent,
+  radio_list: TmplRadioListComponent,
   round_button: RoundIconButtonComponent,
   select_text: SelectTextComponent,
   shared_data: TmplSharedDataComponent,

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -1,0 +1,10 @@
+<ion-radio-group [value]="value()" (ionChange)="handleItemClick($event.detail.value)">
+  @for (item of params().answerList; track item.name) {
+    <ion-item lines="none">
+      <ion-radio labelPlacement="end" justify="start" [value]="item.name">
+        <plh-tmpl-text [row]="{ _nested_name: '', name: '', type: 'text', value: item.text }">
+        </plh-tmpl-text>
+      </ion-radio>
+    </ion-item>
+  }
+</ion-radio-group>

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -1,8 +1,10 @@
 <ion-radio-group [value]="value()" (ionChange)="handleItemClick($event.detail.value)">
-  @for (item of params().answerList; track item.name) {
+  @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
-      <ion-radio labelPlacement="end" justify="start" [value]="item.name">
-        <plh-tmpl-text [row]="{ _nested_name: '', name: '', type: 'text', value: item.text }">
+      <ion-radio labelPlacement="end" justify="start" [value]="item[params().optionsKey]">
+        <plh-tmpl-text
+          [row]="{ _nested_name: '', name: '', type: 'text', value: item[params().optionsValue] }"
+        >
         </plh-tmpl-text>
       </ion-radio>
     </ion-item>

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.scss
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.scss
@@ -1,0 +1,10 @@
+// Remove default styling of ionic components to keep the design minimal
+ion-radio-group {
+  ion-item {
+    --background: transparent;
+  }
+  ion-radio::part(label) {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -36,7 +36,12 @@ export class TmplRadioListComponent extends TemplateBaseComponentWithParams(Auth
     toObservable(this.rows).pipe(
       map((rows) => rows.find((r) => r.type === "data_items")),
       filter((row) => row !== undefined),
-      switchMap((row) => this.dataItemsService.getItemsObservable(row, this.parent.templateRowMap))
+      switchMap((row) =>
+        this.dataItemsService.getItemsObservable(
+          row,
+          this.parentContainerComponentRef.templateRowMap
+        )
+      )
     )
   );
 }

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -1,11 +1,16 @@
-import { Component } from "@angular/core";
+import { Component, computed } from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { filter, map, switchMap } from "rxjs/operators";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
 import { IAnswerListItem } from "../../../../utils";
+import { DataItemsService } from "../data-items/data-items.service";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   answer_list: coerce.objectArray<IAnswerListItem>([
     { name: null, text: null, image: null, image_checked: null },
   ]),
+  options_key: coerce.string("name"),
+  options_value: coerce.string("text"),
 }));
 
 @Component({
@@ -14,7 +19,53 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   styleUrls: ["./radio-list.component.scss"],
 })
 export class TmplRadioListComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  constructor(private dataItemsService: DataItemsService) {
+    super();
+  }
+
   public async handleItemClick(value: string) {
     await this.setValue(value);
+  }
+
+  public answerOptions = computed(() => {
+    const params = this.params();
+    return this.getAnswerOptions(
+      this.dataItemRows(),
+      params.answerList,
+      params.optionsKey,
+      params.optionsValue
+    );
+  });
+
+  // Allow radio_list to include data_items child row to define answer list
+  private dataItemRows = toSignal(
+    toObservable(this.rows).pipe(
+      map((rows) => rows.find((r) => r.type === "data_items")),
+      filter((row) => row !== undefined),
+      switchMap((row) => this.dataItemsService.getItemsObservable(row, this.parent.templateRowMap))
+    )
+  );
+
+  private getAnswerOptions(
+    dataItemRows: any[] | undefined,
+    answerList: IAnswerListItem[],
+    optionsKey: string,
+    optionsValue: string
+  ): any[] {
+    // Priority 1: Use data_items rows if available
+    if (dataItemRows !== undefined) {
+      return dataItemRows.map((item) => ({
+        ...item,
+        name: item[optionsKey],
+        text: item[optionsValue],
+      }));
+    }
+
+    // Priority 2: Use answerList from params
+    return answerList.map((item) => ({
+      ...item,
+      name: item[optionsKey],
+      text: item[optionsValue],
+    }));
   }
 }

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -19,6 +19,10 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   styleUrls: ["./radio-list.component.scss"],
 })
 export class TmplRadioListComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  public answerOptions = computed(() => {
+    return this.dataItemRows() ?? this.params().answerList;
+  });
+
   constructor(private dataItemsService: DataItemsService) {
     super();
   }
@@ -26,16 +30,6 @@ export class TmplRadioListComponent extends TemplateBaseComponentWithParams(Auth
   public async handleItemClick(value: string) {
     await this.setValue(value);
   }
-
-  public answerOptions = computed(() => {
-    const params = this.params();
-    return this.getAnswerOptions(
-      this.dataItemRows(),
-      params.answerList,
-      params.optionsKey,
-      params.optionsValue
-    );
-  });
 
   // Allow radio_list to include data_items child row to define answer list
   private dataItemRows = toSignal(
@@ -45,27 +39,4 @@ export class TmplRadioListComponent extends TemplateBaseComponentWithParams(Auth
       switchMap((row) => this.dataItemsService.getItemsObservable(row, this.parent.templateRowMap))
     )
   );
-
-  private getAnswerOptions(
-    dataItemRows: any[] | undefined,
-    answerList: IAnswerListItem[],
-    optionsKey: string,
-    optionsValue: string
-  ): any[] {
-    // Priority 1: Use data_items rows if available
-    if (dataItemRows !== undefined) {
-      return dataItemRows.map((item) => ({
-        ...item,
-        name: item[optionsKey],
-        text: item[optionsValue],
-      }));
-    }
-
-    // Priority 2: Use answerList from params
-    return answerList.map((item) => ({
-      ...item,
-      name: item[optionsKey],
-      text: item[optionsValue],
-    }));
-  }
 }

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -1,0 +1,20 @@
+import { Component } from "@angular/core";
+import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
+import { IAnswerListItem } from "../../../../utils";
+
+const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
+  answer_list: coerce.objectArray<IAnswerListItem>([
+    { name: null, text: null, image: null, image_checked: null },
+  ]),
+}));
+
+@Component({
+  selector: "plh-radio-list",
+  templateUrl: "./radio-list.component.html",
+  styleUrls: ["./radio-list.component.scss"],
+})
+export class TmplRadioListComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  public async handleItemClick(value: string) {
+    await this.setValue(value);
+  }
+}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new component, `radio_list`, to display a list of single-selectable options.

This component exposes the following parameters:
- `answer_list`
- `options_key`
- `options_value`
The latter two options can be used to override the default names for the key/value properties in the provided answer list, as was introduced for the combo box component in #3196.

## Dev Notes

We already have two components with similar functionality: `radio_group` and `radio_button_grid`. An argument could be made that this new component should be exposed as a variant of `radio_group` instead of a standalone component (or indeed that the existing components should also be handled in this way). I think that as the HTML template is completely different for this component, it made sense to create it independently, plus I wanted a clean TS file to keep the logic as simply as possible. We could expose the `radio_list` as a variant of the `radio_group` component at the authoring level, while still keeping the code files separate (e.g. as a subcomponent in the code), but I think that separate template components is acceptable.

Whilst I was able to keep the logic reasonably minimal, the majority of lines were added to enable the customisable key/value names and to allow authoring of the answer list via a nested data-items row ([these commits](https://github.com/IDEMSInternational/open-app-builder/pull/3226/files/24414e63a98e90182d040d265af1477b2106c626..febef6230fb31b3e2a21b2660ad454b8b1c1c703)). The latter functionality was copied over from the combo-box component, and whilst I was able to simplify the logic significantly, it's still a bit of a hack tied to how we handle data-items within a dedicated component (I will add a follow-up to refactor the combo-box component to use the zod params and simplify this equivalent logic). Potentially this could be simplified significantly under the core rewrite, with components that expect a list of options (including the radio components and combo-box) reading from any child rows they may have in a more general way.

I've kept the `answer_list` parameter so named to retain interoperability, but in the core rewrite we'll likely want to rename this parameter and make it clear that its properties are not fixed and depend upon component implementation and author param config. 

## Git Issues

Closes #3211

## Screenshots/Videos

[comp_radio_list](https://docs.google.com/spreadsheets/d/1ykG_OU7bZJhNyoVKzOGjjGJ2F0OHbdJC0sh_7d67fTY/edit?gid=569531329#gid=569531329):

<img width="800" alt="Screenshot 2025-11-26 at 16 29 54" src="https://github.com/user-attachments/assets/df726542-a510-448d-90ba-7257e33f23fc" />

<img width="280" alt="Screenshot 2025-11-26 at 16 30 16" src="https://github.com/user-attachments/assets/10063127-675a-4948-9fce-442c2f949b0d" />

