### PR TITLE
fix: youtube component configuration for ios compatibility

### DIFF
--- a/src/app/shared/components/template/components/youtube/youtube.component.ts
+++ b/src/app/shared/components/template/components/youtube/youtube.component.ts
@@ -23,6 +23,7 @@ const YOUTUBE_URL_QUERY_PARAMS: { [K in keyof YouTubeUrlQueryParamValues]: strin
   showFullscreenButton: "fs",
   interfaceLanguage: "hl",
   showRelatedVideos: "rel",
+  playsinline: "playsinline",
 };
 
 /** Possible values of the supported query params */
@@ -32,6 +33,7 @@ interface YouTubeUrlQueryParamValues {
   showFullscreenButton: "0" | "1";
   interfaceLanguage: string; // 2-letter ISO 639-1 code
   showRelatedVideos: "0" | "1";
+  playsinline: "1"; // playsinline must be enabled for iOS compatibility
 }
 
 @Component({
@@ -98,6 +100,8 @@ export class YoutubeComponent extends TemplateBaseComponent {
     this.setYouTubeParam(url, "interfaceLanguage", languageCode);
     // Disable related videos (at least those from external channels)
     this.setYouTubeParam(url, "showRelatedVideos", "0");
+    // Always enable playsinline for iOS compatibility
+    this.setYouTubeParam(url, "playsinline", "1");
     return url;
   }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the `youtube` component would not show the embedded video on iOS.

## Git Issues

Closes https://github.com/ParentingForLifelongHealth/plh-facilitator-app-cw-content/issues/262

## Screenshots/Videos

`plh_facilitator_cw` deployment

| before | after |
|-|-|
| <img width="325" height="2532" alt="broken" src="https://github.com/user-attachments/assets/7da5de31-335f-439e-8a4d-b0ff9ee7e41b" /> | <img width="325" height="726" alt="fixed" src="https://github.com/user-attachments/assets/d052f587-f9d6-43ee-bf67-2b5afa88b22f" /> |
