### PR TITLE
fix!: preserve snake_case keys in nested parameter values

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box-meta-badge.config.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box-meta-badge.config.ts
@@ -1,5 +1,4 @@
 import { IAnswerOption } from "src/app/shared/utils";
-import { snakeToCamel } from "../../utils";
 
 /** Fallback values when a field is missing on an answer option (not default key names). */
 export const OPTION_META_BADGE_VALUE_DEFAULTS = {
@@ -21,7 +20,7 @@ export function resolveOptionMetaBadgeColor(
 ): string {
   if (!cfg.colorKey.trim()) return cfg.valueDefaults.color;
 
-  const raw = rawOptionFieldForMetaBadgeKey(option, cfg.colorKey);
+  const raw = option[cfg.colorKey];
   return raw != null && raw !== "" ? String(raw) : cfg.valueDefaults.color;
 }
 
@@ -31,15 +30,6 @@ export function resolveOptionMetaBadgeText(
 ): string {
   if (!cfg.textKey.trim()) return cfg.valueDefaults.text;
 
-  const raw = rawOptionFieldForMetaBadgeKey(option, cfg.textKey);
+  const raw = option[cfg.textKey];
   return raw != null && raw !== "" ? String(raw) : cfg.valueDefaults.text;
-}
-
-/**
- * HACK: Prefer exact key, then camelCase variant — answer list keys may be normalized to camelCase
- * by the zod parser when answer_list is passed in directly (not via data_items child rows).
- * TODO: update parser logic?
- */
-function rawOptionFieldForMetaBadgeKey(option: IAnswerOption, key: string): unknown {
-  return option[key] || option[snakeToCamel(key)];
 }

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -3,7 +3,6 @@ import { ModalController } from "@ionic/angular";
 import { ComboBoxModalComponent } from "./combo-box-modal/combo-box-modal.component";
 import { IAnswerOption } from "src/app/shared/utils";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
-import { snakeToCamel } from "../../utils";
 import { ReplaySubject, map, filter, switchMap } from "rxjs";
 import { DataItemsService } from "../data-items/data-items.service";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.html
@@ -1,9 +1,9 @@
 <div class="navigation-bar-wrapper" [attr.data-variant]="params().variant">
   <div class="nav-items">
-    @for (button of params().buttonList; track button.targetTemplate) {
+    @for (button of params().buttonList; track button.target_template) {
       <a
         class="button-wrapper"
-        [routerLink]="'template/' + button.targetTemplate"
+        [routerLink]="'template/' + button.target_template"
         [attr.data-name]="button.name"
         [class.active-link]="$index === activeLinkIndex()"
       >

--- a/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
+++ b/src/app/shared/components/template/components/navigation-bar/navigation-bar.component.ts
@@ -28,7 +28,7 @@ export class TmplNavigationBarComponent extends TemplateBaseComponentWithParams(
 
   private templateMetaService = inject(TemplateMetadataService);
 
-  private targetTemplates = computed(() => this.params().buttonList.map((v) => v.targetTemplate));
+  private targetTemplates = computed(() => this.params().buttonList.map((v) => v.target_template));
 
   constructor() {
     super();

--- a/src/app/shared/components/template/utils/parameter-list.utils.spec.ts
+++ b/src/app/shared/components/template/utils/parameter-list.utils.spec.ts
@@ -249,9 +249,6 @@ describe("parameter_list utils - parse", () => {
   });
 
   it("preserves snake_case keys within nested object/array values", () => {
-    // Top-level keys are converted to camelCase but values (including nested object keys
-    // and array element keys) are left untouched so that authors can use snake_case
-    // properties inside e.g. answer_list options without them being silently rewritten.
     const result = parseTemplateParameterList(
       {
         any_param: { nested_key: "value", another_nested: { deep_key: 1 } },

--- a/src/app/shared/components/template/utils/parameter-list.utils.spec.ts
+++ b/src/app/shared/components/template/utils/parameter-list.utils.spec.ts
@@ -248,6 +248,24 @@ describe("parameter_list utils - parse", () => {
     });
   });
 
+  it("preserves snake_case keys within nested object/array values", () => {
+    // Top-level keys are converted to camelCase but values (including nested object keys
+    // and array element keys) are left untouched so that authors can use snake_case
+    // properties inside e.g. answer_list options without them being silently rewritten.
+    const result = parseTemplateParameterList(
+      {
+        any_param: { nested_key: "value", another_nested: { deep_key: 1 } },
+        object_array_param: [{ key1: "a", extra_snake_key: "preserved" }],
+      } as any,
+      schema
+    );
+    expect(result.anyParam).toEqual({
+      nested_key: "value",
+      another_nested: { deep_key: 1 },
+    });
+    expect(result.objectArrayParam).toEqual([{ key1: "a", extra_snake_key: "preserved" }] as any);
+  });
+
   it("warns if invalid keys passed from parameter_list", () => {
     const consoleSpy = spyOn(console, "warn");
     parseTemplateParameterList({ invalid_key: "value" }, schema);

--- a/src/app/shared/components/template/utils/parameter-list.utils.ts
+++ b/src/app/shared/components/template/utils/parameter-list.utils.ts
@@ -212,20 +212,18 @@ export function parseTemplateParameterList<T extends z.ZodObject<any, any>>(
 
   // NOTE - should not throw as all coerce methods include own catch
   const parsed = schema.parse(parameterList);
-  // Transform snake_case to camelCase. This will keep type-safety following conversion
-  return snakeToCamelKeys(parsed);
+  // Transform snake_case to camelCase. This will keep type-safety following conversion.
+  // NOTE - only top-level keys are converted; nested object/array values are left untouched
+  // so that authors can use snake_case keys within e.g. answer_list options without them being
+  // silently rewritten.
+  return snakeToCamelTopLevelKeys(parsed);
 }
 
-/** Convert all keys in an object from snake_case to camelCase */
-function snakeToCamelKeys<T>(obj: T): ISnakeToCamelKeys<T> {
-  if (Array.isArray(obj)) {
-    return obj.map((v) => snakeToCamelKeys(v)) as ISnakeToCamelKeys<T>;
-  } else if (obj && typeof obj === "object" && obj.constructor === Object) {
-    return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), snakeToCamelKeys(v)])
-    ) as ISnakeToCamelKeys<T>;
-  }
-  return obj as ISnakeToCamelKeys<T>;
+/** Convert top-level keys of an object from snake_case to camelCase (values left untouched) */
+function snakeToCamelTopLevelKeys<T extends object>(obj: T): ISnakeToCamelKeys<T> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [snakeToCamel(k), v])
+  ) as ISnakeToCamelKeys<T>;
 }
 
 export function snakeToCamel(str: string): string {
@@ -247,12 +245,10 @@ type SnakeToCamel<S extends string> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamel<U>>}`
   : S;
 
-// type inference when converting all keys in an object from snake_case to camelCase
-type ISnakeToCamelKeys<T> =
-  T extends Array<infer U>
-    ? ISnakeToCamelKeys<U>[]
-    : T extends object
-      ? {
-          [K in keyof T as K extends string ? SnakeToCamel<K> : K]: ISnakeToCamelKeys<T[K]>;
-        }
-      : T;
+// type inference when converting top-level keys in an object from snake_case to camelCase
+// (nested values are left as-is, mirroring the runtime behavior of `snakeToCamelTopLevelKeys`)
+type ISnakeToCamelKeys<T> = T extends object
+  ? {
+      [K in keyof T as K extends string ? SnakeToCamel<K> : K]: T[K];
+    }
+  : T;

--- a/src/app/shared/components/template/utils/parameter-list.utils.ts
+++ b/src/app/shared/components/template/utils/parameter-list.utils.ts
@@ -212,10 +212,8 @@ export function parseTemplateParameterList<T extends z.ZodObject<any, any>>(
 
   // NOTE - should not throw as all coerce methods include own catch
   const parsed = schema.parse(parameterList);
-  // Transform snake_case to camelCase. This will keep type-safety following conversion.
-  // NOTE - only top-level keys are converted; nested object/array values are left untouched
-  // so that authors can use snake_case keys within e.g. answer_list options without them being
-  // silently rewritten.
+  // Only top-level keys are converted so that authors can use snake_case keys within nested values
+  // (e.g. answer_list option fields) without them being silently rewritten.
   return snakeToCamelTopLevelKeys(parsed);
 }
 
@@ -245,8 +243,7 @@ type SnakeToCamel<S extends string> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamel<U>>}`
   : S;
 
-// type inference when converting top-level keys in an object from snake_case to camelCase
-// (nested values are left as-is, mirroring the runtime behavior of `snakeToCamelTopLevelKeys`)
+// Converts top-level snake_case keys to camelCase; values (including nested object keys) are unchanged.
 type ISnakeToCamelKeys<T> = T extends object
   ? {
       [K in keyof T as K extends string ? SnakeToCamel<K> : K]: T[K];


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

For components that use the modern zod-based params parsing, the logic for parsing parameter lists was recursively converting all object keys from snake_case to camelCase, including keys inside nested values such as `answer_list` option fields (an answer list may be defined in a data list, for example, and use custom column names for the fields that contain each options identifier and display text). This required a HACK in the combo-box component logic that had to look up each key under both its original and camelCase form.

These changes are marked as breaking since in theory it may have previously been possible for authors to access nested snake_case keys on objects they pass to parameters using camelCase – in the context of components that take an answer_list object param. However, there should be no such cases of this.

## Dev Notes
- Changed `snakeToCamelKeys` to a shallow `snakeToCamelTopLevelKeys` that only converts the top-level param keys (e.g. `button_list` → `buttonList`), leaving nested object/array contents untouched. Updated the `ISnakeToCamelKeys` type to match.
- Added a test asserting that nested keys are preserved

Knock-on changes:

- Removed the `rawOptionFieldForMetaBadgeKey` HACK from `combo-box-meta-badge.config.ts`
- Updated navigation-bar to access `button.target_template` instead of `button.targetTemplate` (nested keys are no longer rewritten)
  - This is the only case in the code of directly referring to these nested param keys

## Git Issues

Closes #

## Screenshots/Videos

[comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329) updated with example that uses a snake_case key identifier, which should be unaffected by the changes

<img width="345" height="705" alt="Screenshot 2026-06-01 at 15 43 53" src="https://github.com/user-attachments/assets/169d1958-c272-4596-95f4-7dfb612a1d0c" />
