### PR TITLE
style: fix spacing of child elements of wrapping display groups

### DIFF
--- a/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
+++ b/src/app/shared/components/template/components/layout/display-group/display-group.component.scss
@@ -24,6 +24,8 @@
 .display-group-wrapper[data-param-style~="wrap"],
 .display-group-wrapper[data-wrap="true"] {
   flex-wrap: wrap;
+  // gap replaces sibling margins so wrapped rows stay aligned (e.g. when centred)
+  gap: 1em;
 }
 // assign default background colour to the display group wrapper (useful in sticky group)
 .display-group-wrapper[data-param-style~="background_solid"] {
@@ -34,7 +36,9 @@
 .display-group-wrapper[data-param-style~="row"] > plh-template-component:not([data-hidden="true"]) {
   margin: 0;
 }
-.display-group-wrapper[data-param-style~="row"]
+.display-group-wrapper[data-param-style~="row"]:not([data-wrap="true"]):not(
+    [data-param-style~="wrap"]
+  )
   > plh-template-component:not([data-hidden="true"])
   ~ plh-template-component:not([data-hidden="true"]) {
   margin: 0;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes misaligned spacing in wrapping display groups. When `wrap` param is true, spacing now uses flex `gap` on the container instead of sibling margins. Display groups without `wrap: true` are unaffected.

## Git Issues

Closes #

## Screenshots/Videos



### debug deployment

See spacing of elements in second example on [debug_display_group_wrap](https://docs.google.com/spreadsheets/d/1XOknY8BZoaGcKhme-kzsKS6yiiTsc7iU4PBKclnsKcU/edit?gid=1422144003#gid=1422144003):

<img width="1092" height="507" alt="Screenshot 2026-06-24 at 16 43 38" src="https://github.com/user-attachments/assets/3f5b52f9-bdc1-481a-a57e-6fb945a42f34" />

| before | after |
|--|--|
| <img width="240" alt="Screenshot 2026-06-24 at 16 43 52" src="https://github.com/user-attachments/assets/b269ccb4-b67d-4534-9d4e-610cedf82de6" /> | <img width="240" alt="Screenshot 2026-06-24 at 16 42 30" src="https://github.com/user-attachments/assets/60e5ff0f-37f0-4891-8ae8-7339086bc738" /> |


### `plh_kids_teens_pa` example

Updated [show_certificates](https://docs.google.com/spreadsheets/d/1KKfrEtHpXm0sMNY21dYKMmZBOny_Vnum-zr1zgdPcmM/edit?gid=1853110357#gid=1853110357):

<img width="150" alt="Screenshot 2026-06-24 at 16 24 51" src="https://github.com/user-attachments/assets/283c1fc8-5f37-4340-bb01-5ee5a3865541" />
<img width="250" alt="Screenshot 2026-06-24 at 16 24 45" src="https://github.com/user-attachments/assets/c2283360-931e-48c8-9415-6874fb51375b" />
