### PR TITLE
fix: plh_parent_group: push/pull bug

### DIFF
--- a/packages/components/plh/parent-group/utils/rapidpro.utils.spec.ts
+++ b/packages/components/plh/parent-group/utils/rapidpro.utils.spec.ts
@@ -80,6 +80,22 @@ describe("rapidproUtils", () => {
     });
   });
 
+  it("should not throw when rapidpro_fields is missing", () => {
+    const parentFromApp = {
+      app_user_id: "app-user-123",
+    } as IParentFromExternalSource;
+    const parentGroupId = "group-456";
+    const result = rapidproUtils.transformParentWithExternalSourceDataToLocalFormat(
+      parentFromApp,
+      parentGroupId
+    );
+    expect(result).toEqual({
+      id: "group-456+app-user-123",
+      group_id: "group-456",
+      app_user_id: "app-user-123",
+    });
+  });
+
   describe("formatParentGroupDataForPush", () => {
     it("should remove protected fields and RapidPro fields from parent group and parents", () => {
       const parentGroup: any = {
@@ -266,6 +282,93 @@ describe("rapidproUtils", () => {
           id: "parent-20",
           group_id: "group-10",
           first_name: "Incoming Parent 20",
+        },
+      ]);
+    });
+
+    it("should merge by app_user_id and avoid duplicate appended local parent", () => {
+      const existing = [
+        {
+          app_user_id: "593cc833-7f71-4021-8ea1-d23faa7873d1",
+          rapidpro_fields: {
+            gender: "woman",
+            name: "Bobby",
+            timestamp: "2026-04-14T14:18:08.133Z",
+          },
+        } as IParentInSharedData,
+        {
+          app_user_id: "2825e892-16f0-4a17-bee0-0dd1635852ea",
+          rapidpro_fields: {
+            gender: "man",
+            name: "Gigi",
+            timestamp: "2026-04-14T14:19:45.470Z",
+          },
+        } as IParentInSharedData,
+      ];
+      const incoming = [
+        {
+          id: "b3d292f6-b7ce-4096-b30e-f1dff9890718+593cc833-7f71-4021-8ea1-d23faa7873d1",
+          group_id: "b3d292f6-b7ce-4096-b30e-f1dff9890718",
+          app_user_id: "593cc833-7f71-4021-8ea1-d23faa7873d1",
+          text: "Test 1",
+        } as IParent,
+      ];
+      const result = rapidproUtils.mergeParentsArraysPreservingExternalSourceData(
+        existing,
+        incoming
+      );
+      expect(result).toEqual([
+        {
+          id: "b3d292f6-b7ce-4096-b30e-f1dff9890718+593cc833-7f71-4021-8ea1-d23faa7873d1",
+          group_id: "b3d292f6-b7ce-4096-b30e-f1dff9890718",
+          app_user_id: "593cc833-7f71-4021-8ea1-d23faa7873d1",
+          text: "Test 1",
+          rapidpro_fields: {
+            gender: "woman",
+            name: "Bobby",
+            timestamp: "2026-04-14T14:18:08.133Z",
+          },
+        },
+        {
+          app_user_id: "2825e892-16f0-4a17-bee0-0dd1635852ea",
+          rapidpro_fields: {
+            gender: "man",
+            name: "Gigi",
+            timestamp: "2026-04-14T14:19:45.470Z",
+          },
+        },
+      ]);
+    });
+
+    it("should merge by auth_user_id when available", () => {
+      const existing = [
+        {
+          auth_user_id: "auth-user-42",
+          app_user_id: "app-user-42",
+          rapidpro_fields: { name: "Auth Parent" },
+        } as IParentInSharedData,
+      ];
+      const incoming = [
+        {
+          id: "group-1+auth-user-42",
+          group_id: "group-1",
+          auth_user_id: "auth-user-42",
+          app_user_id: "app-user-42",
+          first_name: "Incoming",
+        } as IParent,
+      ];
+      const result = rapidproUtils.mergeParentsArraysPreservingExternalSourceData(
+        existing,
+        incoming
+      );
+      expect(result).toEqual([
+        {
+          id: "group-1+auth-user-42",
+          group_id: "group-1",
+          auth_user_id: "auth-user-42",
+          app_user_id: "app-user-42",
+          first_name: "Incoming",
+          rapidpro_fields: { name: "Auth Parent" },
         },
       ]);
     });

--- a/packages/components/plh/parent-group/utils/rapidpro.utils.ts
+++ b/packages/components/plh/parent-group/utils/rapidpro.utils.ts
@@ -82,17 +82,20 @@ function transformParentWithExternalSourceDataToLocalFormat(
   parentGroupId: string
 ): IParent {
   const { rapidpro_uuid, app_user_id, auth_user_id, rapidpro_fields, ...rest } = parent;
+  const normalizedRapidproFields =
+    rapidpro_fields && typeof rapidpro_fields === "object" ? rapidpro_fields : {};
   const parsedExternalFields = Object.fromEntries(
-    Object.entries(rapidpro_fields).map(([key, value]) => [`rp_${key}`, value])
+    Object.entries(normalizedRapidproFields).map(([key, value]) => [`rp_${key}`, value])
   );
 
-  const uniqueId = rapidpro_uuid || auth_user_id || app_user_id;
+  const uniqueId = rapidpro_uuid || auth_user_id || app_user_id || (rest as IParent).id;
+  const localParentId = `${parentGroupId}+${uniqueId}`;
 
   return {
     ...rest,
     ...parsedExternalFields,
     // Use a combined id of the parent group id and source identifier to ensure uniqueness
-    id: `${parentGroupId}+${uniqueId}`,
+    id: localParentId,
     group_id: parentGroupId,
     ...(rapidpro_uuid ? { rp_uuid: rapidpro_uuid } : {}),
     ...(app_user_id ? { app_user_id } : {}),
@@ -156,6 +159,12 @@ function findMatchingIncomingParent(
   const incomingByRapidproUuid = new Map(
     incoming.filter((p) => p.rp_uuid).map((p) => [p.rp_uuid, p])
   );
+  const incomingByAppUserId = new Map(
+    incoming.filter((p) => p.app_user_id).map((p) => [p.app_user_id, p])
+  );
+  const incomingByAuthUserId = new Map(
+    incoming.filter((p) => p.auth_user_id).map((p) => [p.auth_user_id, p])
+  );
   // Try to match by id
   if ((existingParent as IParent).id) {
     const matchById = incomingById.get((existingParent as IParent).id!);
@@ -167,6 +176,15 @@ function findMatchingIncomingParent(
     if (matchById) return matchById;
     const matchByRapidproUuid = incomingByRapidproUuid.get(existingParent.rapidpro_uuid);
     if (matchByRapidproUuid) return matchByRapidproUuid;
+  }
+  // Try to match by app/auth identifiers from app join_remote records
+  if (existingParent.auth_user_id) {
+    const matchByAuthUserId = incomingByAuthUserId.get(existingParent.auth_user_id);
+    if (matchByAuthUserId) return matchByAuthUserId;
+  }
+  if (existingParent.app_user_id) {
+    const matchByAppUserId = incomingByAppUserId.get(existingParent.app_user_id);
+    if (matchByAppUserId) return matchByAppUserId;
   }
   return undefined;
 }


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

`plh_parent_group: pull` was failing because some parent rows in shared data had an unexpected mixed shape (local-style row without rapidpro_fields).

These rows were likely introduced by normal sync behaviour after join:
- `plh_parent_group: join` adds external-style parent records,
- `plh_parent_group: pull` converts them into local-style parent rows,
- a later push re-merged local and shared rows,
- and because matching was too narrow, some local rows were appended back into shared data as extra entries.

That created rows with app_user_id but no rapidpro_fields, and then pull crashed when code assumed rapidpro_fields always existed.

Fix
- Made external-field parsing defensive (missing/null rapidpro_fields no longer throws).
- Expanded parent matching to include app_user_id / auth_user_id so join-origin rows are matched correctly instead of appended.
- Added regression tests for both identifier-based matching and missing rapidpro_fields handling.
This both prevents the crash and blocks the sync path that was creating those erroneous rows.

## Testing

Build the `plh_facilitator_my` app from this PR branch and test the flow of adding multiple parents from the `plh_kids_teens_my` web preview that was previously broken.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
