### PR TITLE
style(plh_kids_teens_pa theme): show image on module list item component

### DIFF
--- a/src/theme/themes/plh_kids_teens_pa/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_overrides.scss
@@ -607,9 +607,6 @@
           padding: 0px !important;
         }
       }
-      .module-image {
-        display: none !important;
-      }
       &[data-highlighted~="true"] {
         border: none;
         background-color: var(--ion-color-primary-variant-700) !important;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the `plh_kids_teens_pa` imposed a rule to hide the images on the `plh_module_list_item` component

## Git Issues

Closes #

## Screenshots/Videos

Note that these changes were made on the web preview via chrome devtools, as my local build is not currently displaying this deployment correctly.

| before | after |
|--|--|
| <img width="363" height="744" alt="Screenshot 2026-05-22 at 12 14 31" src="https://github.com/user-attachments/assets/9fa627ad-91ae-46c6-8110-dfc7c3033737" /> | <img width="363" height="745" alt="Screenshot 2026-05-22 at 12 12 21" src="https://github.com/user-attachments/assets/bac0808d-e975-4ac3-b092-3a0585eebe43" /> |

