### PR TITLE
fix: firebase app check web site key

### DIFF
--- a/src/app/feature/remote-function/providers/firebase.ts
+++ b/src/app/feature/remote-function/providers/firebase.ts
@@ -70,7 +70,7 @@ export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
       }
       await FirebaseAppCheck.initialize({
         isTokenAutoRefreshEnabled: true,
-        provider: new ReCaptchaEnterpriseProvider("myKey"),
+        provider: new ReCaptchaEnterpriseProvider(siteKey),
         debugToken: environment.production ? false : true,
       });
     }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Follow-up to #3097. Fixes an issue where the required "site key" was not used properly in production web environments, causing App Check to fail (due to reCAPTCHA failing).

## Git Issues

Closes #

## Screenshots/Videos

Production token received successfully (I temporarily disabled App Check's debug mode for testing):

<img width="468" height="768" alt="Screenshot 2026-03-31 at 10 20 42" src="https://github.com/user-attachments/assets/8307377f-e5e8-45a0-817c-56775b9b8dfb" />

