### PR TITLE
Deprecate `<meta name="apple-mobile-web-app-capable" content="yes">`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
     <!-- SEO -->


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Description

This PR addresses the console warning 

```
<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. 
Please include <meta name="mobile-web-app-capable" content="yes">
```

which I believe is present on all deployments, see e.g. https://idems-debug.web.app/ and https://plh-teens-tz-uat--pr146-content-1-4-28-wtdpt4ui.web.app/

## Git Issues

Closes #

## Screenshots/Videos

Before:
<img width="1839" height="851" alt="image" src="https://github.com/user-attachments/assets/12e366bb-4146-4dcf-a2be-6970920df054" />

After: 
See preview link
<img width="1813" height="869" alt="image" src="https://github.com/user-attachments/assets/39c42198-92f5-4d8a-b788-f9c0f8612659" />
