### PR TITLE
feat: initialise remote-function service on app launch

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,6 +48,7 @@ import { ScrollService } from "./shared/services/scroll/scroll.service";
 import { ToastService } from "./shared/services/toast/toast.service";
 import { CapacitorEventService } from "./shared/services/capacitor-event/capacitor-event.service";
 import { AuthService } from "./shared/services/auth/auth.service";
+import { RemoteFunctionService } from "./feature/remote-function/remote-function.service";
 
 @Component({
   selector: "app-root",
@@ -149,7 +150,8 @@ export class AppComponent {
     private scrollService: ScrollService,
     private toastService: ToastService,
     private capacitorEventService: CapacitorEventService,
-    private authService: AuthService
+    private authService: AuthService,
+    private remoteFunctionService: RemoteFunctionService
   ) {
     this.initializeApp();
   }
@@ -233,7 +235,7 @@ export class AppComponent {
       /** likely no longer required, should be removed in future (impact can be tested by moving into group) */
       deprecated: (AsyncServiceBase | SyncServiceBase)[];
     } = {
-      eager: [this.crashlyticsService],
+      eager: [this.crashlyticsService, this.remoteFunctionService],
       blocking: [
         this.dbSyncService,
         this.dynamicDataService,

--- a/src/app/feature/remote-function/remote-function.service.ts
+++ b/src/app/feature/remote-function/remote-function.service.ts
@@ -19,7 +19,11 @@ export class RemoteFunctionService extends AsyncServiceBase {
   ) {
     super("Remote Function");
     this.provider = getFunctionProvider(this.config.provider);
-    this.registerInitFunction(this.initialise, "defer");
+    if (this.provider) {
+      this.registerInitFunction(this.initialise, "defer");
+    } else {
+      console.warn("[Remote Function] No provider configured, feature disabled");
+    }
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Configures the remote-function service to initialise eagerly on app launch. This addresses a performance issue where the service would only init when a remote function was actually invoked for the first time via a template action – this would cause a noticeable delay in the action functionality.

## Dev notes

It's a bit untidy that, when working on deployments with remote functions enabled, devs and authors will now see these errors in the console on every app load, unless they configure App Check in firebase using their debug token. Any quick ideas on how to tidy this up @chrismclarke?

<img width="600" height="399" alt="Screenshot 2026-04-13 at 15 28 36" src="https://github.com/user-attachments/assets/930fe9ab-4164-47a7-a372-614ee677b6eb" />


## Git Issues

Should address https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-my-content/issues/162

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
