### PR TITLE
style: plh_kids_teens_pa theme - set footer background colour

### DIFF
--- a/src/theme/themes/plh_kids_teens_pa/_index.scss
+++ b/src/theme/themes/plh_kids_teens_pa/_index.scss
@@ -116,6 +116,7 @@
       plh-module-list-item-background-3: #ffd973,
 
       title-text-color: var(--ion-color-gray-900),
+      footer-background: var(--ion-color-primary-50),
     )
   ) {
     @include overrides.overrides;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Update `plh_kids_teens_pa` to set footer colour via theme variable. Previously this was set in the deployment conifg, a legacy pattern, and was not up-to-date with the current designs.

## Git Issues

In combination with https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/pull/248, addresses https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/issues/209

## Screenshots/Videos

App running on iOS, compare with screenshot in linked issue:

<img width="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-06-29 at 11 50 01" src="https://github.com/user-attachments/assets/212aa408-b55c-4e56-97f2-f0b7b7e08ba2" />
