### PR TITLE
fix: restore set_data operators reverted by ios-button-styles merge

### DIFF
--- a/packages/workflows/src/deployment.workflows.ts
+++ b/packages/workflows/src/deployment.workflows.ts
@@ -70,7 +70,7 @@ const workflows: IDeploymentWorkflows = {
             function: async ({ tasks, args, options }) => {
               // Set Env var for encryption provider to pick up later
               if (options.privateKey) {
-                process.env.DEPLOYMENT_PRIVATE_KEY = options.privateKey;
+                process.env.DEPLOYMENT_PRIVATE_KEY = options.privateKey as string;
               }
               // Pass options (including acceptDefaults flag) to the task
               return tasks.deployment.import(options, args[0]);

--- a/src/app/shared/components/template/processors/itemPipe.spec.ts
+++ b/src/app/shared/components/template/processors/itemPipe.spec.ts
@@ -1,1 +1,56 @@
-// TODO - add spec test
+import { ItemDataPipe } from "./itemPipe";
+
+// yarn ng test --include src/app/shared/components/template/processors/itemPipe.spec.ts
+
+const TEST_ITEMS = () => [
+  { id: "a", value: 3 },
+  { id: "b", value: 1 },
+  { id: "c", value: 2 },
+];
+
+describe("ItemDataPipe", () => {
+  let pipe: ItemDataPipe;
+
+  beforeEach(() => {
+    pipe = new ItemDataPipe();
+  });
+
+  it("filter - returns items matching expression", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "filter", arg: "this.item.value > 1" }]);
+    expect(result.map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("filter - returns empty array when no items match", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "filter", arg: "this.item.value > 10" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("filter - returns items unchanged when expression is empty", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "filter", arg: "" }]);
+    expect(result).toEqual(TEST_ITEMS());
+  });
+
+  it("sort - sorts items by field ascending", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "sort", arg: "value" }]);
+    expect(result.map((r) => r.value)).toEqual([1, 2, 3]);
+  });
+
+  it("reverse - reverses item order", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "reverse" }]);
+    expect(result.map((r) => r.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("limit - returns first n items", () => {
+    const result = pipe.process(TEST_ITEMS(), [{ name: "limit", arg: "2" }]);
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("applies multiple operations in sequence", () => {
+    // sort ascending then limit 2 → lowest two values
+    const result = pipe.process(TEST_ITEMS(), [
+      { name: "sort", arg: "value" },
+      { name: "limit", arg: "2" },
+    ]);
+    expect(result.map((r) => r.value)).toEqual([1, 2]);
+  });
+});

--- a/src/app/shared/components/template/processors/itemPipe.ts
+++ b/src/app/shared/components/template/processors/itemPipe.ts
@@ -32,7 +32,8 @@ export class ItemDataPipe {
       expression: string,
       contextVariables: FlowTypes.IDynamicContext = {}
     ) => {
-      if (!expression) return;
+      // No expression is a no-op; return items so subsequent operations receive a valid array
+      if (!expression) return items;
       return items.filter((item) => {
         // NOTE - expects all non-item condition to be evaluated
         // e.g. `@item.field > @local.some_value` already be evaluated to `this.item.field > "local value"`

--- a/src/app/shared/services/dynamic-data/actions/set_data.action.spec.ts
+++ b/src/app/shared/services/dynamic-data/actions/set_data.action.spec.ts
@@ -186,6 +186,45 @@ describe("set_data Action", () => {
   });
 
   /*************************************************************
+   *  Operators
+   ************************************************************/
+
+  it("set_data with _filter only updates matching items", async () => {
+    const params: IActionSetDataParams = { _filter: "@item.number > 0", string: "updated" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("hello"); // id_0 (number=0) excluded by filter
+    expect(data[1].string).toEqual("updated"); // id_1 (number=1) included by filter
+  });
+
+  it("set_data with _limit only updates first n items", async () => {
+    const params: IActionSetDataParams = { _limit: 1, string: "updated" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("updated");
+    expect(data[1].string).toEqual("hello");
+  });
+
+  it("set_data with _reverse updates items in reversed order via _index", async () => {
+    // After reverse, index 0 is the last original item (id_1)
+    const params: IActionSetDataParams = { _reverse: true, _index: 0, string: "updated" };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("hello"); // id_0 is now at index 1
+    expect(data[1].string).toEqual("updated"); // id_1 is now at index 0
+  });
+
+  it("set_data with _sort affects which item is targeted by _index", async () => {
+    // Sorted descending (sort by number then reverse), index 0 = id_1 (number=1)
+    const params: IActionSetDataParams = {
+      _sort: "number",
+      _reverse: true,
+      _index: 0,
+      string: "updated",
+    };
+    const data = await triggerTestSetDataAction(service, params);
+    expect(data[0].string).toEqual("hello"); // id_0 (number=0) is at index 1 after desc sort
+    expect(data[1].string).toEqual("updated"); // id_1 (number=1) is at index 0 after desc sort
+  });
+
+  /*************************************************************
    *  Quality Control
    ************************************************************/
 
@@ -206,6 +245,32 @@ describe("set_data Action", () => {
     };
     await expectAsync(triggerTestSetDataAction(service, params)).toBeRejectedWithError(
       `[Update Fail] no doc exists\ndata_list: test_flow\n_index: 10`
+    );
+  });
+
+  it("throws error with operator context when _index is out of range after filtering", async () => {
+    const params: IActionSetDataParams = {
+      _filter: "@item.number > 100", // matches nothing
+      _index: 0,
+      string: "updated",
+    };
+    // Error should mention the active operators and the post-operator count
+    await expectAsync(triggerTestSetDataAction(service, params)).toBeRejectedWithError(
+      /post-operator count: 0/
+    );
+  });
+
+  it("throws error when _limit is negative", async () => {
+    const params: IActionSetDataParams = { _limit: -1, string: "updated" };
+    await expectAsync(triggerTestSetDataAction(service, params)).toBeRejectedWithError(
+      /invalid _limit/
+    );
+  });
+
+  it("throws error when _limit is not an integer", async () => {
+    const params: IActionSetDataParams = { _limit: 1.5, string: "updated" };
+    await expectAsync(triggerTestSetDataAction(service, params)).toBeRejectedWithError(
+      /invalid _limit/
     );
   });
 });

--- a/src/app/shared/services/dynamic-data/actions/set_data.action.ts
+++ b/src/app/shared/services/dynamic-data/actions/set_data.action.ts
@@ -7,10 +7,9 @@ import {
   evaluateDynamicDataUpdate,
   isItemChanged,
 } from "../dynamic-data.utils";
+import { ItemDataPipe } from "../../../components/template/processors/itemPipe";
 
 interface IActionSetDataOperatorParams {
-  // TODO - ideally use same itemPipe operators
-  // (although filter will need to be updated to include dynamic context)
   _filter?: string;
   _limit?: number;
   _reverse?: boolean;
@@ -56,7 +55,7 @@ export default async (service: DynamicDataService, params: IActionSetDataParams)
 
 async function generateUpdateList(service: DynamicDataService, params: IActionSetDataParams) {
   // remove metadata from rest of update
-  const { _id, _index, _list_id, _updates, ...update } = params;
+  const { _id, _index, _list_id, _updates, _filter, _limit, _reverse, _sort, ...update } = params;
   const query: MangoQuery = {};
   if (_id) {
     query.selector = { id: _id };
@@ -67,11 +66,20 @@ async function generateUpdateList(service: DynamicDataService, params: IActionSe
     const msg = `[Update Fail] no doc exists\ndata_list: ${_list_id}\n_id: ${_id}`;
     throw new Error(msg);
   }
+  const operators = { _filter, _limit, _reverse, _sort };
+  items = applyOperators(items, operators);
   // NOTE - RXDB doesn't support querying by index or pagination so still retrieve all and then reduce
   if (typeof _index === "number") {
     const targetItem = items[_index];
     if (!targetItem) {
-      const msg = `[Update Fail] no doc exists\ndata_list: ${_list_id}\n_index: ${_index}`;
+      let msg = `[Update Fail] no doc exists\ndata_list: ${_list_id}\n_index: ${_index}`;
+      // Include operator context so an _index miss caused by filter/limit is diagnosable
+      const activeOps = Object.fromEntries(
+        Object.entries(operators).filter(([, v]) => v !== undefined && v !== false)
+      );
+      if (Object.keys(activeOps).length > 0) {
+        msg += `\noperators: ${JSON.stringify(activeOps)}\npost-operator count: ${items.length}`;
+      }
       throw new Error(msg);
     }
     items = [items[_index]];
@@ -80,6 +88,32 @@ async function generateUpdateList(service: DynamicDataService, params: IActionSe
   const schema = await service.getSchema("data_list", _list_id);
 
   return parseUpdateData(schema, update, items, _list_id);
+}
+
+function applyOperators(
+  items: FlowTypes.Data_listRow[],
+  { _filter, _sort, _reverse, _limit }: IActionSetDataOperatorParams
+) {
+  const operations: { name: string; arg?: string }[] = [];
+  if (_filter) {
+    // Filter expressions are evaluated as JS by ItemDataPipe (via JSEvaluator),
+    // which binds item context to `this`. `hackParseTemplatedParams` un-converts
+    // `this.item` -> `@item` for update value evaluation; re-apply the conversion
+    // here so authors can use the canonical `@item.x` syntax in filter expressions.
+    const filterArg = _filter.replace(/@item/g, "this.item");
+    operations.push({ name: "filter", arg: filterArg });
+  }
+  if (_sort) operations.push({ name: "sort", arg: _sort });
+  if (_reverse) operations.push({ name: "reverse" });
+  if (_limit !== undefined) {
+    const limit = Number(_limit);
+    if (!Number.isInteger(limit) || limit < 0) {
+      throw new Error(`[Set Data] invalid _limit: ${_limit} (must be a non-negative integer)`);
+    }
+    operations.push({ name: "limit", arg: String(limit) });
+  }
+  if (operations.length === 0) return items;
+  return new ItemDataPipe().process(items, operations);
 }
 
 function parseUpdateData(


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

PR #3493 accidentally reverted the `set_data` operator changes from PR #3492 during merge conflict resolution. This PR restores those changes

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
