### PR TITLE
fix: ensure combo-box value is undefined if no answer selected (not null)

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -136,7 +136,7 @@ export class TmplComboBoxComponent
       this.answerText.set(answer?.[optionsValue] || "");
       this.customAnswerSelected.set(data?.data?.customAnswerSelected);
       this.customAnswerText = this.customAnswerSelected() ? answer?.[optionsValue] || "" : "";
-      await this.setValue(answer?.[optionsKey] || null);
+      await this.setValue(answer?.[optionsKey] || undefined);
     });
     await modal.present();
   }
@@ -162,7 +162,7 @@ export class TmplComboBoxComponent
       this.params().prioritisePlaceholder = false;
       const answer = data?.data?.answer;
       this.answerText.set(answer?.[optionsValue] || "");
-      await this.setValue(answer?.[optionsKey] || null);
+      await this.setValue(answer?.[optionsKey] || undefined);
     });
     await modal.present();
   }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Ensures that the value of the combo-box is always `undefined` when it has no value. Previously, it was sometimes `undefined` and sometimes `null`, which seemed to cause issues in some cases of saving the data to dynamic data.

## Git Issues

Closes #

## Screenshots/Videos


