### PR TITLE
fix: remove phantom display-group background when sticky

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -44,6 +44,7 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
 
   ngOnInit() {
     this.getParams();
+    this.makeStickyHostTransparent();
   }
 
   public clickDisplayGroup() {
@@ -83,5 +84,23 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
       "top"
     );
     return { backgroundImage, backgroundPosition };
+  }
+
+  /**
+   * As well as applying to the host element, as with all other components,
+   * display-group styles are intentionally applied on the inner wrapper in the template.
+   * For sticky groups, the dynamic host element can be rendered in a different place to the content,
+   * so host-level background styles (from TemplateComponent.setStyleList) can cause visual issues.
+   * Keep host transparent and preserve authored styling on the inner wrapper.
+   */
+  private makeStickyHostTransparent() {
+    if (!this.params.sticky) return;
+
+    const hostElement = this.parentTemplateComponentRef?.elRef?.nativeElement as
+      | HTMLElement
+      | undefined;
+    if (!hostElement) return;
+    hostElement.style.setProperty("background", "transparent");
+    hostElement.style.setProperty("border", "none");
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where users may see multiple versions of a styled sticky display group. See linked issue for detailed description of the bug. This is a bit of a workaround on top of a hack, but the display group styling implementation is too fragile to fundamentally change.

## Git Issues

Closes #3478

## Screenshots/Videos

Demo of `plh_kids_teens_my` deployment's [onboarding_language_select](https://docs.google.com/spreadsheets/d/1LUIu_aqkzYjyUq0ecQEmWJa62CEvQ4E2L4Fkz_94ydw/edit?gid=1766355281#gid=1766355281). Compare recording with that on linked issue

https://github.com/user-attachments/assets/d533ef04-9b86-4a03-91ab-1ba767c0327e

