### PR TITLE
[REMOTE ASSETS] downloadAssetPackByName to await initialise

### DIFF
--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -165,6 +165,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     }
 
     try {
+      await this.ready();
       await this.getAssetPackManifest(assetPackName);
       const total = this.countDownloadFiles(this.manifest?.rows as IAssetEntry[]);
       this.downloadProgressCount.set(total ? { completed: 0, total } : null);
@@ -227,6 +228,12 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
 
     try {
       console.log(`[REMOTE ASSETS] Downloading manifest for asset pack: ${assetPackName}`);
+
+      if (!this.provider) {
+        throw new Error(
+          "Remote asset provider is not initialized. Please ensure remote_assets is configured in deployment config."
+        );
+      }
 
       // Use provider's downloadFileAsText method to handle different blob formats (Firebase data URLs vs Supabase regular blobs)
       const jsonText = await this.provider.downloadFileAsText(relativePath);


### PR DESCRIPTION
PR Checklist

- [ ] PR title descriptive (can be used in release notes)

## Issue

When attempting to download an asset pack on https://plh-teens-tz-uat--pr146-content-1-4-28-wtdpt4ui.web.app/template/test_remote_assets, I was getting the console error 

```
remote-asset.service.ts:241 [REMOTE ASSETS] Error downloading manifest for assets_tz_sw: 
TypeError: Cannot read properties of undefined (reading 'downloadFileAsText')
   at remote-asset.service.ts:232:44
   at Generator.next (<anonymous>)
   at RemoteAssetService.getAssetPackManifest (remote-asset.service.ts:245:26)
   at remote-asset.service.ts:168:18
   at Generator.next (<anonymous>)
```

## Solution

Claude analysed this and found

Summary
Problem: The error occurred because `downloadAssetPackByName` was calling `getAssetPackManifest` before the service's async `initialise()` method had completed, leaving `this.provider` undefined.

Changes Made:

Added initialization check in `downloadAssetPackByName` (line 166): Added `await this.ready()` to ensure the service is fully initialized before attempting to download the manifest.

Added defensive provider check in `getAssetPackManifest` (lines 230-233): Added a null check for `this.provider` with a helpful error message explaining the configuration requirement.

These changes ensure that:

The remote asset provider is fully initialized before attempting to download assets
If initialization fails, you get a clear error message indicating that `remote_assets` needs to be configured in the deployment config
No more undefined reference errors when calling `downloadFileAsText()`
Try running your asset pack download again, and it should work correctly now!

Claude Haiku 4.5 • 1x
