### PR TITLE
fix: audio player duration display in half-hour timezones

### DIFF
--- a/packages/shared/src/utils/string-utils.spec.ts
+++ b/packages/shared/src/utils/string-utils.spec.ts
@@ -1,6 +1,35 @@
-import { basenameFromExternalUrl, isExternalHttpUrl, parseStringValue } from "./string-utils";
+import {
+  basenameFromExternalUrl,
+  formatDurationMmSs,
+  isExternalHttpUrl,
+  parseStringValue,
+} from "./string-utils";
 
+/** yarn workspace shared test --include packages/shared/src/utils/string-utils.spec.ts */
 describe("string-utils", () => {
+  describe("formatDurationMmSs", () => {
+    it("formats whole minutes and seconds", () => {
+      expect(formatDurationMmSs(125)).toBe("02:05");
+    });
+
+    it("zero-pads single-digit values", () => {
+      expect(formatDurationMmSs(61)).toBe("01:01");
+      expect(formatDurationMmSs(9)).toBe("00:09");
+    });
+
+    it("shows total minutes beyond 59 without wrapping", () => {
+      expect(formatDurationMmSs(3661)).toBe("61:01");
+    });
+
+    it("returns 00:00 for zero", () => {
+      expect(formatDurationMmSs(0)).toBe("00:00");
+    });
+
+    it("truncates fractional seconds", () => {
+      expect(formatDurationMmSs(61.9)).toBe("01:01");
+    });
+  });
+
   describe("isExternalHttpUrl", () => {
     it("returns true for http and https URLs", () => {
       expect(isExternalHttpUrl("https://example.com/file.png")).toBe(true);

--- a/packages/shared/src/utils/string-utils.spec.ts
+++ b/packages/shared/src/utils/string-utils.spec.ts
@@ -28,6 +28,12 @@ describe("string-utils", () => {
     it("truncates fractional seconds", () => {
       expect(formatDurationMmSs(61.9)).toBe("01:01");
     });
+
+    it("returns 00:00 for non-finite or negative values", () => {
+      expect(formatDurationMmSs(NaN)).toBe("00:00");
+      expect(formatDurationMmSs(Infinity)).toBe("00:00");
+      expect(formatDurationMmSs(-1)).toBe("00:00");
+    });
   });
 
   describe("isExternalHttpUrl", () => {

--- a/packages/shared/src/utils/string-utils.ts
+++ b/packages/shared/src/utils/string-utils.ts
@@ -55,6 +55,16 @@ export function isExternalHttpUrl(value: string): boolean {
 }
 
 /**
+ * Format a duration in seconds as "mm:ss".
+ * Handles durations ≥ 1 hour by showing total minutes (e.g. 65:04).
+ */
+export function formatDurationMmSs(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = Math.floor(totalSeconds % 60);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+/**
  * Last path segment of an http(s) URL, sanitized for use as a filename.
  * @returns undefined if the URL is invalid or has no usable path segment.
  */

--- a/packages/shared/src/utils/string-utils.ts
+++ b/packages/shared/src/utils/string-utils.ts
@@ -59,6 +59,9 @@ export function isExternalHttpUrl(value: string): boolean {
  * Handles durations ≥ 1 hour by showing total minutes (e.g. 65:04).
  */
 export function formatDurationMmSs(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+    return "00:00";
+  }
   const m = Math.floor(totalSeconds / 60);
   const s = Math.floor(totalSeconds % 60);
   return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;

--- a/src/app/shared/components/template/components/audio/audio.component.html
+++ b/src/app/shared/components/template/components/audio/audio.component.html
@@ -41,16 +41,17 @@
       <div class="time">
         @if (params().variant.includes("large")) {
           <div class="time-value">
-            {{ progressSeconds() * 1000 | date: "mm:ss" }}
+            {{ formatDurationMmSs(progressSeconds()) }}
           </div>
           <div class="time-value">
-            {{ durationSeconds() * 1000 | date: "mm:ss" }}
+            {{ formatDurationMmSs(durationSeconds()) }}
           </div>
         } @else {
           <div class="time-value">
             {{
-              (hasEnded() || !hasStarted() ? durationSeconds() : progressSeconds()) * 1000
-                | date: "mm:ss"
+              formatDurationMmSs(
+                hasEnded() || !hasStarted() ? durationSeconds() : progressSeconds()
+              )
             }}
           </div>
         }

--- a/src/app/shared/components/template/components/audio/audio.component.ts
+++ b/src/app/shared/components/template/components/audio/audio.component.ts
@@ -4,6 +4,7 @@ import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "..
 import { ModalController } from "@ionic/angular";
 import { TemplatePopupComponent } from "../layout/popup/popup.component";
 import { TemplateAssetService } from "../../services/template-asset.service";
+import { formatDurationMmSs } from "packages/shared/src/utils/string-utils";
 
 // Names of ion-icons to be used by default in the player.
 // Will be overridden if user provides values for play_icon_asset, pause_icon_asset or forward_icon_asset
@@ -75,6 +76,8 @@ export class TmplAudioComponent
   hasEnded = signal(false);
   /** @ignore */
   trackerInterval: NodeJS.Timeout;
+  /** Utility function to format duration in "mm:ss" format */
+  public formatDurationMmSs = formatDurationMmSs;
   /** Track any opened transcript modal to close on destroy */
   private transcriptModal: HTMLIonModalElement;
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the displayed duration of audio files supplied to the audio component would be wrong in some timezones.

## Dev notes

> Problem
> The audio player used Angular's date pipe to format playback durations (e.g. durationSeconds() * 1000 | date: "mm:ss"). The date pipe treats its input as a Unix timestamp and applies the device's local timezone offset, so users in timezones with a fractional-hour offset (e.g. IST UTC+5:30) saw incorrect durations — a 31-second clip would display as 30:31 instead of 00:31.
> 
> Solution
> Replaced the date pipe with a dedicated formatDurationMmSs utility function added to packages/shared/src/utils/string-utils.ts. It uses plain arithmetic (Math.floor) with no date/timezone involvement, and correctly handles durations ≥ 1 hour by showing total minutes rather than wrapping (e.g. 65:04 instead of 05:04). Tests added to string-utils.spec.ts.

## Git Issues

Closes #3504

## Screenshots/Videos

[comp_audio](https://docs.google.com/spreadsheets/d/1utD4Kr0WVjvDwnMbg2wYupaPQ0VY0H2csb86fyi4bPI/edit?gid=603128459#gid=603128459) showing expected values (contrast with screenshot in linked issue)

<img width="1000" alt="Screenshot 2026-05-19 at 13 35 13" src="https://github.com/user-attachments/assets/aa584fc0-8a9b-4fac-9b0e-b623e91145af" />

