### PR TITLE
[CHORE] Move title overrides (page, section) to component level

### DIFF
--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -53,4 +53,19 @@
       text-align: center !important;
     }
   }
+
+  &[data-variant~="section_banner"] {
+    padding: var(--regular-padding);
+    background-color: color-mix(in srgb, var(--ion-color-primary-50), white 2%);
+    border-bottom: 1.5px solid var(--ion-color-primary-200);
+    h1 {
+      font-size: var(--font-size-title-tiny);
+      font-weight: var(--font-weight-bold);
+    }
+  }
+
+  &[data-variant~="page_banner"] h1 {
+    font-size: var(--font-size-title-medium);
+    margin: var(--regular-margin) 0;
+  }
 }

--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -55,7 +55,7 @@
   }
 
   &[data-variant~="section_banner"] {
-    padding: var(--regular-padding);
+    padding: 18px;
     background-color: color-mix(in srgb, var(--ion-color-primary-50), white 2%);
     border-bottom: 1.5px solid var(--ion-color-primary-200);
     h1 {

--- a/src/theme/themes/ae_app/_overrides.scss
+++ b/src/theme/themes/ae_app/_overrides.scss
@@ -350,29 +350,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-primary-900);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -9,6 +9,16 @@
     }
   }
 
+  // Title
+  plh-tmpl-title {
+    .title-wrapper[data-variant~="section_banner"] {
+      h1 {
+        font-size: var(--font-size-text-medium) !important;
+        font-weight: var(--font-weight-medium) !important;
+      }
+    }
+  }
+
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -9,27 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #effcfc;
-      border-bottom: 1px solid #b2f3ed;
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_my/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -364,29 +364,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-secondary-contrast);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_my/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_my/_overrides.scss
@@ -367,28 +367,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--color-secondary-blue-80);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_pa/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_overrides.scss
@@ -364,29 +364,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-gray-900);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -367,28 +367,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--color-secondary-blue-80);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_tz/_overrides.scss
+++ b/src/theme/themes/plh_kids_tz/_overrides.scss
@@ -225,28 +225,7 @@
       }
     }
   }
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      margin: 8px 0;
-      line-height: var(--font-size-title-large);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-bold) !important;
-      background-color: var(--ion-color-primary-50);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px 24px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-title-large) !important;
-      padding: 10px 0;
-    }
-  }
+
   // Progress Path
   plh-progress-path {
     // Fine-tune the position of the child steps to reflect theme image


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Theme level styling for `section` and `page` banner moved to the component level and removed from override files (excluding `facilitator_cw` theme).

## Follow up Issue/Task
- Expose title text colour variable. Removing the title overrides left the title colour as `ion-color-primary` by default.

## Git Issues

Closes #3457

## Screenshots/Videos

| Master Branch | This Branch |
|---------------|--------------|
| <img width="280" src="https://github.com/user-attachments/assets/e59bf3d5-7b80-4522-b68d-18e87e62d9e5" /> | <img width="280" src="https://github.com/user-attachments/assets/67ec970c-ab61-481a-ab68-b8f1b3e83187" /> |
| <img width="280" src="https://github.com/user-attachments/assets/d01ef8c4-790d-4bd0-b9fe-41aa962a671a" /> | <img width="280" src="https://github.com/user-attachments/assets/4f9e49a1-6b91-4a52-9e5c-f845201e4bdd" />|
| <img width="280" src="https://github.com/user-attachments/assets/3e644ad0-c436-4e74-a805-1d5ad292a9a6" /> | <img width="280" src="https://github.com/user-attachments/assets/e714c48d-0955-41cb-84c9-8ac4fb739523" /> |
| <img width="280" src="https://github.com/user-attachments/assets/c1952008-c401-41b1-95d3-57abac8d6a6c" /> | <img width="280" src="https://github.com/user-attachments/assets/0122edfb-3ac8-4f22-a28d-0a9b0ef26178" /> |
