### PR TITLE
feat: Canto remote assets - define remote asset packs in deployment config by Canto custom field conditions

### DIFF
--- a/packages/data-models/deployment.model.ts
+++ b/packages/data-models/deployment.model.ts
@@ -137,6 +137,77 @@ export interface IAssetSource {
   remote?: boolean;
 }
 
+/** Match a Canto custom field value */
+export interface ICantoRemoteAssetPackCustomFieldCondition {
+  type: "custom_field";
+  /** Canto custom field name, e.g. "Caregiver Gender" */
+  field: string;
+  /** Value the custom field must match */
+  value: string;
+}
+
+/** Match when all nested conditions match */
+export interface ICantoRemoteAssetPackAndCondition {
+  type: "and";
+  conditions: ICantoRemoteAssetPackCondition[];
+}
+
+/** Match when any nested condition matches */
+export interface ICantoRemoteAssetPackOrCondition {
+  type: "or";
+  conditions: ICantoRemoteAssetPackCondition[];
+}
+
+/**
+ * Condition used to select Canto assets for a remote asset pack.
+ *
+ * Currently only `custom_field` leaf conditions are implemented in the sync pipeline.
+ * `and` / `or` composition is supported and can combine any condition types as they are added.
+ *
+ * To add a new leaf type (e.g. subfolder, scheme, file extension):
+ * 1. Add an interface here with a `type` discriminator
+ * 2. Extend this union
+ * 3. Handle the new type in `packages/scripts/src/tasks/providers/canto/remote-assets.ts`
+ *
+ * @example Custom field only
+ * `{ type: "custom_field", field: "Caregiver Gender", value: "Female" }`
+ *
+ * @example Combine conditions (all must match)
+ * `{ type: "and", conditions: [
+ *   { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+ *   // future: { type: "scheme", scheme: "audio" },
+ * ]}`
+ *
+ * @example Future leaf types (not yet implemented)
+ * `{ type: "subfolder", path: "videos/intro" }`
+ * `{ type: "scheme", scheme: "audio" }`
+ * `{ type: "extension", extension: ".mp3" }`
+ */
+export type ICantoRemoteAssetPackCondition =
+  | ICantoRemoteAssetPackCustomFieldCondition
+  | ICantoRemoteAssetPackAndCondition
+  | ICantoRemoteAssetPackOrCondition;
+
+/**
+ * Remote asset pack defined within a Canto source folder.
+ * Matching assets are written to `app_data/remote_assets/{name}` instead of core assets.
+ */
+export interface ICantoRemoteAssetPack {
+  /** Asset pack name used for `app_data/remote_assets/{name}` and the pack manifest */
+  name: string;
+  condition: ICantoRemoteAssetPackCondition;
+}
+
+export interface ICantoSourceFolder {
+  id: string;
+  name: string;
+  /**
+   * Remote asset packs to extract from this Canto folder.
+   * Each pack uses a `condition` to select matching files (see `ICantoRemoteAssetPackCondition`).
+   */
+  remote_assets?: ICantoRemoteAssetPack[];
+}
+
 /** Deployment settings not available at runtime  */
 interface IDeploymentCoreConfig {
   google_drive: {
@@ -174,7 +245,7 @@ interface IDeploymentCoreConfig {
     /** The URL of the Canto repository, e.g. "https://parentingforlifelonghealth.canto.com/" */
     url: string;
     /** Canto folder/album id and local name for downloaded source assets */
-    sourceFolders: { id: string; name: string }[];
+    sourceFolders: ICantoSourceFolder[];
     /** Optional overrides mapping Canto language labels to app language codes, e.g. `{ English: "us_en" }`. */
     languageMappings?: Record<string, string>;
   };

--- a/packages/scripts/src/tasks/providers/canto/copy.ts
+++ b/packages/scripts/src/tasks/providers/canto/copy.ts
@@ -69,14 +69,14 @@ const copyFilesFromFolder = async (
   const sources: IDownloadedAssetSource[] = [
     { path: coreOutputFolder, name: folderConfig.name, remote: false },
   ];
-  for (const pack of remotePacks) {
-    const copiedFiles = remoteCopiedFiles.get(pack.name) ?? 0;
+  for (const packName of remoteOutputFolders.keys()) {
+    const copiedFiles = remoteCopiedFiles.get(packName) ?? 0;
     console.log(
-      `Restructured ${copiedFiles} remote assets to ${remoteOutputFolders.get(pack.name)}`
+      `Restructured ${copiedFiles} remote assets to ${remoteOutputFolders.get(packName)}`
     );
     sources.push({
-      path: remoteOutputFolders.get(pack.name)!,
-      name: pack.name,
+      path: remoteOutputFolders.get(packName)!,
+      name: packName,
       remote: true,
     });
   }

--- a/packages/scripts/src/tasks/providers/canto/copy.ts
+++ b/packages/scripts/src/tasks/providers/canto/copy.ts
@@ -12,6 +12,7 @@ import {
   CANTO_CUSTOM_FIELD_THEME,
   DEFAULT_CANTO_LANGUAGE_CODES,
 } from "./constants";
+import { findMatchingRemotePack, getCantoCustomFieldValue } from "./remote-assets";
 
 const DEFAULT_THEME_NAME = "theme_default";
 
@@ -24,7 +25,7 @@ const copyFiles = async (folders: CantoDownloadedFolder[]): Promise<IDownloadedA
   await fs.emptyDir(outputRoot);
   const copiedFolders: IDownloadedAssetSource[] = [];
   for (const folder of folders) {
-    copiedFolders.push(await copyFilesFromFolder(folder, outputRoot));
+    copiedFolders.push(...(await copyFilesFromFolder(folder, outputRoot)));
   }
   return copiedFolders;
 };
@@ -32,43 +33,73 @@ const copyFiles = async (folders: CantoDownloadedFolder[]): Promise<IDownloadedA
 const copyFilesFromFolder = async (
   sourceFolder: CantoDownloadedFolder,
   outputRoot: string
-): Promise<IDownloadedAssetSource> => {
+): Promise<IDownloadedAssetSource[]> => {
   const { folderConfig } = sourceFolder;
+  const remotePacks = folderConfig.remote_assets ?? [];
   console.log(`Restructuring Canto files for "${folderConfig.name}"`);
   const manifestPath = path.join(sourceFolder.path, "manifest.json");
   const manifest = (await fs.readJson(manifestPath)) as CantoManifest;
   if (!manifest) {
     throw new Error(`Canto manifest not found for source folder: ${sourceFolder.path}`);
   }
-  const outputFolder = path.join(outputRoot, folderConfig.name);
-  let copiedFiles = 0;
+
+  const coreOutputFolder = path.join(outputRoot, folderConfig.name);
+  const remoteOutputFolders = new Map(
+    remotePacks.map((pack) => [pack.name, path.join(outputRoot, pack.name)])
+  );
+  let coreCopiedFiles = 0;
+  const remoteCopiedFiles = new Map(remotePacks.map((pack) => [pack.name, 0]));
+
   for (const file of manifest) {
-    const langVariation = getLanguageVariation(file);
-    const themeVariation = getThemeVariation(file);
-    const assetPathName = getFilePath(file, folderConfig.id);
-    const srcPath = path.join(sourceFolder.path, assetPathName);
-    const destPath = path.join(
-      outputFolder,
-      themeVariation || "",
-      langVariation || "",
-      assetPathName
-    );
+    const matchingPack = findMatchingRemotePack(file, remotePacks, { folderId: folderConfig.id });
+    const outputFolder = matchingPack
+      ? remoteOutputFolders.get(matchingPack.name)!
+      : coreOutputFolder;
+    const destPath = path.join(outputFolder, getRestructuredRelativePath(file, folderConfig.id));
+    const srcPath = path.join(sourceFolder.path, getFilePath(file, folderConfig.id));
     await fs.copy(srcPath, destPath);
-    copiedFiles++;
+
+    if (matchingPack) {
+      remoteCopiedFiles.set(matchingPack.name, remoteCopiedFiles.get(matchingPack.name)! + 1);
+    } else {
+      coreCopiedFiles++;
+    }
   }
-  console.log(`Restructured ${copiedFiles} files to ${outputFolder}`);
-  return { path: outputFolder, name: folderConfig.name, remote: false };
+
+  const sources: IDownloadedAssetSource[] = [
+    { path: coreOutputFolder, name: folderConfig.name, remote: false },
+  ];
+  for (const pack of remotePacks) {
+    const copiedFiles = remoteCopiedFiles.get(pack.name) ?? 0;
+    console.log(
+      `Restructured ${copiedFiles} remote assets to ${remoteOutputFolders.get(pack.name)}`
+    );
+    sources.push({
+      path: remoteOutputFolders.get(pack.name)!,
+      name: pack.name,
+      remote: true,
+    });
+  }
+  console.log(`Restructured ${coreCopiedFiles} core assets to ${coreOutputFolder}`);
+  return sources;
 };
 
+function getRestructuredRelativePath(file: CantoManifest[0], cantoFolderId: string) {
+  const langVariation = getLanguageVariation(file);
+  const themeVariation = getThemeVariation(file);
+  const assetPathName = getFilePath(file, cantoFolderId);
+  return path.join(themeVariation || "", langVariation || "", assetPathName);
+}
+
 function getThemeVariation(file: CantoManifest[0]) {
-  const theme = getCustomFieldValue(file, CANTO_CUSTOM_FIELD_THEME);
+  const theme = getCantoCustomFieldValue(file, CANTO_CUSTOM_FIELD_THEME);
   return theme === DEFAULT_THEME_NAME ? undefined : theme;
 }
 
 function getLanguageVariation(file: CantoManifest[0]) {
   const defaultLanguage =
     WorkflowRunner.config.app_config.APP_LANGUAGES?.default || DEFAULT_APP_LANGUAGE_CODE;
-  const languageLabel = getCustomFieldValue(file, CANTO_CUSTOM_FIELD_LANGUAGE_LABEL);
+  const languageLabel = getCantoCustomFieldValue(file, CANTO_CUSTOM_FIELD_LANGUAGE_LABEL);
   const languageMappings = {
     ...DEFAULT_CANTO_LANGUAGE_CODES,
     ...WorkflowRunner.config.canto?.languageMappings,
@@ -77,9 +108,4 @@ function getLanguageVariation(file: CantoManifest[0]) {
   return languageCode === defaultLanguage ? undefined : languageCode;
 }
 
-function getCustomFieldValue(file: CantoManifest[0], fieldName: string) {
-  const value = file.additional?.[fieldName];
-  return Array.isArray(value) ? value[0] : value;
-}
-
-export { copyFiles };
+export { copyFiles, getRestructuredRelativePath };

--- a/packages/scripts/src/tasks/providers/canto/remote-assets.spec.ts
+++ b/packages/scripts/src/tasks/providers/canto/remote-assets.spec.ts
@@ -1,0 +1,157 @@
+import type { ICantoRemoteAssetPack } from "data-models";
+import {
+  findMatchingRemotePack,
+  getCantoCustomFieldValue,
+  matchesRemoteAssetCondition,
+} from "./remote-assets";
+import type { CantoManifestEntry } from "./types";
+
+const matchContext = { folderId: "source-folder-id" };
+
+const createFile = (
+  overrides: Partial<CantoManifestEntry> & Pick<CantoManifestEntry, "name">
+): CantoManifestEntry => ({
+  id: "file-id",
+  scheme: "image",
+  url: { directUrlOriginal: "https://example.com/file.jpg" },
+  ...overrides,
+});
+
+/** yarn workspace scripts test -t remote-assets.spec.ts */
+describe("Canto remote asset matching", () => {
+  it("reads string custom field values", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Female" },
+    });
+    expect(getCantoCustomFieldValue(file, "Caregiver Gender")).toEqual("Female");
+  });
+
+  it("reads the first value from array custom fields", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": ["Female", "Male"] },
+    });
+    expect(getCantoCustomFieldValue(file, "Caregiver Gender")).toEqual("Female");
+  });
+
+  it("matches a custom field condition", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Female" },
+    });
+    expect(
+      matchesRemoteAssetCondition(
+        file,
+        { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+        matchContext
+      )
+    ).toEqual(true);
+  });
+
+  it("matches array custom field values", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": ["Female", "Male"] },
+    });
+    expect(
+      matchesRemoteAssetCondition(
+        file,
+        { type: "custom_field", field: "Caregiver Gender", value: "Male" },
+        matchContext
+      )
+    ).toEqual(true);
+  });
+
+  it("matches when all and conditions match", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Female", Age: "Adult" },
+    });
+    expect(
+      matchesRemoteAssetCondition(
+        file,
+        {
+          type: "and",
+          conditions: [
+            { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+            { type: "custom_field", field: "Age", value: "Adult" },
+          ],
+        },
+        matchContext
+      )
+    ).toEqual(true);
+  });
+
+  it("does not match when an and condition fails", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Female", Age: "Child" },
+    });
+    expect(
+      matchesRemoteAssetCondition(
+        file,
+        {
+          type: "and",
+          conditions: [
+            { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+            { type: "custom_field", field: "Age", value: "Adult" },
+          ],
+        },
+        matchContext
+      )
+    ).toEqual(false);
+  });
+
+  it("matches when any or condition matches", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Male" },
+    });
+    expect(
+      matchesRemoteAssetCondition(
+        file,
+        {
+          type: "or",
+          conditions: [
+            { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+            { type: "custom_field", field: "Caregiver Gender", value: "Male" },
+          ],
+        },
+        matchContext
+      )
+    ).toEqual(true);
+  });
+
+  it("returns the first matching remote asset pack", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Female" },
+    });
+    const remotePacks: ICantoRemoteAssetPack[] = [
+      {
+        name: "Female Pack",
+        condition: { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+      },
+      {
+        name: "Other Pack",
+        condition: { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+      },
+    ];
+    expect(findMatchingRemotePack(file, remotePacks, matchContext)?.name).toEqual("Female Pack");
+  });
+
+  it("returns undefined when no remote asset pack matches", () => {
+    const file = createFile({
+      name: "test.jpg",
+      additional: { "Caregiver Gender": "Male" },
+    });
+    const remotePacks: ICantoRemoteAssetPack[] = [
+      {
+        name: "Female Pack",
+        condition: { type: "custom_field", field: "Caregiver Gender", value: "Female" },
+      },
+    ];
+    expect(findMatchingRemotePack(file, remotePacks, matchContext)).toBeUndefined();
+  });
+});

--- a/packages/scripts/src/tasks/providers/canto/remote-assets.ts
+++ b/packages/scripts/src/tasks/providers/canto/remote-assets.ts
@@ -19,7 +19,7 @@ export interface ICantoRemoteAssetMatchContext {
 export function getCantoCustomFieldValue(
   file: CantoManifestEntry,
   fieldName: string
-): string | null | undefined {
+): string | undefined {
   const value = file.additional?.[fieldName];
   if (Array.isArray(value)) {
     return value[0] ?? undefined;

--- a/packages/scripts/src/tasks/providers/canto/remote-assets.ts
+++ b/packages/scripts/src/tasks/providers/canto/remote-assets.ts
@@ -1,0 +1,87 @@
+/**
+ * Match Canto manifest entries against remote asset pack conditions.
+ *
+ * Only `custom_field` leaf conditions are implemented today. To support additional
+ * condition types, add a case to `matchesRemoteAssetCondition` below (and the
+ * corresponding type in `data-models/deployment.model.ts`).
+ */
+import type { ICantoRemoteAssetPack, ICantoRemoteAssetPackCondition } from "data-models";
+import { logWarning } from "../../../utils";
+import type { CantoManifest } from "./types";
+
+type CantoManifestEntry = CantoManifest[0];
+
+export interface ICantoRemoteAssetMatchContext {
+  /** Canto source folder id, used by path-based condition types */
+  folderId: string;
+}
+
+export function getCantoCustomFieldValue(
+  file: CantoManifestEntry,
+  fieldName: string
+): string | null | undefined {
+  const value = file.additional?.[fieldName];
+  if (Array.isArray(value)) {
+    return value[0] ?? undefined;
+  }
+  return value ?? undefined;
+}
+
+function matchesCustomFieldCondition(
+  file: CantoManifestEntry,
+  condition: Extract<ICantoRemoteAssetPackCondition, { type: "custom_field" }>
+): boolean {
+  const fieldValue = file.additional?.[condition.field];
+  if (fieldValue === undefined || fieldValue === null) {
+    return false;
+  }
+  if (Array.isArray(fieldValue)) {
+    return fieldValue.includes(condition.value);
+  }
+  return fieldValue === condition.value;
+}
+
+function assertUnreachableCondition(condition: never): never {
+  throw new Error(
+    `Unsupported Canto remote asset condition type: ${(condition as { type: string }).type}`
+  );
+}
+
+export function matchesRemoteAssetCondition(
+  file: CantoManifestEntry,
+  condition: ICantoRemoteAssetPackCondition,
+  _context: ICantoRemoteAssetMatchContext
+): boolean {
+  // Add new leaf condition types here as they are introduced in deployment config
+  switch (condition.type) {
+    case "custom_field":
+      return matchesCustomFieldCondition(file, condition);
+    case "and":
+      return condition.conditions.every((nestedCondition) =>
+        matchesRemoteAssetCondition(file, nestedCondition, _context)
+      );
+    case "or":
+      return condition.conditions.some((nestedCondition) =>
+        matchesRemoteAssetCondition(file, nestedCondition, _context)
+      );
+    default:
+      return assertUnreachableCondition(condition);
+  }
+}
+
+export function findMatchingRemotePack(
+  file: CantoManifestEntry,
+  remotePacks: ICantoRemoteAssetPack[],
+  context: ICantoRemoteAssetMatchContext
+): ICantoRemoteAssetPack | undefined {
+  const matches = remotePacks.filter((pack) =>
+    matchesRemoteAssetCondition(file, pack.condition, context)
+  );
+  if (matches.length > 1) {
+    logWarning({
+      msg1: `Canto asset "${file.name}" matches multiple remote asset packs`,
+      msg2: `Using "${matches[0].name}". Matched: ${matches.map((pack) => pack.name).join(", ")}`,
+    });
+  }
+  return matches[0];
+}

--- a/packages/scripts/src/tasks/providers/canto/types.ts
+++ b/packages/scripts/src/tasks/providers/canto/types.ts
@@ -41,10 +41,9 @@ export interface CantoManifestEntry {
 
 export type CantoManifest = CantoManifestEntry[];
 
-export interface CantoSourceFolder {
-  id: string;
-  name: string;
-}
+import type { ICantoSourceFolder } from "data-models";
+
+export type CantoSourceFolder = ICantoSourceFolder;
 
 export interface CantoDownloadedFolder {
   path: string;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)
- [x] Builds on #3520, which should be merged first

## Description

Adds support for Canto remote asset packs, mirroring the existing Google Drive remote asset flow (`app_data/remote_assets/{packName}`) but with a different selection model.

With GDrive, an entire folder maps to one remote pack (`remote: true`). With Canto, assets are distributed across a source folder and selected by configurable conditions (currently Canto custom field values).

## Changes

- **Deployment config** — `canto.sourceFolders` entries can define `remote_assets[]`, each with a `name` and `condition`. Conditions use a discriminated union (`custom_field`, `and`, `or`) so additional matchers (subfolder, scheme, extension, etc.) can be added later.
- **Canto restructure** (`copy.ts`) — during `sync_assets`, each manifest file is evaluated against pack conditions. Matches go to a separate restructured output folder and are marked `remote: true`; non-matches stay in core assets. Folder structure (`theme`/`lang`/path) is preserved for both.
- **Condition matching** (`remote-assets.ts`) — new module handling custom field matching (including array values), `and`/`or` composition, and first-match resolution when multiple packs match (with a warning).
- **Types** — `ICantoSourceFolder`, `ICantoRemoteAssetPack`, and condition types added to `data-models`; Canto provider types updated to use them.
- **Tests** — unit tests for condition matching and pack resolution.

No workflow or post-processor changes required — remote packs flow through the existing `assets_post_process` step within `sync_assets`.

Example config:
```ts
config.canto = {
  url: "https://parentingforlifelonghealth.canto.com",
  sourceFolders: [
    {
      id: "VW96J",
      name: "Debug Assets",
      remote_assets: [
        {
          name: "assets_facilitor_gender_f",
          condition: {
            type: "custom_field",
            field: "Facilitator Gender",
            value: "F",
          },
        },
        {
          name: "assets_facilitor_gender_m",
          condition: {
            type: "custom_field",
            field: "Facilitator Gender",
            value: "M",
          },
        }
      ],
    },
  ],
  languageMappings: {
    Spanish: "gb_en",
  },
  ...loadEncryptedConfig("canto.json"),
};
```

## Git Issues

Closes #

