### PR TITLE
fix: translate labels of tab components

### DIFF
--- a/src/app/shared/components/template/components/tabs/tabs.component.html
+++ b/src/app/shared/components/template/components/tabs/tabs.component.html
@@ -15,7 +15,7 @@
     [selectedIndex]="params().selectedIndex"
   >
     @for (tabRow of tabRows(); track tabRow.name) {
-      <mat-tab [label]="tabRow.label" [attr.data-rowname]="tabRow.name">
+      <mat-tab [label]="tabRow.label | translate" [attr.data-rowname]="tabRow.name">
         @for (
           childRow of tabRow.childRows | filterDisplayComponent;
           track trackByRow($index, childRow)


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the labels of tab components would not be translated to the app's language.

## Testing

I've tested on the debug deployment by manually adding translated strings to the Spanish translations json file. @MichelePancera I recommend testing directly on the CW deployment to confirm that the issues is resolved.

## Dev notes

A reminder to future devs (i.e. me) that the translation system does not automatically cover values supplied to components as HTML attributes such as this.

## Git Issues

Closes #

## Screenshots/Videos

[comp_tabs](https://docs.google.com/spreadsheets/d/1raJlddyTZlGxQyv78Nm5PHJxMftisYuCWFWgIVvGxq8/edit?gid=1049834765#gid=1049834765) template demo. Note that the only translated strings are the tab labels themselves since these are the only strings for which translations exist (added manually locally, and captured in https://github.com/IDEMSInternational/app-debug-content/pull/222)

<img width="270" height="555" alt="Screenshot 2026-01-27 at 15 09 48" src="https://github.com/user-attachments/assets/b3f2f802-bde7-4c2b-88df-ebaf58446e61" />

