### PR TITLE
feat: plh progress bar

### DIFF
--- a/packages/components/plh/index.ts
+++ b/packages/components/plh/index.ts
@@ -11,6 +11,7 @@ import { PlhCertificateModule } from "./certificate/plh-certificate.module";
 import { PlhParentGroupModule } from "./parent-group/plh-parent-group.module";
 import { PlhParentPointBoxComponent } from "./parent-point-box/parent-point-box.component";
 import { PlhParentPointCounterComponent } from "./parent-point-counter/parent-point-counter.component";
+import { PlhProgressBarComponent } from "./progress-bar/progress-bar.component";
 
 export {
   PlhActivityCheckInComponent,
@@ -26,6 +27,7 @@ export {
   PlhParentPointBoxComponent,
   PlhParentPointCounterComponent,
   PlhProgressPathComponent,
+  PlhProgressBarComponent,
 };
 
 export const PLH_FEATURE_MODULES = [PlhCertificateModule, PlhParentGroupModule];
@@ -42,6 +44,7 @@ export const PLH_COMPONENTS = [
   PlhParentPointBoxComponent,
   PlhParentPointCounterComponent,
   PlhProgressPathComponent,
+  PlhProgressBarComponent,
 ];
 
 export const PLH_COMPONENT_MAPPING = {
@@ -56,6 +59,7 @@ export const PLH_COMPONENT_MAPPING = {
   plh_module_details_header: PlhModuleDetailsHeaderComponent,
   plh_module_list_item: PlhModuleListItemComponent,
   plh_progress_path: PlhProgressPathComponent,
+  plh_progress_bar: PlhProgressBarComponent,
 };
 
 export type PLHComponentName = keyof typeof PLH_COMPONENT_MAPPING;

--- a/packages/components/plh/progress-bar/progress-bar.component.html
+++ b/packages/components/plh/progress-bar/progress-bar.component.html
@@ -1,0 +1,12 @@
+<div class="progress-bar-wrapper">
+  @if (params().title) {
+    <p class="progress-title" [style.color]="accentColor()">{{ params().title }}</p>
+  }
+  <div class="progress-bar-background">
+    <div
+      class="progress-bar"
+      [style.width.%]="displayProgress()"
+      [style.background-color]="accentColor()"
+    ></div>
+  </div>
+</div>

--- a/packages/components/plh/progress-bar/progress-bar.component.scss
+++ b/packages/components/plh/progress-bar/progress-bar.component.scss
@@ -1,0 +1,24 @@
+$progress-bar-background-color: var(--ion-color-gray-100);
+$progress-bar-height: 5px;
+
+.progress-bar-wrapper {
+  width: 100%;
+
+  .progress-title {
+    margin: 0 0 var(--tiny-padding);
+    font-size: var(--font-size-text-small);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .progress-bar-background {
+    width: 100%;
+    border-radius: var(--ion-border-radius-small);
+    background-color: $progress-bar-background-color;
+  }
+
+  .progress-bar {
+    height: $progress-bar-height;
+    border-radius: var(--ion-border-radius-small);
+    transition: width 0.1s linear;
+  }
+}

--- a/packages/components/plh/progress-bar/progress-bar.component.spec.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { IonicModule } from "@ionic/angular";
+
+import { PlhProgressBarComponent } from "./progress-bar.component";
+
+describe("PlhProgressBarComponent", () => {
+  let component: PlhProgressBarComponent;
+  let fixture: ComponentFixture<PlhProgressBarComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PlhProgressBarComponent],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlhProgressBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/components/plh/progress-bar/progress-bar.component.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.ts
@@ -1,0 +1,103 @@
+import { Component, computed, effect, OnDestroy } from "@angular/core";
+import {
+  defineAuthorParameterSchema,
+  TemplateBaseComponentWithParams,
+} from "src/app/shared/components/template/components/base";
+
+const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
+  /** Text displayed above the progress bar. */
+  title: coerce.string(""),
+  /**
+   * Time in ms for the progress bar to animate from 0 to 100.
+   * When set, the component updates its value over this duration.
+   */
+  duration: coerce.number(0),
+  /**
+   * When true and duration is set, the bar animates automatically.
+   * When false, animation is paused at the current value.
+   */
+  auto_play: coerce.boolean(false),
+  /** Color applied to the title and completed portion of the progress bar. */
+  color: coerce.string(""),
+}));
+
+@Component({
+  selector: "plh-progress-bar",
+  templateUrl: "./progress-bar.component.html",
+  styleUrls: ["./progress-bar.component.scss"],
+  standalone: false,
+})
+export class PlhProgressBarComponent
+  extends TemplateBaseComponentWithParams(AuthorSchema)
+  implements OnDestroy
+{
+  private animationFrameId?: number;
+  private animationElapsedMs = 0;
+  private animationDuration = 0;
+
+  accentColor = computed(() => this.params().color || "var(--ion-color-primary)");
+
+  displayProgress = computed(() => {
+    const val = this.value();
+    const num = typeof val === "number" ? val : Number(val);
+    if (Number.isNaN(num)) return 0;
+    return Math.min(100, Math.max(0, num));
+  });
+
+  constructor() {
+    super();
+    effect((onCleanup) => {
+      const duration = this.params().duration;
+      const autoPlay = this.params().autoPlay;
+
+      if (!duration || duration <= 0) {
+        this.animationElapsedMs = 0;
+        this.animationDuration = 0;
+        return;
+      }
+
+      if (duration !== this.animationDuration) {
+        this.animationElapsedMs = 0;
+        this.animationDuration = duration;
+      }
+
+      if (!autoPlay) return;
+
+      if (this.animationElapsedMs === 0) {
+        void this.setValue(0);
+      }
+
+      const startTime = performance.now() - this.animationElapsedMs;
+      let lastValue = Math.round((this.animationElapsedMs / duration) * 100);
+
+      const animate = (currentTime: number) => {
+        const elapsed = currentTime - startTime;
+        this.animationElapsedMs = Math.min(duration, elapsed);
+        const progress = Math.min(100, (elapsed / duration) * 100);
+        const rounded = Math.round(progress);
+        if (rounded !== lastValue) {
+          lastValue = rounded;
+          void this.setValue(rounded);
+        }
+        if (progress < 100) {
+          this.animationFrameId = requestAnimationFrame(animate);
+        }
+      };
+
+      this.animationFrameId = requestAnimationFrame(animate);
+
+      onCleanup(() => {
+        if (this.animationFrameId !== undefined) {
+          cancelAnimationFrame(this.animationFrameId);
+          this.animationFrameId = undefined;
+        }
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.animationFrameId !== undefined) {
+      cancelAnimationFrame(this.animationFrameId);
+    }
+  }
+}


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new component, `plh_progress_bar`, to meet the needs of a specific PLH deployment.

- `value` stores a 0–100 completion percentage 
- `title` param (optional) adds a title above the bar
- Visual style matches the bar variant of task_progress_bar (grey track, coloured fill)
- `color` param styles both the title and fill (defaults to primary)
- `duration` param (ms) optionally auto-animates value from 0 → 100 over that time
- `auto_play` param (default `false`) starts/pauses the duration animation; resuming continues from the current value

This could be reworked into a general (non-PLH) component, potentially after we're sure we have met the immediate needs for PLH.

## Git Issues

@ChrisMarsh82 to link to relevant deployment issue

## Screenshots/Videos

New template: [comp_plh_progress_bar](https://docs.google.com/spreadsheets/d/1F5_69ZGcqDtisPhE5KDHVbfqlSX20E7-yTlktBPNEwc/edit?gid=569531329#gid=569531329)

https://github.com/user-attachments/assets/985dc492-37f9-4f36-8a38-8799606dff67

