### PR TITLE
fix: handle footer background colour including legacy config property

### DIFF
--- a/packages/data-models/appConfig.ts
+++ b/packages/data-models/appConfig.ts
@@ -122,15 +122,14 @@ const activeRoute = (location: Location) => {
 };
 
 interface IAppConfigFooter {
-  background: IHeaderFooterBackgroundOptions;
+  /** @deprecated Use theme var --footer-background instead */
+  background?: IHeaderFooterBackgroundOptions;
   template: string | null;
   /** @deprecated use "template" instead */
   templateName?: string | null;
 }
 
 const APP_FOOTER_DEFAULTS: IAppConfigFooter = {
-  /** @deprecated use --footer-background theme variable instead */
-  background: "primary",
   template: null,
 };
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -47,12 +47,7 @@
         </div>
         @if (footerConfig().template; as footerTemplate) {
           <ion-footer>
-            <!-- Prefer to set background color using theme variable,
-             but legacy deployment config property will take precedence if set -->
-            <ion-toolbar
-              [color]="footerConfig().background"
-              style="--background: var(--footer-background)"
-            >
+            <ion-toolbar [style]="footerToolbarStyle()">
               <plh-template-container
                 [templatename]="footerTemplate"
                 [ignoreQueryParamChanges]="true"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -72,6 +72,23 @@ export class AppComponent {
     };
   });
 
+  /**
+   * Footer toolbar style: use theme var --footer-background (defaults to var(--ion-color-primary);
+   * Use legacy config background property when set.
+   * */
+  public footerToolbarStyle = computed(() => {
+    const legacyBackgroundFromConfig = this.footerConfig().background;
+    let backgroundValue: string;
+    if (!legacyBackgroundFromConfig) {
+      backgroundValue = "var(--footer-background, var(--ion-color-primary))";
+    } else if (legacyBackgroundFromConfig === "none") {
+      backgroundValue = "transparent";
+    } else {
+      backgroundValue = `var(--ion-color-${legacyBackgroundFromConfig})`;
+    }
+    return { "--background": backgroundValue };
+  });
+
   /** Track when app ready to render sidebar and route templates */
   public renderAppTemplates = signal(false);
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #3375. Properly handles both theme-level var and legacy config property for setting background colour of the app footer.

## Git Issues

Related to https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-za-content/issues/399

## Screenshots/Videos

`plh_kids_teens_za` deployment on ios:

| before | after |
|-|-|
| <img width="402" height="850" alt="Screenshot 2026-03-11 at 16 46 12" src="https://github.com/user-attachments/assets/669fb95d-7770-4681-861e-7563bc5647a8" /> | <img width="390" height="856" alt="Screenshot 2026-03-11 at 17 05 57" src="https://github.com/user-attachments/assets/60cf5012-3dc7-48d6-8ab4-f3f04348c1e5" /> |