### PR TITLE
fix: combo-box dropdown text-align

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
@@ -53,6 +53,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   }
 
   .text {
+    text-align: start;
     margin-top: auto;
     margin-bottom: auto;
     width: 100%;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes a regression issue likely introduced by #3411, whereby the display text in the `dropdown` variant of the combo-box component became centre aligned (previously left-aligned).

## Git Issues

Relates to https://github.com/ParentingForLifelongHealth/plh-facilitator-app-my-content/issues/276

## Screenshots/Videos

| before | after |
|---|---|
| <img width="280" height="711" alt="Screenshot 2026-04-13 at 13 29 23" src="https://github.com/user-attachments/assets/a249d276-ba06-4237-9126-5646d5dbbe9a" /> | <img width="280" height="711" alt="Screenshot 2026-04-13 at 13 26 46" src="https://github.com/user-attachments/assets/434ebccf-86ca-4032-9520-5df526ddc720" /> |