### PR TITLE
feat: add asset_pack ensure_downloaded action

### DIFF
--- a/packages/data-models/fields.ts
+++ b/packages/data-models/fields.ts
@@ -16,6 +16,8 @@ enum PROTECTED_FIELDS {
   APP_UPDATE_AVAILABLE = "app_update_available",
   /** Track whether an update has been downloaded and is available for install */
   APP_UPDATE_DOWNLOADED = "app_update_downloaded",
+  /** Track whether a remote asset pack download is currently in progress */
+  ASSET_PACK_DOWNLOAD_IN_PROGRESS = "asset_pack_download_in_progress",
   APP_USER_ID = "app_user_id",
   APP_VERSION = "app_version",
   AUTH_USER_ID = "auth_user_id",

--- a/src/app/shared/services/lifecycle-actions/lifecycle-actions.service.spec.ts
+++ b/src/app/shared/services/lifecycle-actions/lifecycle-actions.service.spec.ts
@@ -2,23 +2,149 @@ import { TestBed } from "@angular/core/testing";
 
 import { LifecycleActionsService } from "./lifecycle-actions.service";
 import { AppDataService } from "../data/app-data.service";
-import { MockAppDataService } from "../data/app-data.service.mock.spec";
 import { TemplateVariablesService } from "../../components/template/services/template-variables.service";
+import { TemplateActionService } from "../../components/template/services/instance/template-action.service";
+import type { FlowTypes } from "src/app/shared/model";
 
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/shared/services/lifecycle-actions/lifecycle-actions.service.spec.ts
+ */
 describe("LifecycleActionsService", () => {
   let service: LifecycleActionsService;
+  let mockTemplateVariablesService: jasmine.SpyObj<TemplateVariablesService>;
+  let handleActionsSpy: jasmine.Spy;
+
+  const dynamicReference = "@global.example_value";
+  const resolvedValue = "resolved_value";
+
+  const launchActionWithDynamicReference: FlowTypes.Lifecycle_Action = {
+    id: "launch_action_1",
+    lifecycle_event: "app_start",
+    action_list: [
+      {
+        trigger: "click",
+        action_id: "track_event",
+        args: ["@global.example_value"],
+      },
+    ],
+  };
 
   beforeEach(() => {
+    mockTemplateVariablesService = jasmine.createSpyObj<TemplateVariablesService>(
+      "TemplateVariablesService",
+      ["evaluateConditionString", "ready"]
+    );
+    mockTemplateVariablesService.ready.and.resolveTo();
+    mockTemplateVariablesService.evaluateConditionString.and.callFake(async (value) => value);
+
     TestBed.configureTestingModule({
       providers: [
-        { provide: AppDataService, useValue: new MockAppDataService() },
-        { provide: TemplateVariablesService, useValue: {} },
+        LifecycleActionsService,
+        {
+          provide: AppDataService,
+          useValue: {
+            ready: () => true,
+            getSheetsWithData: async () => [],
+          },
+        },
+        { provide: TemplateVariablesService, useValue: mockTemplateVariablesService },
       ],
     });
     service = TestBed.inject(LifecycleActionsService);
+    handleActionsSpy = spyOn(TemplateActionService.prototype, "handleActions").and.resolveTo();
   });
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+
+  it("evaluates dynamic action args before running lifecycle actions", async () => {
+    spyOn<any>(service, "getAllLifecycleActionsByEventType").and.resolveTo([
+      launchActionWithDynamicReference,
+    ]);
+    mockTemplateVariablesService.evaluateConditionString
+      .withArgs(dynamicReference)
+      .and.resolveTo(resolvedValue);
+
+    await service.handleLaunchActions();
+
+    expect(handleActionsSpy).toHaveBeenCalledWith([
+      jasmine.objectContaining({
+        action_id: "track_event",
+        args: [resolvedValue],
+      }),
+    ]);
+  });
+
+  it("runs static lifecycle actions without calling dynamic evaluation", async () => {
+    spyOn<any>(service, "getAllLifecycleActionsByEventType").and.resolveTo([
+      {
+        id: "launch_action_2",
+        lifecycle_event: "app_start",
+        action_list: [
+          {
+            trigger: "click",
+            action_id: "track_event",
+            args: ["static_value"],
+          },
+        ],
+      },
+    ]);
+
+    await service.handleLaunchActions();
+
+    expect(handleActionsSpy).toHaveBeenCalledWith([
+      jasmine.objectContaining({
+        action_id: "track_event",
+        args: ["static_value"],
+      }),
+    ]);
+    expect(mockTemplateVariablesService.evaluateConditionString).not.toHaveBeenCalled();
+  });
+
+  it("skips lifecycle actions when conditions are not satisfied", async () => {
+    spyOn<any>(service, "getAllLifecycleActionsByEventType").and.resolveTo([
+      {
+        id: "conditional_launch",
+        lifecycle_event: "app_start",
+        condition_list: ["@fields.example_flag"],
+        action_list: launchActionWithDynamicReference.action_list,
+      },
+    ]);
+    mockTemplateVariablesService.evaluateConditionString
+      .withArgs("@fields.example_flag")
+      .and.resolveTo(false);
+
+    await service.handleLaunchActions();
+
+    expect(handleActionsSpy).not.toHaveBeenCalled();
+  });
+
+  it("evaluates condition_list before running lifecycle actions", async () => {
+    spyOn<any>(service, "getAllLifecycleActionsByEventType").and.resolveTo([
+      {
+        id: "conditional_launch",
+        lifecycle_event: "app_start",
+        condition_list: ["@fields.example_flag"],
+        action_list: [
+          {
+            trigger: "click",
+            action_id: "track_event",
+            args: ["static_value"],
+          },
+        ],
+      },
+    ]);
+    mockTemplateVariablesService.evaluateConditionString
+      .withArgs("@fields.example_flag")
+      .and.resolveTo(true);
+
+    await service.handleLaunchActions();
+
+    expect(mockTemplateVariablesService.evaluateConditionString).toHaveBeenCalledWith(
+      "@fields.example_flag"
+    );
+    expect(handleActionsSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/services/lifecycle-actions/lifecycle-actions.service.ts
+++ b/src/app/shared/services/lifecycle-actions/lifecycle-actions.service.ts
@@ -43,7 +43,13 @@ export class LifecycleActionsService extends SyncServiceBase {
       }
       if (allConditionsSatisfied) {
         console.log(`[Lifecycle Actions] ${launchAction.id}`);
-        await templateActionService.handleActions(launchAction.action_list);
+        // Lifecycle actions are read directly from data lists and passed to
+        // TemplateActionService, bypassing template row processing. In templates,
+        // action_list args/params are resolved earlier via evaluatePLHData during
+        // TemplateRowService.processSingleRow. Evaluate dynamic references here so
+        // authored values like @global.asset_pack_id resolve before handlers run.
+        const evaluatedActions = await this.evaluateLifecycleActionList(launchAction.action_list);
+        await templateActionService.handleActions(evaluatedActions);
       }
     }
     return;
@@ -64,5 +70,44 @@ export class LifecycleActionsService extends SyncServiceBase {
     return allLifecycleActions.filter(
       (launchAction) => launchAction.lifecycle_event === lifecycleEvent
     );
+  }
+
+  /**
+   * Resolve dynamic references in lifecycle action args and params.
+   * Kept on this service (not a shared util) because only lifecycle actions
+   * need this path — template-triggered actions are evaluated during row processing.
+   */
+  private async evaluateLifecycleActionList(actions: FlowTypes.TemplateRowAction[] = []) {
+    return Promise.all(actions.map((action) => this.evaluateLifecycleAction(action)));
+  }
+
+  private async evaluateLifecycleAction(
+    action: FlowTypes.TemplateRowAction
+  ): Promise<FlowTypes.TemplateRowAction> {
+    const evaluated: FlowTypes.TemplateRowAction = { ...action };
+    if (action.args) {
+      evaluated.args = await Promise.all(
+        action.args.map((arg) => this.evaluateLifecycleActionReference(arg))
+      );
+    }
+    if (action.params) {
+      evaluated.params = {};
+      for (const [key, value] of Object.entries(action.params)) {
+        evaluated.params[key] = await this.evaluateLifecycleActionReference(value);
+      }
+    }
+    return evaluated;
+  }
+
+  private async evaluateLifecycleActionReference<T>(value: T): Promise<T> {
+    if (Array.isArray(value)) {
+      return Promise.all(
+        value.map((item) => this.evaluateLifecycleActionReference(item))
+      ) as Promise<T>;
+    }
+    if (typeof value === "string" && value.includes("@")) {
+      return (await this.templateVariablesService.evaluateConditionString(value)) as T;
+    }
+    return value;
   }
 }

--- a/src/app/shared/services/remote-asset/remote-asset-metadata.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset-metadata.service.ts
@@ -62,6 +62,11 @@ export class RemoteAssetMetadataService {
     );
   }
 
+  public async isDownloadCompleted(assetPackName: string) {
+    const assetPack = await this.getAssetPack(assetPackName);
+    return assetPack?.download_status === "completed";
+  }
+
   private async getAssetPack(assetPackName: string) {
     const assetPacks = await this.dynamicDataService.snapshot<IDBAssetPack>(
       "data_list",

--- a/src/app/shared/services/remote-asset/remote-asset-metadata.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset-metadata.service.ts
@@ -67,11 +67,12 @@ export class RemoteAssetMetadataService {
     return assetPack?.download_status === "completed";
   }
 
+  public snapshotAssetPacks() {
+    return this.dynamicDataService.snapshot<IDBAssetPack>("data_list", ASSET_PACKS_DATA_LIST);
+  }
+
   private async getAssetPack(assetPackName: string) {
-    const assetPacks = await this.dynamicDataService.snapshot<IDBAssetPack>(
-      "data_list",
-      ASSET_PACKS_DATA_LIST
-    );
+    const assetPacks = await this.snapshotAssetPacks();
     return assetPacks.find((assetPack) => assetPack.id === assetPackName);
   }
 

--- a/src/app/shared/services/remote-asset/remote-asset.actions.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.actions.ts
@@ -67,11 +67,48 @@ export class RemoteAssetActionFactory {
 export function resolveEnsureDownloadedAssetPackList(
   params?: IAssetPackEnsureDownloadedParams
 ): string[] | null {
-  if (params?.asset_pack_list?.length) {
-    return params.asset_pack_list;
+  const assetPackList = parseAssetPackNames(params?.asset_pack_list);
+  if (assetPackList) {
+    return assetPackList;
   }
-  if (params?.asset_pack) {
-    return [params.asset_pack];
+  return parseAssetPackNames(params?.asset_pack);
+}
+
+function parseAssetPackNames(value: string | string[] | undefined): string[] | null {
+  if (value === undefined || value === null) {
+    return null;
   }
+
+  if (Array.isArray(value)) {
+    const names = value.filter(
+      (item): item is string => typeof item === "string" && item.length > 0
+    );
+    return names.length ? names : null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (trimmed.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          const names = parsed.filter(
+            (item): item is string => typeof item === "string" && item.length > 0
+          );
+          return names.length ? names : null;
+        }
+      } catch {
+        console.warn("[REMOTE ASSETS] Invalid asset pack list string:", value);
+        return null;
+      }
+    }
+
+    return [trimmed];
+  }
+
   return null;
 }

--- a/src/app/shared/services/remote-asset/remote-asset.actions.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.actions.ts
@@ -1,6 +1,7 @@
 import type { IActionHandler } from "src/app/shared/components/template/services/instance/template-action.registry";
 import type { RemoteAssetService } from "./remote-asset.service";
 import type { IAssetPackEnsureDownloadedParams } from "./remote-asset.types";
+import { booleanStringToBoolean } from "../../utils";
 
 export class RemoteAssetActionFactory {
   constructor(private service: RemoteAssetService) {}
@@ -34,7 +35,9 @@ export class RemoteAssetActionFactory {
           );
           return;
         }
-        await this.service.ensureAssetPacksDownloaded(assetPackList);
+        await this.service.ensureAssetPacksDownloaded(assetPackList, {
+          awaitCompletion: shouldAwaitEnsureDownloaded(params as IAssetPackEnsureDownloadedParams),
+        });
       },
       cancel_download: async () => {
         if (this.service.remoteAssetsEnabled()) {
@@ -72,6 +75,14 @@ export function resolveEnsureDownloadedAssetPackList(
     return assetPackList;
   }
   return parseAssetPackNames(params?.asset_pack);
+}
+
+export function shouldAwaitEnsureDownloaded(params?: IAssetPackEnsureDownloadedParams) {
+  if (params?.await === undefined) {
+    return true;
+  }
+  const value = booleanStringToBoolean(params.await);
+  return value !== false;
 }
 
 function parseAssetPackNames(value: string | string[] | undefined): string[] | null {

--- a/src/app/shared/services/remote-asset/remote-asset.actions.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.actions.ts
@@ -1,10 +1,11 @@
 import type { IActionHandler } from "src/app/shared/components/template/services/instance/template-action.registry";
 import type { RemoteAssetService } from "./remote-asset.service";
+import type { IAssetPackEnsureDownloadedParams } from "./remote-asset.types";
 
 export class RemoteAssetActionFactory {
   constructor(private service: RemoteAssetService) {}
 
-  public asset_pack: IActionHandler = async ({ args }) => {
+  public asset_pack: IActionHandler = async ({ args, params }) => {
     const [actionId, ...assetPackArgs] = args;
     const childActions = {
       download: async () => {
@@ -16,6 +17,24 @@ export class RemoteAssetActionFactory {
             "The 'asset_pack: download' action is not available. To enable asset pack functionality, please ensure that the remote asset provider is configured in the deployment config."
           );
         }
+      },
+      ensure_downloaded: async () => {
+        if (!this.service.remoteAssetsEnabled()) {
+          console.error(
+            "The 'asset_pack: ensure_downloaded' action is not available. To enable asset pack functionality, please ensure that the remote asset provider is configured in the deployment config."
+          );
+          return;
+        }
+        const assetPackList = resolveEnsureDownloadedAssetPackList(
+          params as IAssetPackEnsureDownloadedParams
+        );
+        if (!assetPackList) {
+          console.error(
+            "The 'asset_pack: ensure_downloaded' action requires an 'asset_pack' or 'asset_pack_list' parameter."
+          );
+          return;
+        }
+        await this.service.ensureAssetPacksDownloaded(assetPackList);
       },
       cancel_download: async () => {
         if (this.service.remoteAssetsEnabled()) {
@@ -43,4 +62,16 @@ export class RemoteAssetActionFactory {
     }
     return childActions[actionId]();
   };
+}
+
+export function resolveEnsureDownloadedAssetPackList(
+  params?: IAssetPackEnsureDownloadedParams
+): string[] | null {
+  if (params?.asset_pack_list?.length) {
+    return params.asset_pack_list;
+  }
+  if (params?.asset_pack) {
+    return [params.asset_pack];
+  }
+  return null;
 }

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -13,7 +13,11 @@ import { DynamicDataService } from "../dynamic-data/dynamic-data.service";
 import type { IRemoteAssetProvider } from "./providers/base.remote-asset";
 import type { IDBAssetPack } from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
-import { resolveEnsureDownloadedAssetPackList } from "./remote-asset.actions";
+import {
+  resolveEnsureDownloadedAssetPackList,
+  shouldAwaitEnsureDownloaded,
+  RemoteAssetActionFactory,
+} from "./remote-asset.actions";
 import { SystemVariableService } from "../system-variable/system-variable.service";
 
 const MOCK_ASSETS_CONTENTS_LIST: IAssetContents = {
@@ -579,6 +583,62 @@ describe("RemoteAssetsService", () => {
 
     expect(downloadOrder).toEqual(["asset_pack_1", "asset_pack_2", "asset_pack_3"]);
   });
+
+  it("sets asset_pack_download_in_progress before returning when awaitCompletion is false", async () => {
+    spyOn<any>(service, "isOffline").and.returnValue(false);
+    let resolveManifest!: () => void;
+    const manifestPromise = new Promise<FlowTypes.AssetPack>((resolve) => {
+      resolveManifest = () =>
+        resolve({
+          flow_type: "asset_pack",
+          flow_name: "asset_pack_1",
+          rows: [],
+        });
+    });
+    spyOn<any>(service, "getAssetPackManifest").and.returnValue(manifestPromise);
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    mockDynamicDataService.snapshot.and.resolveTo([]);
+    mockSystemVariableService.set.calls.reset();
+
+    const success = await service.ensureAssetPacksDownloaded(["asset_pack_1"], {
+      awaitCompletion: false,
+    });
+
+    expect(success).toBeTrue();
+    expect(mockSystemVariableService.set).toHaveBeenCalledWith(
+      "ASSET_PACK_DOWNLOAD_IN_PROGRESS",
+      "true"
+    );
+    expect(service["downloadAndIntegrateAssetPack"]).not.toHaveBeenCalled();
+
+    resolveManifest();
+    await manifestPromise;
+  });
+
+  it("returns immediately without setting asset_pack_download_in_progress when all packs are completed", async () => {
+    const completedPack: IDBAssetPack = {
+      id: "asset_pack_1",
+      name: "asset_pack_1",
+      download_status: "completed",
+      download_started_at: "2024-01-01T00:00:00.000Z",
+      download_completed_at: "2024-01-01T00:01:00.000Z",
+      download_status_updated_at: "2024-01-01T00:01:00.000Z",
+      assets_total_count: 1,
+      assets_downloaded_count: 1,
+    };
+    mockDynamicDataService.snapshot.and.resolveTo([completedPack]);
+    mockSystemVariableService.set.calls.reset();
+
+    const success = await service.ensureAssetPacksDownloaded(["asset_pack_1"], {
+      awaitCompletion: false,
+    });
+
+    expect(success).toBeTrue();
+    expect(mockSystemVariableService.set).not.toHaveBeenCalledWith(
+      "ASSET_PACK_DOWNLOAD_IN_PROGRESS",
+      "true"
+    );
+  });
 });
 
 describe("resolveEnsureDownloadedAssetPackList", () => {
@@ -624,5 +684,63 @@ describe("resolveEnsureDownloadedAssetPackList", () => {
   it("returns null when no asset pack params are provided", () => {
     expect(resolveEnsureDownloadedAssetPackList({})).toBeNull();
     expect(resolveEnsureDownloadedAssetPackList()).toBeNull();
+  });
+});
+
+describe("shouldAwaitEnsureDownloaded", () => {
+  it("defaults to true when await is omitted", () => {
+    expect(shouldAwaitEnsureDownloaded({ asset_pack: "asset_pack_1" })).toBeTrue();
+    expect(shouldAwaitEnsureDownloaded()).toBeTrue();
+  });
+
+  it("parses authored boolean strings for await", () => {
+    expect(shouldAwaitEnsureDownloaded({ await: false })).toBeFalse();
+    expect(shouldAwaitEnsureDownloaded({ await: "false" })).toBeFalse();
+    expect(shouldAwaitEnsureDownloaded({ await: true })).toBeTrue();
+    expect(shouldAwaitEnsureDownloaded({ await: "true" })).toBeTrue();
+  });
+});
+
+describe("RemoteAssetActionFactory ensure_downloaded", () => {
+  it("passes awaitCompletion false when await is false", async () => {
+    const mockService = {
+      remoteAssetsEnabled: () => true,
+      ensureAssetPacksDownloaded: jasmine
+        .createSpy("ensureAssetPacksDownloaded")
+        .and.resolveTo(true),
+    } as unknown as RemoteAssetService;
+    const { asset_pack } = new RemoteAssetActionFactory(mockService);
+
+    await asset_pack({
+      trigger: "click",
+      action_id: "asset_pack",
+      args: ["ensure_downloaded"],
+      params: { asset_pack: "asset_pack_1", await: false },
+    });
+
+    expect(mockService.ensureAssetPacksDownloaded).toHaveBeenCalledWith(["asset_pack_1"], {
+      awaitCompletion: false,
+    });
+  });
+
+  it("passes awaitCompletion true by default", async () => {
+    const mockService = {
+      remoteAssetsEnabled: () => true,
+      ensureAssetPacksDownloaded: jasmine
+        .createSpy("ensureAssetPacksDownloaded")
+        .and.resolveTo(true),
+    } as unknown as RemoteAssetService;
+    const { asset_pack } = new RemoteAssetActionFactory(mockService);
+
+    await asset_pack({
+      trigger: "click",
+      action_id: "asset_pack",
+      args: ["ensure_downloaded"],
+      params: { asset_pack: "asset_pack_1" },
+    });
+
+    expect(mockService.ensureAssetPacksDownloaded).toHaveBeenCalledWith(["asset_pack_1"], {
+      awaitCompletion: true,
+    });
   });
 });

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -13,6 +13,7 @@ import { DynamicDataService } from "../dynamic-data/dynamic-data.service";
 import type { IRemoteAssetProvider } from "./providers/base.remote-asset";
 import type { IDBAssetPack } from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
+import { resolveEnsureDownloadedAssetPackList } from "./remote-asset.actions";
 
 const MOCK_ASSETS_CONTENTS_LIST: IAssetContents = {
   "images/asset.png": {
@@ -490,5 +491,90 @@ describe("RemoteAssetsService", () => {
     expect(success).toBeFalse();
     expect(service.manifest).toBeNull();
     expect(integrateSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips asset packs that are already completed when using ensureAssetPacksDownloaded", async () => {
+    const completedPack: IDBAssetPack = {
+      id: "asset_pack_1",
+      name: "asset_pack_1",
+      download_status: "completed",
+      download_started_at: "2024-01-01T00:00:00.000Z",
+      download_completed_at: "2024-01-01T00:01:00.000Z",
+      download_status_updated_at: "2024-01-01T00:01:00.000Z",
+      assets_total_count: 1,
+      assets_downloaded_count: 1,
+    };
+    mockDynamicDataService.snapshot.and.resolveTo([completedPack]);
+    const downloadSpy = spyOn(service, "downloadAssetPackByName").and.resolveTo(true);
+
+    const success = await service.ensureAssetPacksDownloaded(["asset_pack_1"]);
+
+    expect(success).toBeTrue();
+    expect(downloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("downloads asset packs that are missing or not completed when using ensureAssetPacksDownloaded", async () => {
+    const errorPack: IDBAssetPack = {
+      id: "asset_pack_1",
+      name: "asset_pack_1",
+      download_status: "error",
+      download_started_at: "2024-01-01T00:00:00.000Z",
+      download_completed_at: "",
+      download_status_updated_at: "2024-01-01T00:01:00.000Z",
+      assets_total_count: 1,
+      assets_downloaded_count: 0,
+    };
+    mockDynamicDataService.snapshot.and.callFake(async (_type, flow_name) =>
+      flow_name === "_asset_packs" ? ([errorPack] as any) : []
+    );
+    const downloadSpy = spyOn(service, "downloadAssetPackByName").and.resolveTo(true);
+
+    const success = await service.ensureAssetPacksDownloaded(["asset_pack_1", "asset_pack_2"]);
+
+    expect(success).toBeTrue();
+    expect(downloadSpy.calls.allArgs()).toEqual([["asset_pack_1"], ["asset_pack_2"]]);
+  });
+
+  it("downloads asset packs sequentially when using ensureAssetPacksDownloaded", async () => {
+    mockDynamicDataService.snapshot.and.resolveTo([]);
+    const downloadOrder: string[] = [];
+    spyOn(service, "downloadAssetPackByName").and.callFake(async (assetPackName) => {
+      downloadOrder.push(assetPackName);
+      return true;
+    });
+
+    await service.ensureAssetPacksDownloaded(["asset_pack_1", "asset_pack_2", "asset_pack_3"]);
+
+    expect(downloadOrder).toEqual(["asset_pack_1", "asset_pack_2", "asset_pack_3"]);
+  });
+});
+
+describe("resolveEnsureDownloadedAssetPackList", () => {
+  it("returns a single-item list from asset_pack", () => {
+    expect(resolveEnsureDownloadedAssetPackList({ asset_pack: "asset_pack_1" })).toEqual([
+      "asset_pack_1",
+    ]);
+  });
+
+  it("returns asset_pack_list when provided", () => {
+    expect(
+      resolveEnsureDownloadedAssetPackList({
+        asset_pack_list: ["asset_pack_1", "asset_pack_2"],
+      })
+    ).toEqual(["asset_pack_1", "asset_pack_2"]);
+  });
+
+  it("prefers asset_pack_list when both params are provided", () => {
+    expect(
+      resolveEnsureDownloadedAssetPackList({
+        asset_pack: "asset_pack_solo",
+        asset_pack_list: ["asset_pack_1", "asset_pack_2"],
+      })
+    ).toEqual(["asset_pack_1", "asset_pack_2"]);
+  });
+
+  it("returns null when no asset pack params are provided", () => {
+    expect(resolveEnsureDownloadedAssetPackList({})).toBeNull();
+    expect(resolveEnsureDownloadedAssetPackList()).toBeNull();
   });
 });

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -564,6 +564,22 @@ describe("resolveEnsureDownloadedAssetPackList", () => {
     ).toEqual(["asset_pack_1", "asset_pack_2"]);
   });
 
+  it("parses asset_pack_list from a JSON string array", () => {
+    expect(
+      resolveEnsureDownloadedAssetPackList({
+        asset_pack_list: '["debug_asset_pack_1","pack_2"]',
+      })
+    ).toEqual(["debug_asset_pack_1", "pack_2"]);
+  });
+
+  it("parses a single asset pack name from asset_pack_list string", () => {
+    expect(
+      resolveEnsureDownloadedAssetPackList({
+        asset_pack_list: "asset_pack_1",
+      })
+    ).toEqual(["asset_pack_1"]);
+  });
+
   it("prefers asset_pack_list when both params are provided", () => {
     expect(
       resolveEnsureDownloadedAssetPackList({

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -14,6 +14,7 @@ import type { IRemoteAssetProvider } from "./providers/base.remote-asset";
 import type { IDBAssetPack } from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
 import { resolveEnsureDownloadedAssetPackList } from "./remote-asset.actions";
+import { SystemVariableService } from "../system-variable/system-variable.service";
 
 const MOCK_ASSETS_CONTENTS_LIST: IAssetContents = {
   "images/asset.png": {
@@ -117,6 +118,7 @@ describe("RemoteAssetsService", () => {
   let service: RemoteAssetService;
   let mockDynamicDataService: jasmine.SpyObj<DynamicDataService>;
   let mockNetworkService: jasmine.SpyObj<NetworkService>;
+  let mockSystemVariableService: jasmine.SpyObj<SystemVariableService>;
 
   beforeEach(() => {
     mockDynamicDataService = jasmine.createSpyObj<DynamicDataService>("DynamicDataService", [
@@ -137,6 +139,10 @@ describe("RemoteAssetsService", () => {
     mockNetworkService.isOffline.and.returnValue(false);
     mockNetworkService.waitUntilConnected.and.resolveTo();
     mockNetworkService.onStatusChange.and.returnValue(() => undefined);
+    mockSystemVariableService = jasmine.createSpyObj<SystemVariableService>(
+      "SystemVariableService",
+      ["set", "get", "remove"]
+    );
 
     TestBed.configureTestingModule({
       imports: [],
@@ -146,6 +152,7 @@ describe("RemoteAssetsService", () => {
         { provide: DeploymentService, useValue: new MockDeploymentService(MOCK_DEPLOYMENT_CONFIG) },
         { provide: DynamicDataService, useValue: mockDynamicDataService },
         { provide: NetworkService, useValue: mockNetworkService },
+        { provide: SystemVariableService, useValue: mockSystemVariableService },
       ],
     });
     service = TestBed.inject(RemoteAssetService);
@@ -412,6 +419,31 @@ describe("RemoteAssetsService", () => {
     ]);
     expect(upsertRows[1].download_started_at).toBe(upsertRows[0].download_started_at);
     expect(upsertRows[2].download_started_at).toBe(upsertRows[0].download_started_at);
+  });
+
+  it("updates asset_pack_download_in_progress while downloading", async () => {
+    spyOn<any>(service, "isOffline").and.returnValue(false);
+    const assetPackManifest: FlowTypes.AssetPack = {
+      flow_type: "asset_pack",
+      flow_name: "asset_pack_1",
+      rows: [],
+    };
+    spyOn<any>(service, "getAssetPackManifest").and.callFake(async () => {
+      service.manifest = assetPackManifest;
+      return assetPackManifest;
+    });
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+
+    await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(mockSystemVariableService.set.calls.allArgs()).toContain([
+      "ASSET_PACK_DOWNLOAD_IN_PROGRESS",
+      "true",
+    ]);
+    expect(mockSystemVariableService.set.calls.allArgs()).toContain([
+      "ASSET_PACK_DOWNLOAD_IN_PROGRESS",
+      "false",
+    ]);
   });
 
   it("cancels an active asset pack download while waiting for connection", async () => {

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -31,7 +31,7 @@ import { SystemVariableService } from "../system-variable/system-variable.servic
  * Manual testing aid: set to a positive value, e.g. 3000, to slow each asset entry donwload.
  * Keep at 0 outside local testing.
  */
-const REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS = 3000;
+const REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS = 0;
 
 @Injectable({
   providedIn: "root",

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -142,6 +142,29 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   /************************************************************************************
    *  Download methods
    ************************************************************************************/
+  public async ensureAssetPacksDownloaded(assetPackList: string[]) {
+    if (!assetPackList?.length) {
+      console.error(
+        "[REMOTE ASSETS] Please provide at least one asset pack name via asset_pack or asset_pack_list"
+      );
+      return false;
+    }
+
+    let allSucceeded = true;
+    for (const assetPackName of assetPackList) {
+      const isCompleted = await this.remoteAssetMetadataService.isDownloadCompleted(assetPackName);
+      if (isCompleted) {
+        console.log(`[REMOTE ASSETS] Asset pack already downloaded: ${assetPackName}`);
+        continue;
+      }
+      const success = await this.downloadAssetPackByName(assetPackName);
+      if (!success) {
+        allSucceeded = false;
+      }
+    }
+    return allSucceeded;
+  }
+
   public async downloadAssetPackByName(assetPackName: string) {
     if (!assetPackName) {
       console.error("[REMOTE ASSETS] Please provide an asset pack name to download");

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -161,10 +161,15 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     }
 
     const awaitCompletion = options.awaitCompletion ?? true;
+    const assetPacks = await this.remoteAssetMetadataService.snapshotAssetPacks();
+    const completedPackIds = new Set(
+      assetPacks
+        .filter((assetPack) => assetPack.download_status === "completed")
+        .map((assetPack) => assetPack.id)
+    );
     const pendingPacks: string[] = [];
     for (const assetPackName of assetPackList) {
-      const isCompleted = await this.remoteAssetMetadataService.isDownloadCompleted(assetPackName);
-      if (isCompleted) {
+      if (completedPackIds.has(assetPackName)) {
         console.log(`[REMOTE ASSETS] Asset pack already downloaded: ${assetPackName}`);
         continue;
       }

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -17,7 +17,11 @@ import { DeploymentService } from "../deployment/deployment.service";
 import { IRemoteAssetProvider, IRemoteAssetConfig } from "./providers/base.remote-asset";
 import { getRemoteAssetProvider } from "./providers";
 import { ASSET_CONTENTS_DATA_LIST } from "./remote-asset.types";
-import type { IActiveAssetPackDownload } from "./remote-asset.types";
+import type {
+  IActiveAssetPackDownload,
+  IDownloadAssetPackByNameOptions,
+  IEnsureAssetPacksDownloadedOptions,
+} from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
 import { RemoteAssetActionFactory } from "./remote-asset.actions";
 import { RemoteAssetMetadataService } from "./remote-asset-metadata.service";
@@ -145,7 +149,10 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   /************************************************************************************
    *  Download methods
    ************************************************************************************/
-  public async ensureAssetPacksDownloaded(assetPackList: string[]) {
+  public async ensureAssetPacksDownloaded(
+    assetPackList: string[],
+    options: IEnsureAssetPacksDownloadedOptions = {}
+  ) {
     if (!assetPackList?.length) {
       console.error(
         "[REMOTE ASSETS] Please provide at least one asset pack name via asset_pack or asset_pack_list"
@@ -153,13 +160,46 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       return false;
     }
 
-    let allSucceeded = true;
+    const awaitCompletion = options.awaitCompletion ?? true;
+    const pendingPacks: string[] = [];
     for (const assetPackName of assetPackList) {
       const isCompleted = await this.remoteAssetMetadataService.isDownloadCompleted(assetPackName);
       if (isCompleted) {
         console.log(`[REMOTE ASSETS] Asset pack already downloaded: ${assetPackName}`);
         continue;
       }
+      pendingPacks.push(assetPackName);
+    }
+
+    if (!pendingPacks.length) {
+      return true;
+    }
+
+    if (!awaitCompletion) {
+      const [firstPendingPack, ...remainingPendingPacks] = pendingPacks;
+      const started = await this.downloadAssetPackByName(firstPendingPack, {
+        awaitCompletion: false,
+        onDownloadStarted: (completion) => {
+          if (!remainingPendingPacks.length) {
+            return;
+          }
+          void completion
+            .finally(() =>
+              this.ensureAssetPacksDownloaded(remainingPendingPacks, { awaitCompletion: true })
+            )
+            .catch((error) =>
+              console.error("[REMOTE ASSETS] Background ensure_downloaded failed", error)
+            );
+        },
+      });
+      if (!started) {
+        return false;
+      }
+      return true;
+    }
+
+    let allSucceeded = true;
+    for (const assetPackName of pendingPacks) {
       const success = await this.downloadAssetPackByName(assetPackName);
       if (!success) {
         allSucceeded = false;
@@ -168,7 +208,11 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     return allSucceeded;
   }
 
-  public async downloadAssetPackByName(assetPackName: string) {
+  public async downloadAssetPackByName(
+    assetPackName: string,
+    options: IDownloadAssetPackByNameOptions = {}
+  ) {
+    const awaitCompletion = options.awaitCompletion ?? true;
     if (!assetPackName) {
       console.error("[REMOTE ASSETS] Please provide an asset pack name to download");
       return false;
@@ -192,6 +236,36 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     });
     this.syncAssetPackDownloadInProgressSystemVariable();
 
+    const completion = this.runAssetPackDownload(assetPackName, {
+      abortController,
+      downloadStartedAt,
+      removeAssetPackConnectionStatusListener,
+    });
+
+    if (!awaitCompletion) {
+      options.onDownloadStarted?.(completion);
+      void completion.catch((error) => {
+        if (!this.isDownloadCancelled(error, abortController.signal)) {
+          console.error(error);
+        }
+      });
+      return true;
+    }
+    return completion;
+  }
+
+  private async runAssetPackDownload(
+    assetPackName: string,
+    {
+      abortController,
+      downloadStartedAt,
+      removeAssetPackConnectionStatusListener,
+    }: {
+      abortController: AbortController;
+      downloadStartedAt: string;
+      removeAssetPackConnectionStatusListener: () => void;
+    }
+  ) {
     try {
       while (true) {
         this.throwIfDownloadCancelled(abortController.signal);

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -27,7 +27,7 @@ import { SystemVariableService } from "../system-variable/system-variable.servic
  * Manual testing aid: set to a positive value, e.g. 3000, to slow each asset entry donwload.
  * Keep at 0 outside local testing.
  */
-const REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS = 0;
+const REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS = 3000;
 
 @Injectable({
   providedIn: "root",

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -21,6 +21,7 @@ import type { IActiveAssetPackDownload } from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
 import { RemoteAssetActionFactory } from "./remote-asset.actions";
 import { RemoteAssetMetadataService } from "./remote-asset-metadata.service";
+import { SystemVariableService } from "../system-variable/system-variable.service";
 
 /**
  * Manual testing aid: set to a positive value, e.g. 3000, to slow each asset entry donwload.
@@ -55,6 +56,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     private deploymentService: DeploymentService,
     private networkService: NetworkService,
     private remoteAssetMetadataService: RemoteAssetMetadataService,
+    private systemVariableService: SystemVariableService,
     private injector: Injector
   ) {
     super("RemoteAsset");
@@ -85,6 +87,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       console.log("[Remote Asset] Remote asset provider initialized:", remoteAssetsConfig.provider);
     } else {
       this.remoteAssetsEnabled.set(false);
+      this.syncAssetPackDownloadInProgressSystemVariable();
       console.log("[Remote Asset] Remote assets not enabled");
     }
 
@@ -187,6 +190,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       downloadStartedAt,
       removeConnectionStatusListener: removeAssetPackConnectionStatusListener,
     });
+    this.syncAssetPackDownloadInProgressSystemVariable();
 
     try {
       while (true) {
@@ -259,6 +263,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       const activeDownload = this.activeAssetPackDownloads.get(assetPackName);
       if (activeDownload?.abortController === abortController) {
         this.activeAssetPackDownloads.delete(assetPackName);
+        this.syncAssetPackDownloadInProgressSystemVariable();
       }
       this.downloadProgressCount.set(null);
     }
@@ -279,6 +284,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     activeDownload.abortController.abort();
     activeDownload.removeConnectionStatusListener();
     this.activeAssetPackDownloads.delete(assetPackName);
+    this.syncAssetPackDownloadInProgressSystemVariable();
     this.downloadProgressCount.set(null);
     await this.remoteAssetMetadataService.setDownloadStatus(assetPackName, "cancelled", {
       downloadStartedAt: activeDownload.downloadStartedAt,
@@ -707,9 +713,15 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       activeDownload.removeConnectionStatusListener();
     }
     this.activeAssetPackDownloads.clear();
+    this.syncAssetPackDownloadInProgressSystemVariable();
     if (this.assetContentsSubscription) {
       this.assetContentsSubscription.unsubscribe();
     }
+  }
+
+  private syncAssetPackDownloadInProgressSystemVariable() {
+    const inProgress = this.activeAssetPackDownloads.size > 0;
+    this.systemVariableService.set("ASSET_PACK_DOWNLOAD_IN_PROGRESS", inProgress.toString());
   }
 
   private async incrementDownloadProgress() {

--- a/src/app/shared/services/remote-asset/remote-asset.types.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.types.ts
@@ -47,3 +47,10 @@ export interface IActiveAssetPackDownload {
   downloadStartedAt: string;
   removeConnectionStatusListener: () => void;
 }
+
+export interface IAssetPackEnsureDownloadedParams {
+  /** Single asset pack name */
+  asset_pack?: string;
+  /** One or more asset pack names */
+  asset_pack_list?: string[];
+}

--- a/src/app/shared/services/remote-asset/remote-asset.types.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.types.ts
@@ -51,6 +51,6 @@ export interface IActiveAssetPackDownload {
 export interface IAssetPackEnsureDownloadedParams {
   /** Single asset pack name */
   asset_pack?: string;
-  /** One or more asset pack names */
-  asset_pack_list?: string[];
+  /** One or more asset pack names, as an array or JSON string array */
+  asset_pack_list?: string | string[];
 }

--- a/src/app/shared/services/remote-asset/remote-asset.types.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.types.ts
@@ -53,4 +53,18 @@ export interface IAssetPackEnsureDownloadedParams {
   asset_pack?: string;
   /** One or more asset pack names, as an array or JSON string array */
   asset_pack_list?: string | string[];
+  /** When false, start downloads without blocking the action queue. Defaults to true. */
+  await?: boolean | string;
+}
+
+export interface IEnsureAssetPacksDownloadedOptions {
+  /** When false, return once a download is registered without waiting for completion. Defaults to true. */
+  awaitCompletion?: boolean;
+}
+
+export interface IDownloadAssetPackByNameOptions {
+  /** When false, return once a download is registered without waiting for completion. Defaults to true. */
+  awaitCompletion?: boolean;
+  /** Called synchronously once a background download is registered. Only used when awaitCompletion is false. */
+  onDownloadStarted?: (completion: Promise<boolean>) => void;
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new template action:
- `asset_pack: ensure_downloaded`
  - This action takes two parameters, at least one of which is required:
    - `asset_pack`: the name of a single asset pack
    - `asset_pack_list`: a list of strings corresponding to names of asset packs
  - An additional parameter, `await` (default `true`), determines whether or not the complete download will be awaited before continuing to the next action in the action queue
    - Setting `await: false` will still wait until any downloads are started and `_asset_pack_download_in_progress` is set, but will then continue with any subsequently authored actions
    - This is useful when calling the action in `app_start` lifecycle actions, for example, where we want any necessary downloads to start and then to proceed to show a loading screen to the user

For each named pack, the action checks the `_asset_packs` dynamic data and skips packs with `download_status: completed`. Any other named asset pack triggers a normal download via the existing `downloadAssetPackByName` flow. Packs are processed sequentially to respect the single-active-download constraint.

Example usage:
```
click | asset_pack: ensure_downloaded | asset_pack_list: @fields.required_asset_pack_list;
```

Also adds a new protected field, `_asset_pack_download_in_progress`, which is `true` if and only if there is currently an asset pack in the process of being downloaded, and is `false` otherwise.

## Notes

The logic could perhaps be combined into the pre-existing `asset_pack: download` action, although not without breaking changes. Currently, `asset_pack: download: my_asset_pack` will always trigger the download and `asset_pack: ensure_downloaded | asset_pack: my_asset_pack` will trigger the download if and only if the corresponding asset pack does not have an entry in the `_asset_packs` dynamic data list with a `download_status` of `completed`.

## Git Issues

Closes #

## Screenshots/Videos

### plh_kids_teens_pa deployment

New lifecycle actions added to [launch_actions](https://docs.google.com/spreadsheets/d/1LUIu_aqkzYjyUq0ecQEmWJa62CEvQ4E2L4Fkz_94ydw/edit?gid=1663150146#gid=1663150146):

<img width="1000" alt="Screenshot 2026-06-24 at 13 11 41" src="https://github.com/user-attachments/assets/5c12edef-3a7b-4873-b1ea-715ca351a527" />

For testing purposes, I set the debug var `REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS` to 300 to simulate a slow download:

<img width="800" alt="Screenshot 2026-06-24 at 13 12 58" src="https://github.com/user-attachments/assets/4cd4fbb1-d340-4ee9-a13f-93de0fa3620a" />

Demo, showing remote asset pack downloading in background via console logs. On subsequent runs, the asset pack is successfully identified as already downloaded and the loading popup is skipped.

https://github.com/user-attachments/assets/46522242-98d8-47a6-beaa-08f4d1de8bab

### Debug deployment

[debug_asset_packs](https://docs.google.com/spreadsheets/d/1QPtxcCZEgUpXA26niqoXD0OQni2WAa3kgTPExonkCKU/edit?gid=1404068505#gid=1404068505):

<img width="800" alt="Screenshot 2026-06-24 at 09 39 23" src="https://github.com/user-attachments/assets/dd2c11ce-7b7b-473d-bce6-10f15eeb66e3" />

Console shows result of pressing second button: First asset back is downloaded, second asset pack doesn't exist so throws an error:

<img width="800" alt="Screenshot 2026-06-24 at 09 37 45" src="https://github.com/user-attachments/assets/c958da2e-cc75-4b41-ac99-ae26615f22f3" />