### PR TITLE
fix: campaign notifications

### DIFF
--- a/src/app/feature/notification/pages/notifications-debug/components/notification-debug-row.component.ts
+++ b/src/app/feature/notification/pages/notifications-debug/components/notification-debug-row.component.ts
@@ -15,9 +15,9 @@ import {
           <div style="flex:1">
             <div>
               <div>
-                {{ notification.extra.title }}
+                {{ notification.title }}
               </div>
-              <div class="info-text">{{ notification.extra.id }}</div>
+              <div class="info-text">{{ notification._row_id }}</div>
             </div>
           </div>
           <div class="next-notification">
@@ -30,7 +30,7 @@ import {
           <div style="flex: 1; margin-right: 8px">
             <div class="divider"></div>
 
-            <div>{{ notification.extra.text }}</div>
+            <div>{{ notification.body }}</div>
           </div>
           <div style="text-align: right">
             <div class="divider"></div>

--- a/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.ts
+++ b/src/app/feature/notification/pages/notifications-debug/notifications-debug.page.ts
@@ -54,7 +54,7 @@ export class NotificationsDebugPage implements OnInit {
     }
   }
   public logDebugInfo(notification: ILocalNotificationInteraction) {
-    console.group(notification.notification_meta.id);
+    console.group(notification.notification_id);
     console.log(notification);
     console.groupEnd();
   }

--- a/src/app/shared/services/notification/local-notification.service.ts
+++ b/src/app/shared/services/notification/local-notification.service.ts
@@ -306,7 +306,7 @@ export class LocalNotificationService extends AsyncServiceBase {
         notification[key] = value;
       }
     });
-    if (!notification.extra?.id) {
+    if (!id) {
       throw new Error(`no id supplied for notification\n${notification.title}`);
     }
     if (!notification.schedule) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue with campaign notifications, which were not being scheduled. The campaign system is considered deprecated, however it is still in use in some production deployments.

## Dev notes

The campaign notification refactor (part of #2993) changed notifications' `extra` param from `{ ...row, campaign_id }` to `{ campaign_id, action_list }`, and moved the row id to a dedicated `scheduleNotification` parameter. Several consumers of `extra` were not updated to match.

- Fix stale `notification.extra?.id` guard in deprecated `LocalNotificationService.scheduleNotification` — after the refactor in https://github.com/IDEMSInternational/open-app-builder/commit/c74785c8a / https://github.com/IDEMSInternational/open-app-builder/commit/6c9c6276a, the stable row identifier is passed as an explicit `id` parameter rather than nested in `extra`, so the guard now validates `id` instead
- Update `notification-debug-row` component template to read `title`, `_row_id`, and `body` directly from the notification object instead of from `extra` (which no longer contains the full campaign row spread)
- Fix `notifications-debug` page `logDebugInfo` to use `notification_id` instead of `notification_meta.id`

## Testing

- [x] Verify campaign notifications can be scheduled without hitting the `no id supplied` error
- [x] Verify the notifications debug page renders notification title, row id, and body text correctly
- [x] Verify the "log full details" button on the debug page logs with the correct identifier

## Git Issues

Closes #3390

## Screenshots/Videos


https://github.com/user-attachments/assets/5a3622d3-c400-4182-86b8-ef31cbfd8b04

