### PR TITLE
style: force radio list component to display visible circle on ios

### DIFF
--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -1,7 +1,7 @@
 <ion-radio-group [value]="value()" (ionChange)="handleItemClick($event.detail.value)">
   @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
-      <ion-radio labelPlacement="end" justify="start" [value]="item[params().optionsKey]">
+      <ion-radio labelPlacement="end" justify="start" mode="md" [value]="item[params().optionsKey]">
         <plh-tmpl-text
           [row]="{ _nested_name: '', name: '', type: 'text', value: item[params().optionsValue] }"
         >


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Ensures that the radio list component displays with a circle on all platforms. Previously, on iOS the component would default to the [iOS "mode" as implemented by ionic](https://ionicframework.com/docs/api/radio), which shows ticks next to the selected option but doesn't make it clear that the list is a radio list.

## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-cw-content/issues/239

## Screenshots/Videos

| Before | After |
|-|-|
| <img width="362" height="795" alt="Screenshot 2026-01-22 at 16 50 35" src="https://github.com/user-attachments/assets/79b515f3-629e-434c-9407-eb9f0e022531" /> | <img width="363" height="787" alt="Screenshot 2026-01-22 at 16 53 06" src="https://github.com/user-attachments/assets/e131de72-cb5e-4349-938c-f302bce42e56" /> |

