### PR TITLE
style: panama theme adjustments

### DIFF
--- a/src/app/feature/theme/components/colour-palette/colour-palette.component.scss
+++ b/src/app/feature/theme/components/colour-palette/colour-palette.component.scss
@@ -1,6 +1,6 @@
 @use "/src/theme/mixins";
 
-$colors: primary, secondary, primary-variant, secondary-variant, green;
+$colors: primary, secondary, primary-variant, secondary-variant, green, red;
 $colorWeights: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
 
 .palette-container {

--- a/src/app/feature/theme/components/colour-palette/colour-palette.component.ts
+++ b/src/app/feature/theme/components/colour-palette/colour-palette.component.ts
@@ -7,6 +7,6 @@ import { Component } from "@angular/core";
   standalone: false,
 })
 export class ColourPaletteComponent {
-  themeColours = ["primary", "primary-variant", "secondary", "secondary-variant", "green"];
+  themeColours = ["primary", "primary-variant", "secondary", "secondary-variant", "green", "red"];
   colourWeights = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
 }

--- a/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-modal/combo-box-modal.component.scss
@@ -85,7 +85,7 @@
       background: var(--ion-color-primary-100);
       border: 1.5px solid var(--ion-color-primary-400);
       label {
-        font-weight: var(--font-weight-normal);
+        font-weight: var(--font-weight-standard);
         color: var(--ion-color-primary-800);
       }
     }

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -26,8 +26,8 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     opacity: 0.9;
 
     &.placeholder-style {
-      color: var(--ion-color-primary-300);
-      font-weight: var(--font-weight-medium);
+      color: var(--ion-color-gray-800);
+      font-weight: var(--font-weight-standard);
     }
   }
   &.with-value {

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -1,6 +1,6 @@
 $placeholder-text: var(--combo-box-placeholder-text, var(--ion-color-gray-500));
 $selected-value-text: var(--combo-box-selected-value-text, var(--ion-color-primary-800));
-$background-no-value: var(--combo-box-background-no-value, #fff);
+$background-no-value: var(--combo-box-background-no-value, var(--ion-color-primary-50));
 $background-with-value: var(--combo-box-background-with-value, var(--ion-color-primary-100));
 $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-300));
 
@@ -21,7 +21,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     min-width: var(--combo-box-min-width, 328px);
   }
   &.no-value {
-    background: var(--ion-color-primary-50);
+    background: $background-no-value;
     border: 1px solid var(--ion-color-primary-300);
     opacity: 0.9;
 
@@ -34,7 +34,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     background: var(--ion-color-primary-100);
     color: var(--ion-color-primary-800);
     border: 1.5px solid var(--ion-color-primary-300);
-    font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-standard);
   }
 }
 

--- a/src/theme/themes/_default.scss
+++ b/src/theme/themes/_default.scss
@@ -9,8 +9,7 @@
     $color-secondary: hsl(31, 100%, 57%),
     // #fa9529
     // Global and component variables
-    $variable-overrides:
-      (
+    $variable-overrides: (
         // an example variable for illustration purposes
         demo-variable: red,
 
@@ -20,10 +19,16 @@
         border-width-default: 2px,
         border-standard: var(--border-width-default) solid var(--border-color-default),
         border-thin-standard: 1px solid var(--border-color-default),
-        gradient-yellow-vertical:
-          linear-gradient(175deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
-        gradient-yellow-horizontal:
-          linear-gradient(85deg, var(--ion-color-yellow-200) 30%, var(--ion-color-yellow-500)),
+        gradient-yellow-vertical: linear-gradient(
+            175deg,
+            var(--ion-color-yellow-200) 30%,
+            var(--ion-color-yellow-500)
+          ),
+        gradient-yellow-horizontal: linear-gradient(
+            85deg,
+            var(--ion-color-yellow-200) 30%,
+            var(--ion-color-yellow-500)
+          ),
         // button-background-primary: var(--gradient-primary-mid-vertical),
         // button-background-secondary: var(--gradient-secondary-mid-vertical),
         // button-background-option: var(--gradient-primary-dark-vertical),
@@ -70,7 +75,7 @@
         pop-up-background: white,
         // paragraph-spacing: var(--tiny-margin),
         combo-box-background-with-value: var(--gradient-primary-light-vertical),
-        combo-box-background-no-value: transparent,
+        // combo-box-background-no-value: transparent,
         combo-box-placeholder-text: rgba(13, 64, 96, 0.5),
         combo-box-border-with-value: var(--ion-color-primary),
         combo-box-selected-value-text: var(--ion-color-primary),

--- a/src/theme/themes/plh_kids_teens_pa/_index.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_index.scss
@@ -13,10 +13,7 @@
     $page-background: white,
     $variable-overrides: (
       ion-font-family: "Quicksand",
-      font-weight-normal: 400,
       font-weight-standard: 500,
-      font-weight-medium: 600,
-      font-weight-bold: 700,
       font-letter-spacing: -0.2px,
       font-letter-spacing-large: -0.5px,
 

--- a/src/theme/themes/plh_kids_teens_pa/_index.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_index.scss
@@ -7,8 +7,9 @@
   @include utils.theme(
     $theme-name: "plh_kids_teens_pa",
     $color-primary: hsl(202, 98%, 32%),
-    $color-primary-variant: hsl(78, 53%, 55%),
-    $color-secondary: hsl(9, 85%, 48%),
+    $color-primary-variant: hsl(196, 83%, 55%),
+    $color-secondary: hsl(78, 53%, 55%),
+    $color-red: hsl(9, 85%, 48%),
     $page-background: white,
     $variable-overrides: (
       ion-font-family: "Quicksand",
@@ -109,6 +110,8 @@
       text-bubble-border-color-3: var(--ion-color-secondary-variant-300),
       text-bubble-background-color-4: var(--ion-color-secondary-50),
       text-bubble-border-color-4: var(--ion-color-secondary-300),
+      plh-lesson-cta-border-color: var(--ion-color-secondary-800),
+      plh-lesson-cta-background-color: var(--ion-color-secondary-600),
       // PLH module list item
       plh-module-list-item-background-1: #a6e9ff,
       plh-module-list-item-background-2: #ffa777,

--- a/src/theme/themes/plh_kids_teens_pa/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_overrides.scss
@@ -933,7 +933,7 @@
         plh-tmpl-title p,
         plh-tmpl-title h1 {
           text-align: center;
-          color: white;
+          color: var(--ion-color-primary-900);
         }
         plh-tmpl-title {
           div.title-wrapper {

--- a/src/theme/themes/plh_kids_teens_pa/_overrides.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_overrides.scss
@@ -263,7 +263,7 @@
   // accordion
   plh-accordion-component {
     ion-accordion {
-      background: var(--ion-color-primary-600);
+      background: var(--ion-color-primary-700);
       border: none;
       border-radius: var(--ion-border-radius-small);
       box-shadow: none;
@@ -598,12 +598,12 @@
       border: none;
       box-shadow: none !important;
       min-height: 54px !important;
-      background-color: var(--ion-color-primary-variant-700);
+      background-color: var(--ion-color-primary-100);
       border-radius: 16px !important;
       margin-bottom: 8px !important;
       .module-title {
         p {
-          color: white !important;
+          color: var(--ion-color-primary-800) !important;
           padding: 0px !important;
         }
       }

--- a/src/theme/themes/utils/generate-theme.scss
+++ b/src/theme/themes/utils/generate-theme.scss
@@ -133,6 +133,7 @@
   $result: map.merge($result, generate-colour-variants($yellow, "yellow", $weights));
   $result: map.merge($result, generate-colour-variants($gray, "gray", $weights));
   $result: map.merge($result, generate-colour-variants($green, "green", $weights));
+  $result: map.merge($result, generate-colour-variants($red, "red", $weights));
   $result: map.merge(
     $result,
     generate-colour-variants($primary-variant, "primary-variant", $weights)

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -93,7 +93,6 @@
 
   // Font Weight //
   --font-weight-standard: 400;
-  --font-weight-normal: 500;
   --font-weight-medium: 600;
   --font-weight-bold: 700;
 


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Makes some adjustments to the `plh_kids_teens_pa` theme:
- Reorganises the core theme colours to better fit with the theme system
- Overrides the colour for the lesson CTA component, default green -> brand green
- Overrides colours for specific components to improve contrast for accessibility reasons: `combo_box`, `accordion`, `plh_course_accordion`, `plh_module_list_item`, `plh_completion_modal`

If we do want to add additional overrides, for example to make use of the third red/pink "accent" colour in some components, then this is always an option. Currently, these changes will mean that the red colour is generally never used.

These changes are all scoped to the `plh_kids_teens_pa` theme, so will not affect other deployments, with one exception: the `combo_box` component. Previously, there was an accessibility issue with the contrast ration of the combo box when it showed its placeholder text, across all themes. Therefore the core styling has been updated. See screenshots below for specific details.

## Git Issues

After publishing changes, should close https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/issues/155

## Screenshots/Videos

`plh_kids_teenz_pa` deployment. Most "before" screenshots are taken from https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/issues/155. I have checked all relevant contrasts between foreground/background using the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) and can confirm that they now all comfortably pass the 4.5:1 threshold.

| before | after |
|-|-|
| <img width="344" height="706" alt="Screenshot 2026-06-01 at 17 02 24" src="https://github.com/user-attachments/assets/360140f8-b914-4483-ba51-cc3a8d3ee2ed" /> | <img width="344" height="706" alt="Screenshot 2026-06-01 at 17 03 08" src="https://github.com/user-attachments/assets/4bad240f-1b50-4d66-a3d7-d0a1146612c5" /> |
| <img width="285" height="593" alt="599240437-99cfa25a-13fd-4c6c-83af-72bf754c5024" src="https://github.com/user-attachments/assets/2c9ab2cd-5907-4e10-b5b5-57239a0f5a9c" /> | <img width="346" height="708" alt="Screenshot 2026-06-02 at 11 06 26" src="https://github.com/user-attachments/assets/9b2f23cc-1762-4725-a1dd-cb882a5770e0" /> |
| <img width="297" height="590" alt="599271263-3d15f7a4-11ea-4d7d-b077-cd35a0c8106d" src="https://github.com/user-attachments/assets/8389eb2f-954d-4fa8-adff-f3635f83c182" /> | <img width="345" height="705" alt="Screenshot 2026-06-02 at 15 09 52" src="https://github.com/user-attachments/assets/f537c3ac-315f-4dcf-8bf7-6fbef13d0260" /> |
| <img width="382" height="667" alt="599280546-fd7dc280-9b2b-4846-9e6f-277cb1c07b8c" src="https://github.com/user-attachments/assets/014d0ab6-542a-4f4f-a1fb-98527f259e50" /> | <img width="344" height="707" alt="Screenshot 2026-06-02 at 15 23 01" src="https://github.com/user-attachments/assets/f06af38b-fb50-4985-8532-1feb8618d170" /> |
| <img width="293" height="594" alt="599273357-4218159b-5970-4bcc-b761-913fc918dba5" src="https://github.com/user-attachments/assets/c57f0527-c413-4ce8-a927-21f7b4328e4a" /> | <img width="346" height="707" alt="Screenshot 2026-06-02 at 15 41 29" src="https://github.com/user-attachments/assets/e27bd393-48a6-4e7c-8ea2-34ee4ddb0135" /> |
| <img width="320" height="651" alt="599263419-ad571904-43d7-4261-ae27-9debc18e79bb" src="https://github.com/user-attachments/assets/af98661f-d30e-48f8-90e7-aa1f2ea3b914" /> | <img width="342" height="704" alt="Screenshot 2026-06-02 at 15 25 30" src="https://github.com/user-attachments/assets/90cb3f5d-0fdc-461f-92c9-a1602529cca8" /> |
 
`combo-box`, demonstrated on the debug deployment across multiple themes. These styling chnages bring the styling of the un-seleected combo-box in line with the styling of the un-selected options in the combo-box's modal.

| theme | before | after |
|-|-|-|
| `default` | <img width="346" height="704" alt="Screenshot 2026-06-02 at 16 02 28" src="https://github.com/user-attachments/assets/7809b48c-f259-4069-bff9-fe4d08d7fbf6" /> | <img width="344" height="706" alt="Screenshot 2026-06-02 at 16 08 44" src="https://github.com/user-attachments/assets/162f0cc2-e9e6-4333-afb9-ddca787f579f" /> |
| `plh_facilitator_cw` | <img width="346" height="702" alt="Screenshot 2026-06-02 at 16 02 48" src="https://github.com/user-attachments/assets/46ae218f-ef02-471e-9fe3-51ee5da21840" /> | <img width="344" height="705" alt="Screenshot 2026-06-02 at 16 00 33" src="https://github.com/user-attachments/assets/365d9465-4659-459e-8f3b-bbf816c36e1b" /> |
| `plh_kids_kw` | <img width="343" height="707" alt="Screenshot 2026-06-02 at 16 03 02" src="https://github.com/user-attachments/assets/b3f1ab91-fea1-4fb4-8e85-a769a098fcb1" /> | <img width="345" height="705" alt="Screenshot 2026-06-02 at 16 00 53" src="https://github.com/user-attachments/assets/11c5da6b-1de1-4ee8-ae25-4096e06b473d" /> |



