### PR TITLE
Feat: combo box dropdown text wrap

### DIFF
--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
@@ -16,6 +16,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   width: 100%;
   height: 58px;
   display: flex;
+  align-items: center;
   min-height: var(--combo-box-min-height, 58px);
   font-size: var(--combo-box-font-size-standard, 18px);
   border-radius: var(--ion-border-radius-standard, 8px);
@@ -55,16 +56,14 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     flex: 1;
     min-width: 0;
     text-align: start;
-    margin-top: auto;
-    margin-bottom: auto;
+    line-height: normal;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
   ion-icon {
-    margin-top: auto;
-    margin-bottom: auto;
+    flex-shrink: 0;
     margin-left: auto;
     width: 0.8125rem;
   }

--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
@@ -20,8 +20,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   font-size: var(--combo-box-font-size-standard, 18px);
   border-radius: var(--ion-border-radius-standard, 8px);
   background: white;
-  padding-left: var(--small-padding, 10px);
-  padding-right: var(--small-padding, 10px);
+  padding: var(--small-padding, 10px);
 
   &.placeholder-style {
     color: $placeholder-text;
@@ -71,6 +70,17 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
 
   .dropdown-caret {
     transition: transform 0.2s;
+  }
+
+  &.wrap-text {
+    height: auto;
+
+    .text {
+      text-overflow: unset;
+      text-wrap: wrap;
+      overflow: visible;
+      white-space: normal;
+    }
   }
 }
 

--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
@@ -76,8 +76,6 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     height: auto;
 
     .text {
-      flex: unset;
-      min-width: unset;
       text-overflow: unset;
       overflow: visible;
       white-space: normal;

--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.scss
@@ -52,13 +52,14 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   }
 
   .text {
+    flex: 1;
+    min-width: 0;
     text-align: start;
     margin-top: auto;
     margin-bottom: auto;
-    width: 100%;
-    text-overflow: ellipsis;
-    text-wrap: nowrap;
     overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   ion-icon {
@@ -76,10 +77,12 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     height: auto;
 
     .text {
+      flex: unset;
+      min-width: unset;
       text-overflow: unset;
-      text-wrap: wrap;
       overflow: visible;
       white-space: normal;
+      overflow-wrap: break-word;
     }
   }
 }

--- a/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box-dropdown/combo-box-dropdown.component.ts
@@ -34,6 +34,7 @@ export class ComboBoxDropdownComponent {
     colorKey: "",
     valueDefaults: { ...OPTION_META_BADGE_VALUE_DEFAULTS },
   });
+  public wrap = input<boolean>(false);
 
   /** When option count exceeds `SEARCH_THRESHOLD`, open search modal instead of inline popover. */
   public showSearch = computed(
@@ -92,6 +93,7 @@ export class ComboBoxDropdownComponent {
       "placeholder-style": (!val && placeholder) || this.prioritisePlaceholder(),
       "with-value": val ? true : undefined,
       "no-value": val ? undefined : true,
+      "wrap-text": this.wrap(),
     };
   });
 

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.html
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.html
@@ -7,6 +7,7 @@
       'placeholder-style': (!value() && params().placeholder) || params().prioritisePlaceholder,
       'with-value': !!value(),
       'no-value': !value(),
+      'wrap-text': params().wrap,
     }"
     [disabled]="disabled()"
   >
@@ -24,6 +25,7 @@
     [optionsKey]="params().optionsKey"
     [optionsValue]="params().optionsValue"
     [optionMetaBadge]="optionMetaBadge()"
+    [wrap]="params().wrap"
     (searchDismiss)="onSearchDismiss($event)"
     (selectionChange)="setValue($event)"
   />

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -14,7 +14,6 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   border-radius: var(--ion-border-radius-standard, 8px);
   font-weight: var(--font-weight-standard);
   font-size: var(--combo-box-font-size-standard, 18px);
-  line-height: var(--line-height-text-large, 32px);
   color: var(--ion-color-gray-400);
   min-height: var(--combo-box-min-height, 58px);
   @media (max-width: 400px) {
@@ -35,6 +34,12 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
     color: var(--ion-color-primary-800);
     border: 1.5px solid var(--ion-color-primary-300);
     font-weight: var(--font-weight-standard);
+  }
+
+  &.wrap-text {
+    white-space: normal;
+    overflow-wrap: break-word;
+    height: auto;
   }
 }
 

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.scss
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.scss
@@ -16,6 +16,7 @@ $border-with-value: var(--combo-box-border-with-value, var(--ion-color-primary-3
   font-size: var(--combo-box-font-size-standard, 18px);
   color: var(--ion-color-gray-400);
   min-height: var(--combo-box-min-height, 58px);
+  padding: var(--small-padding, 10px);
   @media (max-width: 400px) {
     min-width: var(--combo-box-min-width, 328px);
   }

--- a/src/app/shared/components/template/components/combo-box/combo-box.component.ts
+++ b/src/app/shared/components/template/components/combo-box/combo-box.component.ts
@@ -42,6 +42,8 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   input_position: coerce.string("bottom"),
   /** Placeholder text for the answer input field. Modal variant only. */
   answer_placeholder: coerce.string(""),
+  /** When true, allows the displayed button text to wrap over multiple lines. */
+  wrap: coerce.boolean(false),
 }));
 
 @Component({


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a wrap author param to the combo-box component so authors can control how long display text is rendered in the trigger button.

- New `wrap` param (boolean, default `false`) on `combo_box` component.
- When `wrap: true`, button text wraps over multiple lines in both modal and dropdown variants
- When `wrap: false` (default), the dropdown variant truncates overflowing text with an ellipsis (`...`)
- Fixes descender clipping (e.g. on "y") in the dropdown button by centring content with `align-items: center` instead of auto margins
- Fixes an issue for the default modal variant, where the vertical spacing between wrapped lines was excessive

## Git Issues

Closes #3553
Addresses https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/issues/233, in combination with authoring updates to use the new `wrap` param.

## Screenshots/Videos

[comp_combo_box](https://docs.google.com/spreadsheets/d/1uIkaMlDjoDN7uTpHkSeEQ6Yp-4ehX9IrBQMrolpfjQc/edit?gid=569531329#gid=569531329):

<img width="800" alt="Screenshot 2026-06-29 at 12 53 51" src="https://github.com/user-attachments/assets/113095a1-acd0-41f6-a0d3-fb94cbb31eb0" />

`plh_kids_teens_pa` theme is shown.

| before | after |
| ---- | ----- |
| <img width="363" height="741" alt="Screenshot 2026-06-29 at 12 52 57" src="https://github.com/user-attachments/assets/a236de28-e401-4716-a204-0430a359568e" /> |  <img width="361" height="741" alt="Screenshot 2026-06-29 at 14 13 37" src="https://github.com/user-attachments/assets/0c4a8220-44c1-49d9-aa5e-4aea8b78f233" /> |