### PR TITLE
fix: sign in with Apple now populates name fields more reliably

### DIFF
--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -1,10 +1,5 @@
 import { Injectable, Injector } from "@angular/core";
-import {
-  AdditionalUserInfo,
-  FirebaseAuthentication,
-  User,
-  SignInResult,
-} from "@capacitor-firebase/authentication";
+import { FirebaseAuthentication, User, SignInResult } from "@capacitor-firebase/authentication";
 import { FirebaseError } from "firebase/app";
 import { AuthErrorCodes } from "firebase/auth";
 import { FirebaseService } from "../../firebase/firebase.service";
@@ -87,7 +82,7 @@ export class FirebaseAuthProvider extends AuthProviderBase {
           const { profile = {} } = additionalUserInfo ?? {};
           const mergedProfile = { ...this.loadStoredProfile(), ...profile };
           this.setAuthUser(user, mergedProfile);
-          this.saveUserInfo(user, profile);
+          this.saveUserInfo(user, mergedProfile);
         } else {
           console.warn("[Firebase Auth] sign-in returned no user");
         }
@@ -176,7 +171,11 @@ export class FirebaseAuthProvider extends AuthProviderBase {
       return {};
     }
     try {
-      return JSON.parse(stored);
+      const parsed: unknown = JSON.parse(stored);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Partial<IAuthUser>;
+      }
+      return {};
     } catch {
       return {};
     }
@@ -187,17 +186,15 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     const authUser: IAuthUser = {
       ...normalizedProfile,
       uid: user.uid,
-      name: user.displayName ?? undefined,
+      name: user.displayName ?? normalizedProfile.name,
     };
     this.authUser.set(authUser);
   }
 
-  private saveUserInfo(user: User, profile: AdditionalUserInfo["profile"]) {
+  private saveUserInfo(user: User, profile: Partial<IAuthUser>) {
     // NOTE - additionalUserInfo is only returned on first signIn so persist to localStorage
-    // for access on automated sign-in following restart. Merge with any existing profile so
-    // Apple name fields captured on first sign-in are not lost on subsequent sign-ins.
-    const mergedProfile = { ...this.loadStoredProfile(), ...(profile ?? {}) };
-    const normalizedProfile = this.normalizeProfile(user, mergedProfile);
+    // for access on automated sign-in following restart.
+    const normalizedProfile = this.normalizeProfile(user, profile);
     localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(normalizedProfile));
   }
 

--- a/src/app/shared/services/auth/providers/firebase.auth.ts
+++ b/src/app/shared/services/auth/providers/firebase.auth.ts
@@ -84,8 +84,9 @@ export class FirebaseAuthProvider extends AuthProviderBase {
         const { user, additionalUserInfo } = await signInFn();
         if (user) {
           // Note: Apple allows for anonymous sign-in so profile info may be minimal
-          const { profile = {} } = additionalUserInfo;
-          this.setAuthUser(user, profile);
+          const { profile = {} } = additionalUserInfo ?? {};
+          const mergedProfile = { ...this.loadStoredProfile(), ...profile };
+          this.setAuthUser(user, mergedProfile);
           this.saveUserInfo(user, profile);
         } else {
           console.warn("[Firebase Auth] sign-in returned no user");
@@ -146,19 +147,58 @@ export class FirebaseAuthProvider extends AuthProviderBase {
     return this.authUser();
   }
 
+  private isAppleUser(user: User): boolean {
+    return user.providerData?.some((provider) => provider.providerId === "apple.com") ?? false;
+  }
+
+  /**
+   * Apple only returns name data on first authorization and not as OpenID given_name claims.
+   * Fall back to the first word of displayName (set by native Apple sign-in on first login) when needed.
+   */
+  private resolveGivenName(user: User, profile: Partial<IAuthUser>): string | undefined {
+    if (profile.given_name) {
+      return profile.given_name;
+    }
+    if (this.isAppleUser(user) && user.displayName) {
+      return user.displayName.trim().split(/\s+/)[0] || undefined;
+    }
+    return undefined;
+  }
+
+  private normalizeProfile(user: User, profile: Partial<IAuthUser>): Partial<IAuthUser> {
+    const given_name = this.resolveGivenName(user, profile);
+    return given_name ? { ...profile, given_name } : profile;
+  }
+
+  private loadStoredProfile(): Partial<IAuthUser> {
+    const stored = localStorage.getItem(AUTH_METADATA_FIELD);
+    if (!stored) {
+      return {};
+    }
+    try {
+      return JSON.parse(stored);
+    } catch {
+      return {};
+    }
+  }
+
   private setAuthUser(user: User, profile: Partial<IAuthUser>) {
+    const normalizedProfile = this.normalizeProfile(user, profile);
     const authUser: IAuthUser = {
-      ...profile,
+      ...normalizedProfile,
       uid: user.uid,
-      name: user.displayName,
+      name: user.displayName ?? undefined,
     };
     this.authUser.set(authUser);
   }
 
   private saveUserInfo(user: User, profile: AdditionalUserInfo["profile"]) {
     // NOTE - additionalUserInfo is only returned on first signIn so persist to localStorage
-    // for access on automated sign-in following restart. Use fallback empty object if null
-    localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(profile));
+    // for access on automated sign-in following restart. Merge with any existing profile so
+    // Apple name fields captured on first sign-in are not lost on subsequent sign-ins.
+    const mergedProfile = { ...this.loadStoredProfile(), ...(profile ?? {}) };
+    const normalizedProfile = this.normalizeProfile(user, mergedProfile);
+    localStorage.setItem(AUTH_METADATA_FIELD, JSON.stringify(normalizedProfile));
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where the `_auth_user_given_name` was not being populated reliably for Apple Sign In users. Apple does not provide OpenID `given_name` claims like Google does; on first sign-in the native plugin only exposes the full name via `displayName`. So the strategy is now:
- Resolve `given_name` from the OpenID profile when present, otherwise take the first word of `displayName` for Apple users
- Persist the resolved name in `localStorage` and merge with existing profile data so it survives subsequent sign-ins (when Apple stops sending name info)

We have previously had apps rejected by apple for the stated reason:

> The app requires users to provide their name and/or email address after using Sign in with Apple. This information is already provided by the [Authentication Services framework](https://developer.apple.com/documentation/authenticationservices).

Until recently, it has always been sufficient to reply to the rejected review with an explanation, I use the following wording:

> The "Name" field is for a display name within the app that the user can choose that may differ from their real name. Sign in is not required, but for users who do sign in we attempt to fetch the name associated with their Apple account and pre-populate this field when available

However, a recent submission (v1.2.2) of the `plh_kids_teens_pa` app was repeatedly rejected despite adding this explanation, which led me to review the underlying logic for populating the required field.

## Git Issues

Closes #

## Screenshots/Videos

`plh_kids_teens_pa` deployment showing name field populated automatically after signing in with Apple:

<img width="800" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-06-28 at 20 16 26" src="https://github.com/user-attachments/assets/d78faf94-8e05-4f2f-89ed-7758ba3536d1" />

