### PR TITLE
fix: handle case where firebase is not initialised as auth provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": "IDEMS International",
   "license": "See LICENSE",
   "homepage": "https://idems.international/",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -220,6 +220,9 @@ export class AppComponent {
         this.dbSyncService,
         this.dynamicDataService,
         this.userMetaService,
+        // Auth service made blocking to ensure auth state is available for initial render
+        // See https://github.com/IDEMSInternational/open-app-builder/pull/3246
+        // Can be removed as blocking init after move to reactive template architecture
         this.authService,
         this.tourService,
         this.taskService,

--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -70,7 +70,11 @@ export class AuthService extends AsyncServiceBase {
   }
 
   private async initialise() {
-    await this.provider.initialise(this.injector);
+    try {
+      await this.provider.initialise(this.injector);
+    } catch (error) {
+      console.error("[Auth] Provider initialisation failed:", error);
+    }
     this.registerTemplateActionHandlers();
 
     // Explicitly set storage entry to ensure available for initial render by end of init

--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -37,9 +37,9 @@ export class FirebaseAuthProvider extends AuthProviderBase {
 
   public override async initialise(injector: Injector) {
     const firebaseService = injector.get(FirebaseService);
-    // TODO - is service required here?
     if (!firebaseService.app) {
-      throw new Error("[Firebase Auth] app not configured");
+      console.warn("[Firebase Auth] Firebase not configured, auth features will be unavailable");
+      return;
     }
     this.subscribeToAuthStateChanges();
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where, if Firebase was not configured as an auth provider for a given deployment, an error would be thrown that would block app initialisation for a minute. The fact that this now blocks initialisation is due to the auth service now being a blocking service on init as of #3246.

## Git Issues

Closes #

## Screenshots/Videos

Tested on [`plh_kids_teens_pa` deployment](https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content), which doesn't yet have Firebase configured:

| before | after |
|-|-|
| <img width="625" height="57" alt="Screenshot 2025-12-19 at 12 07 34" src="https://github.com/user-attachments/assets/c54dd091-5f6e-4a18-95e0-b939d0c932b2" /> | <img width="619" height="42" alt="Screenshot 2025-12-19 at 12 03 44" src="https://github.com/user-attachments/assets/b409942b-ae16-4c28-a210-a976642b9aa2" /> |


