### PR TITLE
fix: save_to_device action

### DIFF
--- a/src/app/shared/services/file-manager/file-manager.service.spec.ts
+++ b/src/app/shared/services/file-manager/file-manager.service.spec.ts
@@ -13,14 +13,19 @@ import { TemplateActionRegistry } from "../../components/template/services/insta
  */
 describe("FileManagerService", () => {
   let service: FileManagerService;
+  let registeredHandlers: any;
 
   beforeEach(() => {
+    registeredHandlers = {};
     TestBed.configureTestingModule({
       imports: [],
       providers: [
         { provide: ErrorHandlerService, useValue: new MockErrorHandlerService() },
         { provide: TemplateAssetService, useValue: {} },
-        { provide: TemplateActionRegistry, useValue: { register: () => undefined } },
+        {
+          provide: TemplateActionRegistry,
+          useValue: { register: (handlers: any) => (registeredHandlers = handlers) },
+        },
         { provide: DeploymentService, useValue: new MockDeploymentService() },
       ],
     });
@@ -29,5 +34,20 @@ describe("FileManagerService", () => {
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("handles save_to_device actions without params", async () => {
+    const downloadTemplateAssetSpy = spyOn<any>(service, "downloadTemplateAsset").and.resolveTo();
+
+    await registeredHandlers.save_to_device({
+      trigger: "click",
+      action_id: "save_to_device",
+      args: ["assets/example.pdf"],
+    });
+
+    expect(downloadTemplateAssetSpy).toHaveBeenCalledOnceWith({
+      relativePath: "assets/example.pdf",
+      open: true,
+    });
   });
 });

--- a/src/app/shared/services/file-manager/file-manager.service.ts
+++ b/src/app/shared/services/file-manager/file-manager.service.ts
@@ -36,7 +36,7 @@ export class FileManagerService extends SyncServiceBase {
     this.templateActionRegistry.register({
       // Native: save file to Documents folder in external device storage and open;
       // Web: download file
-      save_to_device: async ({ args, params }) => {
+      save_to_device: async ({ args, params = {} }) => {
         const pathOrUrl = args[0];
         const { open = true, subfolder = "", filename = undefined } = params;
         if (isExternalHttpUrl(pathOrUrl)) {


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the `save_to_device` action would throw an error if no params were provided.

This is a regression issue introduced by https://github.com/IDEMSInternational/open-app-builder/pull/3417/changes/3cad442ec4b913f701edc042294d3a77e4a41415, which was included in release [v0.26.4](https://github.com/IDEMSInternational/open-app-builder/releases/tag/v0.26.4), which was published on April 13th. So any apps released that were built from that code version or later will be affected. If there are any for which downloading assets is a core feature, we should re-release them after including these changes.

## Git Issues

Closes #3529

## Screenshots/Videos

[feature_save_open_file](https://docs.google.com/spreadsheets/d/1_5XijOqleQJSZzWthlH4Zkyw4TmKCiup8b69yglihcQ/edit?gid=960980632#gid=960980632) is now working as expected

<img width="853" height="364" alt="Screenshot 2026-06-15 at 14 56 22" src="https://github.com/user-attachments/assets/d4e89308-1141-4c17-9d3d-c3eb6fe88310" />
