### PR TITLE
chore: add clarifying comments to remote-asset config properties

### DIFF
--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -86,12 +86,22 @@ export interface IDeploymentRuntimeConfig {
   /** Friendly name used to identify the deployment name */
   name: string;
 
-  /** 3rd party integration for remote asset storage and sync */
+  /**
+   * Remote asset packs (download on device / CDN URLs on web).
+   * Requires the chosen provider to be initialised elsewhere in this config
+   * (`supabase` or `firebase`).
+   */
   remote_assets?: {
-    /** Enable remote asset storage and sync by specifying provider */
     provider: "supabase" | "firebase";
-    /** By convention, this should match the deployment name */
+    /**
+     * Supabase Storage bucket name. Required when `provider` is `"supabase"`.
+     *
+     * Ignored when `provider` is `"firebase"`: the Firebase provider uses
+     * `firebase.config.storageBucket` (and native SDK defaults) instead.
+     * A value may still be set for consistency or future sync tooling.
+     */
     bucketName: string;
+    /** Path prefix inside the bucket for all remote asset files (both providers). */
     folderName: string;
   };
 

--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -100,7 +100,7 @@ export interface IDeploymentRuntimeConfig {
      * `firebase.config.storageBucket` (and native SDK defaults) instead.
      * A value may still be set for consistency or future sync tooling.
      */
-    bucketName: string;
+    bucketName?: string;
     /** Path prefix inside the bucket for all remote asset files (both providers). */
     folderName: string;
   };

--- a/src/app/shared/services/remote-asset/providers/base.remote-asset.ts
+++ b/src/app/shared/services/remote-asset/providers/base.remote-asset.ts
@@ -21,7 +21,9 @@ export interface IRemoteAssetProvider {
 }
 
 export interface IRemoteAssetConfig {
+  /** Supabase bucket name only; Firebase reads `firebase.config.storageBucket` instead. */
   bucketName: string;
+  /** Prefix prepended to object paths within the bucket (all providers). */
   folderName: string;
 }
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Prompted by https://github.com/IDEMSInternational/open-app-builder/pull/3165#issuecomment-4498656226, adds some clarifying comments to the config properties relating to remote assets, primarily to clarify that the `remote_assets.bucketName` property is only required for supabase configurations, and is ignored for firebase configurations.

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
