### PR TITLE
fix: plh-bottom-nav and navigation-bar components fill full width of footer

### DIFF
--- a/packages/components/plh/plh-kids-kw/components/bottom-navigation-bar/bottom-navigation-bar.component.html
+++ b/packages/components/plh/plh-kids-kw/components/bottom-navigation-bar/bottom-navigation-bar.component.html
@@ -1,23 +1,25 @@
 <div class="plh-bottom-nav-wrapper" [attr.data-variant]="params.variant">
-  @for (button of params.buttonList; track button.name) {
-    <a
-      class="nav-item"
-      routerLinkActive="active-link"
-      [routerLink]="'template/' + button.target_template"
-      #rla="routerLinkActive"
-      [attr.data-name]="button.name"
-      [attr.data-variant]="params.variant"
-      [attr.data-isActive]="rla.isActive"
-      [attr.data-hideInactiveText]="params.hideInactiveText"
-      [attr.data-dim-when-inactive]="!button.active_icon || null"
-    >
-      <img
-        class="icon"
-        [src]="(button.active_icon && rla.isActive ? button.active_icon : button.icon) | plhAsset"
-      />
-      <div class="label" [attr.data-hideInactiveText]="params.hideInactiveText">
-        {{ button.label }}
-      </div>
-    </a>
-  }
+  <div class="nav-items">
+    @for (button of params.buttonList; track button.name) {
+      <a
+        class="nav-item"
+        routerLinkActive="active-link"
+        [routerLink]="'template/' + button.target_template"
+        #rla="routerLinkActive"
+        [attr.data-name]="button.name"
+        [attr.data-variant]="params.variant"
+        [attr.data-isActive]="rla.isActive"
+        [attr.data-hideInactiveText]="params.hideInactiveText"
+        [attr.data-dim-when-inactive]="!button.active_icon || null"
+      >
+        <img
+          class="icon"
+          [src]="(button.active_icon && rla.isActive ? button.active_icon : button.icon) | plhAsset"
+        />
+        <div class="label" [attr.data-hideInactiveText]="params.hideInactiveText">
+          {{ button.label }}
+        </div>
+      </a>
+    }
+  </div>
 </div>

--- a/packages/components/plh/plh-kids-kw/components/bottom-navigation-bar/bottom-navigation-bar.component.scss
+++ b/packages/components/plh/plh-kids-kw/components/bottom-navigation-bar/bottom-navigation-bar.component.scss
@@ -1,8 +1,12 @@
 .plh-bottom-nav-wrapper {
-  display: flex;
-  justify-content: space-around;
-  padding: 8px;
-  gap: 8px;
+  .nav-items {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-around;
+    padding: 8px;
+    gap: 8px;
+  }
   &[data-variant="inverted"] {
     background-color: var(--ion-color-primary);
     .label {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -51,6 +51,7 @@
               <plh-template-container
                 [templatename]="footerTemplate"
                 [ignoreQueryParamChanges]="true"
+                style="max-width: 100%"
               ></plh-template-container>
             </ion-toolbar>
           </ion-footer>

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
@@ -1,17 +1,19 @@
 <div class="navigation-bar-wrapper" [attr.data-variant]="params().variant">
-  @for (button of params().buttonList; track button.targetTemplate) {
-    <a
-      class="button-wrapper"
-      [routerLink]="'template/' + button.targetTemplate"
-      [attr.data-name]="button.name"
-      [class.active-link]="$index === activeLinkIndex()"
-    >
-      <div class="image-wrapper">
-        <img [src]="button.image | plhAsset" />
-      </div>
-      @if (button.text) {
-        <p>{{ button.text }}</p>
-      }
-    </a>
-  }
+  <div class="nav-items">
+    @for (button of params().buttonList; track button.targetTemplate) {
+      <a
+        class="button-wrapper"
+        [routerLink]="'template/' + button.targetTemplate"
+        [attr.data-name]="button.name"
+        [class.active-link]="$index === activeLinkIndex()"
+      >
+        <div class="image-wrapper">
+          <img [src]="button.image | plhAsset" />
+        </div>
+        @if (button.text) {
+          <p>{{ button.text }}</p>
+        }
+      </a>
+    }
+  </div>
 </div>

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.scss
@@ -3,9 +3,13 @@
 $navigation-bar-height: var(--navigation-bar-height);
 
 .navigation-bar-wrapper {
-  @include mixins.flex-space-between;
-  height: $navigation-bar-height;
-  padding: var(--tiny-padding);
+  .nav-items {
+    height: $navigation-bar-height;
+    padding: var(--tiny-padding);
+    @include mixins.flex-space-between;
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+  }
 
   a.button-wrapper {
     @include mixins.flex-centered;

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -910,7 +910,7 @@
   // bottom_nav
   plh-bottom-navigation-bar {
     .plh-bottom-nav-wrapper {
-      border-top: 1px solid #e7e8e9;
+      border-top: 1px solid var(--ion-color-primary-200);
       .label {
         color: #6686b1;
       }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the template in the footer did not take up the full width of the viewport, which meant that it was not possible to set the background colour of the footer correctly via the background colour of the template displayed in the footer (this limited us to setting the footer background colour via the `APP_FOOTER_DEFAULTS.background` config property, which is limited to the values `"primary" | "secondary" | "none"`).

Also, updates the `plh_kids_teens_za` theme slightly as a step towards addressing https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/issues/399

NB: We currently have two different navigation bar templates that can be used in the footer, `plh_bottom_nav` and `navigation_bar`. This is for historical reasons and these two components should probably at some point be merged, but that is beyond the scope of this PR. 

## Git Issues

Allows https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/issues/399 to be addressed by authoring, see latest version of the [ZA footer template](https://docs.google.com/spreadsheets/d/1dpTYJMY2c8CWJ8yiGTR1vSX1LryPSpsxQSPbUjRi0fg/edit?gid=260327446#gid=260327446)

## Screenshots/Videos

[comp_navigation_bar](https://docs.google.com/spreadsheets/d/1zrwdmmMbVhhAs2Z8PttCAJidk7N9VgCG7E99SOcWFZs/edit?gid=569531329#gid=569531329), unchanged vs master:
| before | after |
|-|-|
| <img width="800" height="696" alt="Screenshot 2026-03-10 at 16 03 51" src="https://github.com/user-attachments/assets/077fc680-6200-4f17-9f58-6a059b90a7c2" /> | <img width="800" height="695" alt="Screenshot 2026-03-10 at 15 49 35" src="https://github.com/user-attachments/assets/46a3face-cb01-479c-897e-6e461dd55caf" /> |


[comp_plh_bottom_nav](https://docs.google.com/spreadsheets/d/1weQYXdg4McVzhM5d4p0-iqKgqNaXeVMjLp4Qwp-u6MI/edit?gid=569531329#gid=569531329) – top border, a theme override of `plh_kids_teens_za`, now goes full width:

| before | after |
|-|-|
| <img width="800" height="699" alt="Screenshot 2026-03-10 at 16 02 04" src="https://github.com/user-attachments/assets/63cf6cd4-23bc-4b37-b152-f91caac86db7" /> | <img width="800" height="701" alt="Screenshot 2026-03-10 at 15 49 48" src="https://github.com/user-attachments/assets/32643b08-030f-49f3-8c13-65487cb4e56b" /> |


[ZA footer template](https://docs.google.com/spreadsheets/d/1dpTYJMY2c8CWJ8yiGTR1vSX1LryPSpsxQSPbUjRi0fg/edit?gid=260327446#gid=260327446):

| master | feature branch |
|-|-|
| <img width="800" height="700" alt="Screenshot 2026-03-10 at 15 58 53" src="https://github.com/user-attachments/assets/04d647ac-5afc-4243-89fb-5666fe5d0315" /> | <img width="800" height="701" alt="Screenshot 2026-03-10 at 15 56 24" src="https://github.com/user-attachments/assets/b8acbaac-e277-4953-9246-043dd2e16ba1" /> |