### PR TITLE
chore: expose 'wrap' param on display-group component

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.html
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.html
@@ -23,6 +23,7 @@
     [attr.data-param-style]="params.style"
     [attr.data-rowname]="_row.name"
     [attr.data-variant]="params.variant"
+    [attr.data-wrap]="params.wrap"
     [style.marginBottom.px]="params.offset"
     [style]="_row.style_list | styleList"
     [ngStyle]="backgroundImageStyles"

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -21,7 +21,8 @@
   height: unset;
   width: 100%;
 }
-.display-group-wrapper[data-param-style~="wrap"] {
+.display-group-wrapper[data-param-style~="wrap"],
+.display-group-wrapper[data-wrap="true"] {
   flex-wrap: wrap;
 }
 // assign default background colour to the display group wrapper (useful in sticky group)

--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.ts
@@ -1,6 +1,10 @@
 import { Component, OnInit } from "@angular/core";
 import { TemplateBaseComponent } from "../../base";
-import { getNumberParamFromTemplateRow, getStringParamFromTemplateRow } from "../../../../../utils";
+import {
+  getBooleanParamFromTemplateRow,
+  getNumberParamFromTemplateRow,
+  getStringParamFromTemplateRow,
+} from "../../../../../utils";
 import { NgStyle } from "@angular/common";
 import { TemplateAssetService } from "../../../services/template-asset.service";
 
@@ -23,6 +27,8 @@ interface IDisplayGroupParams {
   backgroundImagePosition: string;
   /** TEMPLATE PARAMETER: "sticky". Set to "top" or "bottom" to make the display group a sticky inline header/footer */
   sticky: "top" | "bottom" | null;
+  /** TEMPLATE PARAMETER: "wrap". If true, content will wrap over multiple lines if there is not enough space */
+  wrap: boolean;
 }
 
 @Component({
@@ -59,6 +65,7 @@ export class TmplDisplayGroupComponent extends TemplateBaseComponent implements 
       .join(" ")
       .concat(" " + this.params.style) as IDisplayGroupParams["variant"];
     this.params.sticky = getStringParamFromTemplateRow(this._row, "sticky", null) as any;
+    this.params.wrap = getBooleanParamFromTemplateRow(this._row, "wrap", false);
     this.type = this.getTypeFromStyles();
     this.backgroundImageStyles = this.getBackgroundImageStyles();
   }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a new parameter on the display group component, `wrap`. This takes a boolean value (default `false` to preserve existing behaviour), which, if true, causes the display group contents to wrap over multiple lines in the case that the content would otherwise overflow.

## Author notes

This behaviour was actually already possible to author, either via the `style_list` or via an (undocumented) value for the `style` param, `style: flex`. Exposing as a dedicated component parameter instead seems appropriate.

Managing when child elements should themselves reduce in size (e.g. text wrapping within a button) vs the elements wrapping onto a new line is tricky (even in base-level CSS, putting aside exposing options to authors). There can be no general solution since it isn't uniquely determined how the elements should behave. Therefore the current tools used, e.g. setting `flex: 1` in a component's style list, should still be used to fine tune this behaviour for a given use case.

For similar reasons, I decided against making the wrapping behaviour default, as this would almost certainly cause visual knock-ons for existing production deployments.

## Dev notes

I had originally planned to refactor some of the display group code, starting with the param handling to use the zod-based approach. However even this proved to be complex due to the tangled nature of the existing display group code and the many intersecting visual variations that can be applied. Whilst this refactor probably wouldn't have caused issues, it would be very difficult to test all the existing use cases currently in production, and additionally one of the major advantages of the zod-based approach (dynamic runtime param changes) is unlikely to be useful for the display group component in particular. Therefore, I abandoned these attempts, and think we should instead focus on fleshing out the features of the new "reactive" rewrite display group component added in #3461.

## Git Issues

Relates to https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-my-content/issues/189 and #3477

## Screenshots/Videos

[debug_display_group_wrap](https://docs.google.com/spreadsheets/d/1XOknY8BZoaGcKhme-kzsKS6yiiTsc7iU4PBKclnsKcU/edit?gid=1422144003#gid=1422144003):

<img width="640" alt="Screenshot 2026-05-11 at 12 36 39" src="https://github.com/user-attachments/assets/0d6ff48d-f77a-4bc6-a2cb-ba5b62382b40" />

(note that in the production example, only row 9 has been updated vs its equivalent in [onboarding_settings_page_7](https://docs.google.com/spreadsheets/d/1aUwbR38bDjfGwoFG1DaHaRejyoCbFGhyFOZ0lVJmOks/edit?gid=1684597844#gid=1684597844))


Behaviour on web, demonstrating small screen sizes:


https://github.com/user-attachments/assets/4f913347-91e8-4a97-8529-bcf9ea8305e1



Demo on Android, with accessibility large display settings set to extreme:

<img width="376" height="822" alt="Screenshot 2026-05-11 at 12 17 56" src="https://github.com/user-attachments/assets/08168f2d-cf06-4b2a-a016-07088a657083" />
