### PR TITLE
[CHORE] Expose new title component variable

### DIFF
--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -3,10 +3,18 @@
 .title-wrapper {
   display: flex;
   align-items: center;
-  h1 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin: 0;
+  }
+  h1 {
     line-height: var(--line-height-text-largest);
     font-weight: var(--font-weight-bold);
+    color: var(--title-text-color, var(--ion-color-primary));
     @media (max-width: 375px) {
       font-size: var(--font-size-title-tiny);
     }

--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -53,4 +53,19 @@
       text-align: center !important;
     }
   }
+
+  &[data-variant~="section_banner"] {
+    padding: var(--regular-padding);
+    background-color: color-mix(in srgb, var(--ion-color-primary-50), white 2%);
+    border-bottom: 1.5px solid var(--ion-color-primary-200);
+    h1 {
+      font-size: var(--font-size-title-tiny);
+      font-weight: var(--font-weight-bold);
+    }
+  }
+
+  &[data-variant~="page_banner"] h1 {
+    font-size: var(--font-size-title-medium);
+    margin: var(--regular-margin) 0;
+  }
 }

--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -55,7 +55,7 @@
   }
 
   &[data-variant~="section_banner"] {
-    padding: var(--regular-padding);
+    padding: 18px;
     background-color: color-mix(in srgb, var(--ion-color-primary-50), white 2%);
     border-bottom: 1.5px solid var(--ion-color-primary-200);
     h1 {

--- a/src/app/shared/components/template/components/title/title.component.scss
+++ b/src/app/shared/components/template/components/title/title.component.scss
@@ -1,5 +1,7 @@
 @use "/src/theme/mixins";
 
+$text-color: var(--title-text-color, var(--ion-color-primary-900));
+
 .title-wrapper {
   display: flex;
   align-items: center;
@@ -14,7 +16,7 @@
   h1 {
     line-height: var(--line-height-text-largest);
     font-weight: var(--font-weight-bold);
-    color: var(--title-text-color, var(--ion-color-primary));
+    color: $text-color;
     @media (max-width: 375px) {
       font-size: var(--font-size-title-tiny);
     }
@@ -63,7 +65,7 @@
   }
 
   &[data-variant~="section_banner"] {
-    padding: 18px;
+    padding: 18px 24px;
     background-color: color-mix(in srgb, var(--ion-color-primary-50), white 2%);
     border-bottom: 1.5px solid var(--ion-color-primary-200);
     h1 {
@@ -72,8 +74,11 @@
     }
   }
 
-  &[data-variant~="page_banner"] h1 {
-    font-size: var(--font-size-title-medium);
+  &[data-variant~="page_banner"] {
     margin: var(--regular-margin) 0;
+    h1 {
+      font-size: var(--font-size-title-medium);
+      font-weight: var(--font-weight-bold);
+    }
   }
 }

--- a/src/theme/_typography.scss
+++ b/src/theme/_typography.scss
@@ -12,7 +12,7 @@ p {
 }
 
 .standard {
-  color: var(--ion-color-primary);
+  color: var(--ion-color-primary-900);
 }
 .alternative {
   color: var(--ion-color-primary-contrast);

--- a/src/theme/themes/ae_app/_index.scss
+++ b/src/theme/themes/ae_app/_index.scss
@@ -53,6 +53,7 @@
       task-progress-bar-color: var(--ion-color-green),
       // checkbox-background-color: white,
       progress-path-line-background: var(--ion-color-gray-100),
+      title-text-color: var(--ion-color-primary-900),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/ae_app/_overrides.scss
+++ b/src/theme/themes/ae_app/_overrides.scss
@@ -350,29 +350,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-primary-900);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_facilitator_cw/_index.scss
+++ b/src/theme/themes/plh_facilitator_cw/_index.scss
@@ -99,6 +99,7 @@
       plh-module-list-item-background-1: hsl(334, 43%, 70%),
       plh-module-list-item-background-2: hsl(29, 77%, 70%),
       plh-module-list-item-background-3: hsl(123, 34%, 70%),
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_cw/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_cw/_overrides.scss
@@ -9,6 +9,16 @@
     }
   }
 
+  // Title
+  plh-tmpl-title {
+    .title-wrapper[data-variant~="section_banner"] {
+      h1 {
+        font-size: var(--font-size-text-medium) !important;
+        font-weight: var(--font-weight-medium) !important;
+      }
+    }
+  }
+
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_mx/_index.scss
+++ b/src/theme/themes/plh_facilitator_mx/_index.scss
@@ -136,6 +136,7 @@
       text-bubble-border-color-3: var(--color-accent-orange-70),
       text-bubble-background-color-4: var(--color-accent-blue-90),
       text-bubble-border-color-4: var(--color-accent-blue-70),
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_facilitator_mx/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_mx/_overrides.scss
@@ -9,27 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #effcfc;
-      border-bottom: 1px solid #b2f3ed;
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_my/_index.scss
+++ b/src/theme/themes/plh_facilitator_my/_index.scss
@@ -91,6 +91,7 @@
       // BOX SHADOW
       box-shadow-primary: 0px 1.5px 8px rgba(104, 148, 188, 0.6),
       box-shadow-secondary: 0px 1.5px 8px rgba(212, 165, 147, 0.6),
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_facilitator_my/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_my/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_facilitator_ph/_index.scss
+++ b/src/theme/themes/plh_facilitator_ph/_index.scss
@@ -104,6 +104,7 @@
       box-shadow-secondary: 0px 1.5px 8px rgba(133, 178, 196, 0.6),
       box-shadow-yellow: 0px 1.5px 8px rgba(255, 233, 153, 0.5),
       box-shadow-red: 0px 1.5px 8px rgba(255, 179, 172, 0.5),
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_facilitator_ph/_overrides.scss
+++ b/src/theme/themes/plh_facilitator_ph/_overrides.scss
@@ -9,28 +9,6 @@
     }
   }
 
-  //Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      background-color: var(--ion-color-primary-100);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px;
-        border: none;
-        font-size: var(--font-size-text-medium) !important;
-        font-weight: var(--font-weight-medium) !important;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Task Card
   plh-task-card {
     .card-wrapper {

--- a/src/theme/themes/plh_kids_kw/_index.scss
+++ b/src/theme/themes/plh_kids_kw/_index.scss
@@ -112,6 +112,7 @@
       text-bubble-border-color-3: var(--ion-color-secondary-variant-300),
       text-bubble-background-color-4: var(--ion-color-secondary-50),
       text-bubble-border-color-4: var(--ion-color-secondary-300),
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -364,29 +364,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-secondary-contrast);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_kw/_overrides.scss
+++ b/src/theme/themes/plh_kids_kw/_overrides.scss
@@ -364,6 +364,18 @@
     }
   }
 
+  // Title
+  plh-tmpl-title {
+    .title-wrapper[data-variant~="section_banner"] {
+      font-weight: var(--font-weight-medium) !important;
+      background-color: #e7f2fd;
+      border-bottom: 1px solid var(--ion-color-primary-variant-200);
+    }
+    .title-wrapper[data-variant~="page_banner"] h1 {
+      font-size: var(--font-size-text-extra-large) !important;
+    }
+  }
+
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_my/_index.scss
+++ b/src/theme/themes/plh_kids_teens_my/_index.scss
@@ -153,6 +153,8 @@
       plh-module-list-item-background-1: #a6e9ff,
       plh-module-list-item-background-2: #ffa777,
       plh-module-list-item-background-3: #ffd973,
+
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_kids_teens_my/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_my/_overrides.scss
@@ -367,28 +367,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--color-secondary-blue-80);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_pa/_index.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_index.scss
@@ -113,6 +113,8 @@
       plh-module-list-item-background-1: #a6e9ff,
       plh-module-list-item-background-2: #ffa777,
       plh-module-list-item-background-3: #ffd973,
+
+      title-text-color: var(--ion-color-gray-900),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_kids_teens_pa/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_overrides.scss
@@ -364,29 +364,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--ion-color-gray-900);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--ion-color-primary-variant-200);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-      margin: 15px 0;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_teens_za/_index.scss
+++ b/src/theme/themes/plh_kids_teens_za/_index.scss
@@ -151,6 +151,8 @@
       plh-module-list-item-background-1: #a6e9ff,
       plh-module-list-item-background-2: #ffa777,
       plh-module-list-item-background-3: #ffd973,
+
+      title-text-color: var(--ion-color-primary-shade),
     )
   ) {
     @include overrides.overrides;

--- a/src/theme/themes/plh_kids_teens_za/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_za/_overrides.scss
@@ -367,28 +367,6 @@
     }
   }
 
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      line-height: var(--line-height-text-large);
-      color: var(--color-surface-black);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-medium) !important;
-      background-color: #e7f2fd;
-      border-bottom: 1px solid var(--color-secondary-blue-80);
-      h1 {
-        padding: 18px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-text-extra-large) !important;
-    }
-  }
-
   // Text Area
   plh-text-area {
     .wrapper .text_area {

--- a/src/theme/themes/plh_kids_tz/_overrides.scss
+++ b/src/theme/themes/plh_kids_tz/_overrides.scss
@@ -225,28 +225,7 @@
       }
     }
   }
-  // Title
-  plh-tmpl-title {
-    .title-wrapper h1 {
-      font-size: var(--font-size-text-title);
-      margin: 8px 0;
-      line-height: var(--font-size-title-large);
-    }
-    .title-wrapper[data-variant~="section_banner"] {
-      font-size: var(--font-size-text-large) !important;
-      font-weight: var(--font-weight-bold) !important;
-      background-color: var(--ion-color-primary-50);
-      border-bottom: 1px solid var(--ion-color-primary-300);
-      h1 {
-        padding: 18px 24px;
-        border: none;
-      }
-    }
-    .title-wrapper[data-variant~="page_banner"] h1 {
-      font-size: var(--font-size-title-large) !important;
-      padding: 10px 0;
-    }
-  }
+
   // Progress Path
   plh-progress-path {
     // Fine-tune the position of the child steps to reflect theme image


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
- This PR is a follow-up to #3462. A new `title-text-color` variable has been created to ease theme overrides. The default colour remains `ion-color-primary` but can now be defined in different theme designs without overrides.

## Git Issues

Closes #3460
Closes #3462 

## Screenshots/Videos

| Master Branch | This Branch |
|----------------|-------------|
| <img width="280" src="https://github.com/user-attachments/assets/e59bf3d5-7b80-4522-b68d-18e87e62d9e5" /> | <img width="280" src="https://github.com/user-attachments/assets/666c0cbb-b73a-4f8f-88d1-fc2ceb620aab" /> |
| <img width="280" src="https://github.com/user-attachments/assets/d01ef8c4-790d-4bd0-b9fe-41aa962a671a" /> | <img width="280" src="https://github.com/user-attachments/assets/c5b8f7a9-f905-4b20-8a3e-7e3c37d0507a" />|
| <img width="280" src="https://github.com/user-attachments/assets/3e644ad0-c436-4e74-a805-1d5ad292a9a6" /> | <img width="280" src="https://github.com/user-attachments/assets/23822576-7c4d-4bb0-bf8b-bcf64a13c93e" />|
| <img width="280" src="https://github.com/user-attachments/assets/49f940df-1f8a-4723-be3f-228b2eed00d6" /> | <img width="280" src="https://github.com/user-attachments/assets/1a2ae3b6-c081-4c41-9a5a-e3622ce5f3c9" /> |

