### PR TITLE
feat(toast action): expose duration param

### DIFF
--- a/src/app/shared/services/toast/toast.service.ts
+++ b/src/app/shared/services/toast/toast.service.ts
@@ -12,10 +12,8 @@ interface IToastActionParams {
    */
   duration?: "short" | "long";
   /**
-   * On Android 12 and newer, all toasts are always shown at the bottom regardless of this value.
-   * @default 'bottom'
+   * The Capacitor Toast API also exposes a 'position' parameter, but it is not supported on web or newer Android versions, so should not be used.
    */
-  position?: "bottom" | "center" | "top";
 }
 
 @Injectable({
@@ -46,7 +44,6 @@ export class ToastService extends SyncServiceBase {
         await Toast.show({
           text: params.message,
           duration: params.duration,
-          position: params.position,
         });
       }
     } catch (error) {

--- a/src/app/shared/services/toast/toast.service.ts
+++ b/src/app/shared/services/toast/toast.service.ts
@@ -5,6 +5,17 @@ import { TemplateActionRegistry } from "../../components/template/services/insta
 
 interface IToastActionParams {
   message?: string;
+  /**
+   * Either 'short' (2000ms) or 'long' (3500ms).
+   * Arbitrary ms values are not supported by the Capacitor API (a restriction of the native platforms).
+   * @default 'short'
+   */
+  duration?: "short" | "long";
+  /**
+   * On Android 12 and newer, all toasts are always shown at the bottom regardless of this value.
+   * @default 'bottom'
+   */
+  position?: "bottom" | "center" | "top";
 }
 
 @Injectable({
@@ -34,6 +45,8 @@ export class ToastService extends SyncServiceBase {
       if (params.message) {
         await Toast.show({
           text: params.message,
+          duration: params.duration,
+          position: params.position,
         });
       }
     } catch (error) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Exposes a new param on the `toast` action: `duration`. This can take values "short" or "long" (default "short"). Specific ms values are not supported, this is a limitation of the underlying native APIs that Capacitor exposes.

The [Capacitor Toast API](https://capacitorjs.com/docs/apis/toast) exposes an additional param, `position`. However, this is explicitly not supported on Android 12+, and from testing is also not supported in browser (tested on latest Chrome version). Therefore I have not exposed this param as it cannot be relied upon cross-platform.

## Git Issues

Closes #

## Screenshots/Videos

[feature_action_toast](https://docs.google.com/spreadsheets/d/1WGR_pxk-7iBHKX2BDdzdmjiaVjiwe-qKIou47uZFqHo/edit?gid=99275306#gid=99275306):


<img width="552" height="702" alt="Screenshot 2026-05-19 at 12 38 03" src="https://github.com/user-attachments/assets/f4d26d60-6634-4e06-b721-28c55aace742" />
