### PR TITLE
Refactor `course-accordion` and `sub-item` styling for accessibility

### DIFF
--- a/packages/components/plh/course-accordion/course-accordion.component.scss
+++ b/packages/components/plh/course-accordion/course-accordion.component.scss
@@ -78,11 +78,13 @@
       }
     }
     .course-title-and-progress-bar {
+      display: flex;
+      flex-direction: column;
       width: 100%;
       flex-shrink: 10;
       margin: 0 4px;
       margin-inline-end: auto;
-      padding: var(--regular-padding) 8px;
+      padding: 10px 8px;
       flex: 1 1 12rem;
       min-width: 0;
 
@@ -98,6 +100,7 @@
         flex-shrink: 1;
         width: 100%;
         display: flex;
+        flex-flow: row wrap;
         gap: var(--tiny-padding, 6px);
         align-items: center;
         justify-content: space-between;

--- a/packages/components/plh/course-accordion/course-accordion.component.scss
+++ b/packages/components/plh/course-accordion/course-accordion.component.scss
@@ -4,12 +4,14 @@
 }
 
 .course-accordion-container {
+  container-type: inline-size;
+
   border-radius: var(--ion-border-radius-small);
   background-color: var(--ion-color-primary-50);
   color: var(--ion-color-primary-800);
   letter-spacing: var(--font-letter-spacing, 0);
   width: 100%;
-  height: 100%;
+  height: auto;
 
   &[data-state="locked"] {
     pointer-events: none;
@@ -81,6 +83,8 @@
       margin: 0 4px;
       margin-inline-end: auto;
       padding: var(--regular-padding) 8px;
+      flex: 1 1 12rem;
+      min-width: 0;
 
       .course-title {
         font-size: var(--font-size-text-medium, 20px);
@@ -101,7 +105,7 @@
         margin-bottom: 4px;
         --task-progress-bar-color: var(--ion-color-primary-700);
         --task-progress-bar-background-color: white;
-        --task-progress-bar-height: 5px;
+        --task-progress-bar-height: 6px;
         plh-task-progress-bar {
           width: 100%;
         }
@@ -146,6 +150,23 @@
       color: var(--ion-color-gray-800);
       margin: 0 0 8px 0;
       padding: 0;
+    }
+  }
+
+  @container (max-width: 320px) {
+    .course-button {
+      padding: 0px;
+      .course-image {
+        display: none;
+      }
+      .course-title-and-progress-bar {
+        .progress-bar-container {
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-start;
+          align-items: flex-start;
+        }
+      }
     }
   }
 }

--- a/packages/components/plh/course-accordion/course-sub-item/course-sub-item.component.scss
+++ b/packages/components/plh/course-accordion/course-sub-item/course-sub-item.component.scss
@@ -4,10 +4,12 @@
 
 .course-sub-item {
   cursor: pointer;
+  container-type: inline-size;
 
   width: 100%;
-  min-height: 56px;
+  min-height: 3.5rem;
   display: flex;
+  flex-flow: row wrap;
   justify-content: space-between;
   align-items: center;
   text-align: left;
@@ -23,6 +25,8 @@
     font-weight: 500;
     letter-spacing: var(--font-letter-spacing, 0);
     margin-inline-end: 6px;
+    flex: 1 1 8rem;
+    min-width: 0;
   }
 
   .state-container {
@@ -35,13 +39,13 @@
       padding: 2px 8px;
       border-style: solid;
       border-width: 1px;
-      border-radius: var(--ion-border-radius-rounded, 100%);
+      border-radius: var(--ion-border-radius-rounded, 50px);
       p {
         margin: 0;
       }
     }
     ion-icon {
-      font-size: var(--icon-size-tiny, 24px);
+      font-size: var(--icon-size-tiny, 1.8rem);
       --ionicon-stroke-width: 42px;
     }
   }
@@ -85,6 +89,14 @@
       }
       ion-icon {
         color: var(--ion-color-gray-700);
+      }
+    }
+  }
+
+  @container (max-width: 320px) {
+    .state-container {
+      ion-icon {
+        font-size: 2rem;
       }
     }
   }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description
- The `course-accordion` now wraps under extreme scaling such that the inner elements remain accessible on devices with large displays. 
- The progress container also wraps into a column by default to give the `progress-loader` more space to stretch in whatever situation. If that is not a desired design decision, then we would have to set defined widths for the loader and text/ use container sizing in media queries.
- The `course-image` is hidden for larger display sizes or screens with small widths (>300px).

## Git Issues

Closes #3476 

## Screenshots/Videos
The app was tested in an emulator under varying constraints.

| Constraints | Screen |
|------------|---------|
| Large Display size, Large Font Size | <img width="160" src="https://github.com/user-attachments/assets/2ba8602b-aa7a-4861-96c5-ded447597230" /> <img width="166" src="https://github.com/user-attachments/assets/f369ec26-00d0-4ace-91f8-24ef4b5596e9" /> <img width="166" src="https://github.com/user-attachments/assets/61aab908-a1ca-48bf-8cc3-b13638d79062" />|
| Medium Display size, Large Font Size | <img width="160" src="https://github.com/user-attachments/assets/4e55dbdd-bbc8-40ae-99f0-85ccc36d7433" /> <img width="160" src="https://github.com/user-attachments/assets/32b62a18-6c7e-4d6b-bad7-72944aba895b" /> <img width="160" src="https://github.com/user-attachments/assets/70b7f257-5c00-4334-8242-701af644aeff" />|
| Small Display size, Medium Font Size | <img width="180" src="https://github.com/user-attachments/assets/68b92ffc-a8f8-4b7c-a048-b7e0d8c33663" /> <img width="180" src="https://github.com/user-attachments/assets/7f3acb06-bc1b-4275-a739-3700ae9be275" />|
