### PR TITLE
Feat: plh-get-up-next component

### DIFF
--- a/packages/components/plh/get-up-next/get-up-next.component.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.spec.ts
@@ -32,7 +32,8 @@ describe("PlhGetUpNextComponent", () => {
 
   function createComponent(
     tasks: Record<string, unknown>[] = [],
-    courses: Record<string, unknown>[] = []
+    courses: Record<string, unknown>[] = [],
+    options: { spySetValue?: boolean } = {}
   ) {
     mockDynamicDataService.query$.and.callFake((_flowType: string, listName: string) => {
       if (listName === "module_tasks") return of(tasks);
@@ -50,6 +51,9 @@ describe("PlhGetUpNextComponent", () => {
       type: "plh_get_up_next",
       value: null,
     } as any;
+    if (options.spySetValue) {
+      spyOn(component, "setValue").and.resolveTo();
+    }
     fixture.detectChanges();
   }
 
@@ -125,7 +129,7 @@ describe("PlhGetUpNextComponent", () => {
     expect(component.upNextTask()?.id).toBe("matches");
   });
 
-  it("should return the most recently completed task when none are in progress", () => {
+  it("should return the next incomplete module after last completed when none are in progress", () => {
     createComponent([
       {
         id: "older_completed",
@@ -143,7 +147,7 @@ describe("PlhGetUpNextComponent", () => {
       },
     ]);
 
-    expect(component.upNextTask()?.id).toBe("newer_completed");
+    expect(component.upNextTask()?.id).toBe("not_started");
   });
 
   it("should prefer an in-progress task over a completed task", () => {
@@ -164,8 +168,6 @@ describe("PlhGetUpNextComponent", () => {
   });
 
   it("should set the component value from the first in-progress task", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
     createComponent(
       [
         {
@@ -183,7 +185,8 @@ describe("PlhGetUpNextComponent", () => {
           tag_list: ["age_5_9"],
         },
       ],
-      [{ id: "course_b", title: "Course B" }]
+      [{ id: "course_b", title: "Course B" }],
+      { spySetValue: true }
     );
 
     await flushSettledValue();
@@ -197,8 +200,6 @@ describe("PlhGetUpNextComponent", () => {
   });
 
   it("should fall through to getFirstItem when the last completed course has no following module", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
     createComponent(
       [
         {
@@ -220,7 +221,8 @@ describe("PlhGetUpNextComponent", () => {
       [
         { id: "relation_c", title: "Mejorar la relación con mi niña o niño" },
         { id: "mood_c", title: "Mood course" },
-      ]
+      ],
+      { spySetValue: true }
     );
 
     await flushSettledValue();
@@ -235,8 +237,6 @@ describe("PlhGetUpNextComponent", () => {
   });
 
   it("should settle with no up-next when all modules are complete", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
     createComponent(
       [
         {
@@ -254,7 +254,8 @@ describe("PlhGetUpNextComponent", () => {
           tag_list: ["age_5_9"],
         },
       ],
-      [{ id: "course_b", title: "Course B" }]
+      [{ id: "course_b", title: "Course B" }],
+      { spySetValue: true }
     );
 
     await flushSettledValue();
@@ -263,8 +264,6 @@ describe("PlhGetUpNextComponent", () => {
   });
 
   it("should set course_id and the next incomplete module in the same course after last completed", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
     createComponent(
       [
         {
@@ -303,11 +302,13 @@ describe("PlhGetUpNextComponent", () => {
           tag_list: ["age_5_9"],
         },
       ],
-      [{ id: "course_b", title: "Course B" }]
+      [{ id: "course_b", title: "Course B" }],
+      { spySetValue: true }
     );
 
     await flushSettledValue();
 
+    expect(component.upNextTask()?.id).toBe("next_module");
     expectSettledValue({
       course_id: "course_b",
       course_title: "Course B",
@@ -317,8 +318,6 @@ describe("PlhGetUpNextComponent", () => {
   });
 
   it("should return the first incomplete task by number when no other checks match", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
     createComponent(
       [
         {
@@ -336,7 +335,8 @@ describe("PlhGetUpNextComponent", () => {
           tag_list: ["age_5_9"],
         },
       ],
-      [{ id: "course_a", title: "Course A" }]
+      [{ id: "course_a", title: "Course A" }],
+      { spySetValue: true }
     );
 
     await flushSettledValue();
@@ -357,6 +357,7 @@ describe("PlhGetUpNextComponent", () => {
         title: "First module",
         tag_course: "course_a",
         last_accessed_ts: 1,
+        tag_list: ["age_5_9"],
       },
     ]);
     const courses$ = new BehaviorSubject<Record<string, unknown>[]>([
@@ -390,9 +391,11 @@ describe("PlhGetUpNextComponent", () => {
         title: "Updated module",
         tag_course: "course_b",
         last_accessed_ts: 2,
+        tag_list: ["age_5_9"],
       },
     ]);
     courses$.next([{ id: "course_b", title: "Course B" }]);
+    fixture.detectChanges();
     await flushSettledValue();
 
     const calls = (component.setValue as jasmine.Spy).calls.allArgs();
@@ -406,15 +409,11 @@ describe("PlhGetUpNextComponent", () => {
     });
   });
 
-  it("should log and settle with check_complete when no matching tasks are found", async () => {
-    spyOn(console, "log");
-    spyOn(component, "setValue").and.resolveTo();
-
-    createComponent([]);
+  it("should settle with check_complete when no matching tasks are found", async () => {
+    createComponent([], [], { spySetValue: true });
 
     await flushSettledValue();
 
-    expect(console.log).toHaveBeenCalledWith("no in progress ATM");
     expectSettledValue({});
   });
 });

--- a/packages/components/plh/get-up-next/get-up-next.component.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+
+import { PlhGetUpNextComponent } from "./get-up-next.component";
+
+describe("PlhGetUpNextComponent", () => {
+  let component: PlhGetUpNextComponent;
+  let fixture: ComponentFixture<PlhGetUpNextComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [PlhGetUpNextComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PlhGetUpNextComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should not render visible UI", () => {
+    expect(component.shouldShow()).toBe(false);
+  });
+});

--- a/packages/components/plh/get-up-next/get-up-next.component.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-import { of } from "rxjs";
+import { of, BehaviorSubject } from "rxjs";
 
 import { PlhGetUpNextComponent } from "./get-up-next.component";
 import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
@@ -20,8 +20,25 @@ describe("PlhGetUpNextComponent", () => {
     user_relationship: "mother",
   };
 
-  function createComponent(tasks: Record<string, unknown>[] = []) {
-    mockDynamicDataService.query$.and.returnValue(of(tasks));
+  async function flushSettledValue() {
+    await fixture.whenStable();
+    await Promise.resolve();
+  }
+
+  function expectSettledValue(value: Record<string, unknown>) {
+    expect(component.setValue).toHaveBeenCalledWith({ check_complete: false });
+    expect(component.setValue).toHaveBeenCalledWith({ check_complete: true, ...value });
+  }
+
+  function createComponent(
+    tasks: Record<string, unknown>[] = [],
+    courses: Record<string, unknown>[] = []
+  ) {
+    mockDynamicDataService.query$.and.callFake((_flowType: string, listName: string) => {
+      if (listName === "module_tasks") return of(tasks);
+      if (listName === "courses") return of(courses);
+      return of([]);
+    });
     fixture = TestBed.createComponent(PlhGetUpNextComponent);
     component = fixture.componentInstance;
     component.parent = {
@@ -60,8 +77,9 @@ describe("PlhGetUpNextComponent", () => {
     expect(component.shouldShow()).toBe(false);
   });
 
-  it("should subscribe to the module_tasks data list", () => {
+  it("should subscribe to the module_tasks and courses data lists", () => {
     expect(mockDynamicDataService.query$).toHaveBeenCalledWith("data_list", "module_tasks");
+    expect(mockDynamicDataService.query$).toHaveBeenCalledWith("data_list", "courses");
   });
 
   it("should return the most recently accessed in-progress task from checkForInProgress", () => {
@@ -107,40 +125,261 @@ describe("PlhGetUpNextComponent", () => {
     expect(component.upNextTask()?.id).toBe("matches");
   });
 
-  it("should set the component value from the first matching task", async () => {
-    spyOn(component, "setValue").and.resolveTo();
-
+  it("should return the most recently completed task when none are in progress", () => {
     createComponent([
       {
-        id: "older",
-        title: "Older module",
-        tag_course: "course_a",
-        last_accessed_ts: 1,
+        id: "older_completed",
+        completed_ts: 1,
         tag_list: ["age_5_9"],
       },
       {
-        id: "newer",
-        title: "Newer module",
-        tag_course: "course_b",
-        last_accessed_ts: 2,
+        id: "newer_completed",
+        completed_ts: 2,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "not_started",
         tag_list: ["age_5_9"],
       },
     ]);
 
-    await fixture.whenStable();
+    expect(component.upNextTask()?.id).toBe("newer_completed");
+  });
 
-    expect(component.setValue).toHaveBeenCalledWith({
+  it("should prefer an in-progress task over a completed task", () => {
+    createComponent([
+      {
+        id: "completed",
+        completed_ts: 99,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "in_progress",
+        last_accessed_ts: 1,
+        tag_list: ["age_5_9"],
+      },
+    ]);
+
+    expect(component.upNextTask()?.id).toBe("in_progress");
+  });
+
+  it("should set the component value from the first in-progress task", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent(
+      [
+        {
+          id: "older",
+          title: "Older module",
+          tag_course: "course_a",
+          last_accessed_ts: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "newer",
+          title: "Newer module",
+          tag_course: "course_b",
+          last_accessed_ts: 2,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      [{ id: "course_b", title: "Course B" }]
+    );
+
+    await flushSettledValue();
+
+    expectSettledValue({
       module_id: "newer",
       module_title: "Newer module",
       course_id: "course_b",
+      course_title: "Course B",
     });
   });
 
-  it("should log when no matching tasks are in progress", () => {
+  it("should set only course_id when falling back to the last completed task", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent(
+      [
+        {
+          id: "older_completed",
+          title: "Older module",
+          tag_course: "course_a",
+          completed_ts: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "newer_completed",
+          title: "Newer module",
+          tag_course: "course_b",
+          completed_ts: 2,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      [{ id: "course_b", title: "Course B" }]
+    );
+
+    await flushSettledValue();
+
+    expectSettledValue({
+      course_id: "course_b",
+      course_title: "Course B",
+    });
+  });
+
+  it("should set course_id and the next incomplete module in the same course after last completed", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent(
+      [
+        {
+          id: "older_completed",
+          title: "Older module",
+          tag_course: "course_b",
+          completed_ts: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "newer_completed",
+          title: "Newer module",
+          tag_course: "course_b",
+          completed_ts: 2,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "next_module",
+          title: "Next module",
+          tag_course: "course_b",
+          number: 2,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "later_module",
+          title: "Later module",
+          tag_course: "course_b",
+          number: 3,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "other_course",
+          title: "Other course module",
+          tag_course: "course_a",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      [{ id: "course_b", title: "Course B" }]
+    );
+
+    await flushSettledValue();
+
+    expectSettledValue({
+      course_id: "course_b",
+      course_title: "Course B",
+      module_id: "next_module",
+      module_title: "Next module",
+    });
+  });
+
+  it("should return the first incomplete task by number when no other checks match", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent(
+      [
+        {
+          id: "second",
+          title: "Second module",
+          tag_course: "course_a",
+          number: 2,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "first",
+          title: "First module",
+          tag_course: "course_a",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      [{ id: "course_a", title: "Course A" }]
+    );
+
+    await flushSettledValue();
+
+    expect(component.upNextTask()?.id).toBe("first");
+    expectSettledValue({
+      module_id: "first",
+      module_title: "First module",
+      course_id: "course_a",
+      course_title: "Course A",
+    });
+  });
+
+  it("should reset check_complete while re-evaluating and settle on true", async () => {
+    const moduleTasks$ = new BehaviorSubject<Record<string, unknown>[]>([
+      {
+        id: "first",
+        title: "First module",
+        tag_course: "course_a",
+        last_accessed_ts: 1,
+      },
+    ]);
+    const courses$ = new BehaviorSubject<Record<string, unknown>[]>([
+      { id: "course_a", title: "Course A" },
+    ]);
+
+    mockDynamicDataService.query$.and.callFake((_flowType: string, listName: string) => {
+      if (listName === "module_tasks") return moduleTasks$.asObservable();
+      if (listName === "courses") return courses$.asObservable();
+      return of([]);
+    });
+
+    fixture = TestBed.createComponent(PlhGetUpNextComponent);
+    component = fixture.componentInstance;
+    component.parent = {
+      handleActions: jasmine.createSpy("handleActions").and.resolveTo(undefined),
+    } as any;
+    component.row = {
+      name: "get_up_next",
+      _nested_name: "get_up_next",
+      type: "plh_get_up_next",
+      value: null,
+    } as any;
+    spyOn(component, "setValue").and.resolveTo();
+    fixture.detectChanges();
+    await flushSettledValue();
+
+    moduleTasks$.next([
+      {
+        id: "updated",
+        title: "Updated module",
+        tag_course: "course_b",
+        last_accessed_ts: 2,
+      },
+    ]);
+    courses$.next([{ id: "course_b", title: "Course B" }]);
+    await flushSettledValue();
+
+    const calls = (component.setValue as jasmine.Spy).calls.allArgs();
+    expect(calls.filter(([value]) => value.check_complete === false).length).toBeGreaterThan(1);
+    expect(component.setValue).toHaveBeenCalledWith({
+      check_complete: true,
+      module_id: "updated",
+      module_title: "Updated module",
+      course_id: "course_b",
+      course_title: "Course B",
+    });
+  });
+
+  it("should log and settle with check_complete when no matching tasks are found", async () => {
     spyOn(console, "log");
+    spyOn(component, "setValue").and.resolveTo();
 
     createComponent([]);
 
+    await flushSettledValue();
+
     expect(console.log).toHaveBeenCalledWith("no in progress ATM");
+    expectSettledValue({});
   });
 });

--- a/packages/components/plh/get-up-next/get-up-next.component.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.spec.ts
@@ -196,7 +196,45 @@ describe("PlhGetUpNextComponent", () => {
     });
   });
 
-  it("should set only course_id when falling back to the last completed task", async () => {
+  it("should fall through to getFirstItem when the last completed course has no following module", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent(
+      [
+        {
+          id: "i_calm_c",
+          title: "Mantener la calma cuando hay estrés",
+          tag_course: "relation_c",
+          number: 3,
+          completed_ts: 100,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "first_mood",
+          title: "First mood module",
+          tag_course: "mood_c",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      [
+        { id: "relation_c", title: "Mejorar la relación con mi niña o niño" },
+        { id: "mood_c", title: "Mood course" },
+      ]
+    );
+
+    await flushSettledValue();
+
+    expect(component.upNextTask()?.id).toBe("first_mood");
+    expectSettledValue({
+      course_id: "mood_c",
+      course_title: "Mood course",
+      module_id: "first_mood",
+      module_title: "First mood module",
+    });
+  });
+
+  it("should settle with no up-next when all modules are complete", async () => {
     spyOn(component, "setValue").and.resolveTo();
 
     createComponent(
@@ -221,10 +259,7 @@ describe("PlhGetUpNextComponent", () => {
 
     await flushSettledValue();
 
-    expectSettledValue({
-      course_id: "course_b",
-      course_title: "Course B",
-    });
+    expectSettledValue({});
   });
 
   it("should set course_id and the next incomplete module in the same course after last completed", async () => {

--- a/packages/components/plh/get-up-next/get-up-next.component.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.spec.ts
@@ -1,19 +1,55 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
+import { of } from "rxjs";
 
 import { PlhGetUpNextComponent } from "./get-up-next.component";
+import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
+import { TemplateFieldService } from "src/app/shared/components/template/services/template-field.service";
+import { MockTemplateFieldService } from "src/app/shared/components/template/services/template-field.service.spec";
 
 describe("PlhGetUpNextComponent", () => {
   let component: PlhGetUpNextComponent;
   let fixture: ComponentFixture<PlhGetUpNextComponent>;
+  let mockDynamicDataService: jasmine.SpyObj<DynamicDataService>;
+  let mockTemplateFieldService: MockTemplateFieldService;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [PlhGetUpNextComponent],
-    }).compileComponents();
+  const defaultFields = {
+    child_age_tag: "age_5_9",
+    child_age: "7",
+    child_gender: "female",
+    user_gender: "female",
+    user_relationship: "mother",
+  };
 
+  function createComponent(tasks: Record<string, unknown>[] = []) {
+    mockDynamicDataService.query$.and.returnValue(of(tasks));
     fixture = TestBed.createComponent(PlhGetUpNextComponent);
     component = fixture.componentInstance;
+    component.parent = {
+      handleActions: jasmine.createSpy("handleActions").and.resolveTo(undefined),
+    } as any;
+    component.row = {
+      name: "get_up_next",
+      _nested_name: "get_up_next",
+      type: "plh_get_up_next",
+      value: null,
+    } as any;
     fixture.detectChanges();
+  }
+
+  beforeEach(waitForAsync(() => {
+    mockDynamicDataService = jasmine.createSpyObj("DynamicDataService", ["query$"]);
+    mockDynamicDataService.query$.and.returnValue(of([]));
+    mockTemplateFieldService = new MockTemplateFieldService(defaultFields);
+
+    TestBed.configureTestingModule({
+      declarations: [PlhGetUpNextComponent],
+      providers: [
+        { provide: DynamicDataService, useValue: mockDynamicDataService },
+        { provide: TemplateFieldService, useValue: mockTemplateFieldService },
+      ],
+    }).compileComponents();
+
+    createComponent();
   }));
 
   it("should create", () => {
@@ -22,5 +58,89 @@ describe("PlhGetUpNextComponent", () => {
 
   it("should not render visible UI", () => {
     expect(component.shouldShow()).toBe(false);
+  });
+
+  it("should subscribe to the module_tasks data list", () => {
+    expect(mockDynamicDataService.query$).toHaveBeenCalledWith("data_list", "module_tasks");
+  });
+
+  it("should return the most recently accessed in-progress task from checkForInProgress", () => {
+    createComponent([
+      {
+        id: "completed",
+        last_accessed_ts: 3,
+        completed_ts: 1,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "not_started",
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "older",
+        last_accessed_ts: 1,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "newer",
+        last_accessed_ts: 2,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "wrong_tag",
+        last_accessed_ts: 4,
+        tag_list: ["age_10_14"],
+      },
+    ]);
+
+    expect(component.upNextTask()?.id).toBe("newer");
+  });
+
+  it("should allow tasks when optional list fields are empty", () => {
+    createComponent([
+      {
+        id: "matches",
+        last_accessed_ts: 1,
+      },
+    ]);
+
+    expect(component.upNextTask()?.id).toBe("matches");
+  });
+
+  it("should set the component value from the first matching task", async () => {
+    spyOn(component, "setValue").and.resolveTo();
+
+    createComponent([
+      {
+        id: "older",
+        title: "Older module",
+        tag_course: "course_a",
+        last_accessed_ts: 1,
+        tag_list: ["age_5_9"],
+      },
+      {
+        id: "newer",
+        title: "Newer module",
+        tag_course: "course_b",
+        last_accessed_ts: 2,
+        tag_list: ["age_5_9"],
+      },
+    ]);
+
+    await fixture.whenStable();
+
+    expect(component.setValue).toHaveBeenCalledWith({
+      module_id: "newer",
+      module_title: "Newer module",
+      course_id: "course_b",
+    });
+  });
+
+  it("should log when no matching tasks are in progress", () => {
+    spyOn(console, "log");
+
+    createComponent([]);
+
+    expect(console.log).toHaveBeenCalledWith("no in progress ATM");
   });
 });

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -8,35 +8,24 @@ import {
 } from "src/app/shared/components/template/components/base";
 import { TemplateFieldService } from "src/app/shared/components/template/services/template-field.service";
 import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
-
-const MODULE_TASKS_DATA_LIST = "module_tasks";
-const COURSES_DATA_LIST = "courses";
-
-type IModuleTaskFilterFields = {
-  child_age_tag: unknown;
-  child_age: unknown;
-  child_gender: unknown;
-  user_gender: unknown;
-  user_relationship: unknown;
-};
-
-type IResolvedUpNextValue = {
-  course_id?: string;
-  course_title?: string;
-  module_id?: string;
-  module_title?: string;
-};
-
-type IUpNextValue = IResolvedUpNextValue & {
-  check_complete: boolean;
-};
-
-type IUpNextResolution = {
-  value: IResolvedUpNextValue;
-  task: FlowTypes.Data_listRow;
-};
+import {
+  COURSES_DATA_LIST,
+  IModuleTaskFilterFields,
+  IUpNextValue,
+  MODULE_TASKS_DATA_LIST,
+  resolveUpNextValue,
+  toSettledValue,
+} from "./get-up-next.logic";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({}));
+
+const FILTER_FIELD_NAMES = [
+  "child_age_tag",
+  "child_age",
+  "child_gender",
+  "user_gender",
+  "user_relationship",
+] as const satisfies readonly (keyof IModuleTaskFilterFields)[];
 
 @Component({
   selector: "plh-get-up-next",
@@ -48,44 +37,28 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
   private dynamicDataService = inject(DynamicDataService);
   private templateFieldService = inject(TemplateFieldService);
 
-  private moduleTasks = toSignal(
-    this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", MODULE_TASKS_DATA_LIST),
-    { initialValue: [] as FlowTypes.Data_listRow[] }
+  private moduleTasks = this.queryDataList(MODULE_TASKS_DATA_LIST);
+  private courses = this.queryDataList(COURSES_DATA_LIST);
+
+  private filterFields = computed<IModuleTaskFilterFields>(
+    () =>
+      Object.fromEntries(
+        FILTER_FIELD_NAMES.map((field) => [field, this.templateFieldService.getField(field, false)])
+      ) as IModuleTaskFilterFields
   );
 
-  private courses = toSignal(
-    this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", COURSES_DATA_LIST),
-    { initialValue: [] as FlowTypes.Data_listRow[] }
+  private resolved = computed(() =>
+    resolveUpNextValue(this.moduleTasks(), this.filterFields(), this.courses())
   );
 
-  /** Contact fields referenced by module task checks. */
-  private filterFields = computed<IModuleTaskFilterFields>(() => ({
-    child_age_tag: this.templateFieldService.getField("child_age_tag", false),
-    child_age: this.templateFieldService.getField("child_age", false),
-    child_gender: this.templateFieldService.getField("child_gender", false),
-    user_gender: this.templateFieldService.getField("user_gender", false),
-    user_relationship: this.templateFieldService.getField("user_relationship", false),
-  }));
-
-  upNext = computed(() => resolveUpNext(this.moduleTasks(), this.filterFields()));
-
-  upNextValue = computed(() => {
-    const upNext = this.upNext();
-    if (!upNext) return undefined;
-    return withCourseTitle(upNext.value, this.courses());
-  });
-
-  upNextTask = computed(() => this.upNext()?.task);
+  /** Primary matched module task row, exposed for tests and debugging. */
+  upNextTask = computed(() => this.resolved()?.task);
 
   constructor() {
     super();
     this.shouldShow.set(false);
     effect((onCleanup) => {
-      this.moduleTasks();
-      this.filterFields();
-      this.courses();
-      const resolved = this.upNextValue();
-
+      const resolvedValue = this.resolved()?.value;
       if (!this.parent) return;
 
       let cancelled = false;
@@ -98,12 +71,18 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
       queueMicrotask(() => {
         if (cancelled) return;
 
-        if (!resolved) {
+        if (!resolvedValue) {
           console.log("no in progress ATM");
         }
 
-        void this.setValueIfChanged(toSettledValue(resolved));
+        void this.setValueIfChanged(toSettledValue(resolvedValue));
       });
+    });
+  }
+
+  private queryDataList(listName: string) {
+    return toSignal(this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", listName), {
+      initialValue: [] as FlowTypes.Data_listRow[],
     });
   }
 
@@ -112,144 +91,4 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
       void this.setValue(value);
     }
   }
-}
-
-function resolveUpNext(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields
-): IUpNextResolution | undefined {
-  const inProgress = checkForInProgress(tasks, fields);
-  if (inProgress) {
-    return { task: inProgress, value: toModuleTaskValue(inProgress) };
-  }
-
-  const lastCompleted = checkForLastCompleted(tasks, fields);
-  if (lastCompleted) {
-    const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
-    if (nextInModule) {
-      return {
-        task: lastCompleted,
-        value: {
-          course_id: lastCompleted.tag_course,
-          module_id: nextInModule.id,
-          module_title: nextInModule.title,
-        },
-      };
-    }
-
-    return { task: lastCompleted, value: { course_id: lastCompleted.tag_course } };
-  }
-
-  const firstItem = getFirstItem(tasks, fields);
-  if (firstItem) {
-    return { task: firstItem, value: toModuleTaskValue(firstItem) };
-  }
-
-  return undefined;
-}
-
-function checkForInProgress(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields
-): FlowTypes.Data_listRow | undefined {
-  return pickTask(
-    tasks,
-    (task) => !!task.last_accessed_ts && !task.completed_ts && matchesModuleTaskLists(task, fields),
-    (a, b) => Number(b.last_accessed_ts) - Number(a.last_accessed_ts)
-  );
-}
-
-function checkForLastCompleted(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields
-): FlowTypes.Data_listRow | undefined {
-  return pickTask(
-    tasks,
-    (task) => !!task.completed_ts && matchesModuleTaskLists(task, fields),
-    (a, b) => Number(b.completed_ts) - Number(a.completed_ts)
-  );
-}
-
-function getNextInModule(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields,
-  courseId: unknown
-): FlowTypes.Data_listRow | undefined {
-  return pickTask(
-    tasks,
-    (task) =>
-      !task.completed_ts && task.tag_course == courseId && matchesModuleTaskLists(task, fields),
-    (a, b) => Number(a.number) - Number(b.number)
-  );
-}
-
-function getFirstItem(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields
-): FlowTypes.Data_listRow | undefined {
-  return pickTask(
-    tasks,
-    (task) => !task.completed_ts && matchesModuleTaskLists(task, fields),
-    (a, b) => Number(a.number) - Number(b.number)
-  );
-}
-
-function toModuleTaskValue(row: FlowTypes.Data_listRow): IResolvedUpNextValue {
-  return {
-    module_id: row.id,
-    module_title: row.title,
-    course_id: row.tag_course,
-  };
-}
-
-function withCourseTitle(
-  value: IResolvedUpNextValue,
-  courses: FlowTypes.Data_listRow[]
-): IResolvedUpNextValue {
-  if (!value.course_id) {
-    return value;
-  }
-
-  const course = courses.find((row) => row.id === value.course_id);
-  if (!course?.title) {
-    return value;
-  }
-
-  return { ...value, course_title: course.title };
-}
-
-function toSettledValue(resolved?: IResolvedUpNextValue): IUpNextValue {
-  if (!resolved) {
-    return { check_complete: true };
-  }
-
-  return { ...resolved, check_complete: true };
-}
-
-function pickTask(
-  tasks: FlowTypes.Data_listRow[],
-  predicate: (task: FlowTypes.Data_listRow) => boolean,
-  sort: (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) => number
-): FlowTypes.Data_listRow | undefined {
-  const matches = tasks.filter(predicate).sort(sort);
-  return matches[0];
-}
-
-function matchesModuleTaskLists(
-  task: FlowTypes.Data_listRow,
-  fields: IModuleTaskFilterFields
-): boolean {
-  return (
-    listIncludesOrUnset(task.tag_list, fields.child_age_tag) &&
-    listIncludesOrUnset(task.age_list, fields.child_age) &&
-    listIncludesOrUnset(task.child_gender_list, fields.child_gender) &&
-    listIncludesOrUnset(task.user_gender_list, fields.user_gender) &&
-    listIncludesOrUnset(task.caregiver_relationship_list, fields.user_relationship)
-  );
-}
-
-/** Pass when the list is unset; otherwise require the value to be included. */
-function listIncludesOrUnset(list: unknown, value: unknown): boolean {
-  if (!list) return true;
-  return Array.isArray(list) && list.includes(value);
 }

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -10,6 +10,7 @@ import { TemplateFieldService } from "src/app/shared/components/template/service
 import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
 
 const MODULE_TASKS_DATA_LIST = "module_tasks";
+const COURSES_DATA_LIST = "courses";
 
 type IModuleTaskFilterFields = {
   child_age_tag: unknown;
@@ -19,10 +20,20 @@ type IModuleTaskFilterFields = {
   user_relationship: unknown;
 };
 
-type IUpNextValue = {
-  module_id: string;
-  module_title: string;
-  course_id: string;
+type IResolvedUpNextValue = {
+  course_id?: string;
+  course_title?: string;
+  module_id?: string;
+  module_title?: string;
+};
+
+type IUpNextValue = IResolvedUpNextValue & {
+  check_complete: boolean;
+};
+
+type IUpNextResolution = {
+  value: IResolvedUpNextValue;
+  task: FlowTypes.Data_listRow;
 };
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({}));
@@ -42,6 +53,11 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     { initialValue: [] as FlowTypes.Data_listRow[] }
   );
 
+  private courses = toSignal(
+    this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", COURSES_DATA_LIST),
+    { initialValue: [] as FlowTypes.Data_listRow[] }
+  );
+
   /** Contact fields referenced by module task checks. */
   private filterFields = computed<IModuleTaskFilterFields>(() => ({
     child_age_tag: this.templateFieldService.getField("child_age_tag", false),
@@ -51,54 +67,178 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     user_relationship: this.templateFieldService.getField("user_relationship", false),
   }));
 
-  /** Resolved module task for "up next", if any check finds a match. */
-  upNextTask = computed(() => resolveUpNextTask(this.moduleTasks(), this.filterFields()));
+  upNext = computed(() => resolveUpNext(this.moduleTasks(), this.filterFields()));
+
+  upNextValue = computed(() => {
+    const upNext = this.upNext();
+    if (!upNext) return undefined;
+    return withCourseTitle(upNext.value, this.courses());
+  });
+
+  upNextTask = computed(() => this.upNext()?.task);
 
   constructor() {
     super();
     this.shouldShow.set(false);
-    effect(() => {
-      const nextTask = this.upNextTask();
+    effect((onCleanup) => {
+      this.moduleTasks();
+      this.filterFields();
+      this.courses();
+      const resolved = this.upNextValue();
+
       if (!this.parent) return;
 
-      if (nextTask) {
-        const value = toUpNextValue(nextTask);
-        if (!isEqual(value, this._row?.value)) {
-          void this.setValue(value);
-        }
-        return;
-      }
+      let cancelled = false;
+      onCleanup(() => {
+        cancelled = true;
+      });
 
-      console.log("no in progress ATM");
+      void this.setValueIfChanged({ check_complete: false });
+
+      queueMicrotask(() => {
+        if (cancelled) return;
+
+        if (!resolved) {
+          console.log("no in progress ATM");
+        }
+
+        void this.setValueIfChanged(toSettledValue(resolved));
+      });
     });
+  }
+
+  private setValueIfChanged(value: IUpNextValue) {
+    if (!isEqual(value, this._row?.value)) {
+      void this.setValue(value);
+    }
   }
 }
 
-function resolveUpNextTask(
+function resolveUpNext(
   tasks: FlowTypes.Data_listRow[],
   fields: IModuleTaskFilterFields
-): FlowTypes.Data_listRow | undefined {
-  return checkForInProgress(tasks, fields);
-  // Add further checks here when no in-progress task is found.
+): IUpNextResolution | undefined {
+  const inProgress = checkForInProgress(tasks, fields);
+  if (inProgress) {
+    return { task: inProgress, value: toModuleTaskValue(inProgress) };
+  }
+
+  const lastCompleted = checkForLastCompleted(tasks, fields);
+  if (lastCompleted) {
+    const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
+    if (nextInModule) {
+      return {
+        task: lastCompleted,
+        value: {
+          course_id: lastCompleted.tag_course,
+          module_id: nextInModule.id,
+          module_title: nextInModule.title,
+        },
+      };
+    }
+
+    return { task: lastCompleted, value: { course_id: lastCompleted.tag_course } };
+  }
+
+  const firstItem = getFirstItem(tasks, fields);
+  if (firstItem) {
+    return { task: firstItem, value: toModuleTaskValue(firstItem) };
+  }
+
+  return undefined;
 }
 
 function checkForInProgress(
   tasks: FlowTypes.Data_listRow[],
   fields: IModuleTaskFilterFields
 ): FlowTypes.Data_listRow | undefined {
-  return tasks
-    .filter((task) => matchesInProgressModuleTask(task, fields))
-    .sort((a, b) => Number(b.last_accessed_ts) - Number(a.last_accessed_ts))[0];
+  return pickTask(
+    tasks,
+    (task) => !!task.last_accessed_ts && !task.completed_ts && matchesModuleTaskLists(task, fields),
+    (a, b) => Number(b.last_accessed_ts) - Number(a.last_accessed_ts)
+  );
 }
 
-function matchesInProgressModuleTask(
+function checkForLastCompleted(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) => !!task.completed_ts && matchesModuleTaskLists(task, fields),
+    (a, b) => Number(b.completed_ts) - Number(a.completed_ts)
+  );
+}
+
+function getNextInModule(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields,
+  courseId: unknown
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) =>
+      !task.completed_ts && task.tag_course == courseId && matchesModuleTaskLists(task, fields),
+    (a, b) => Number(a.number) - Number(b.number)
+  );
+}
+
+function getFirstItem(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) => !task.completed_ts && matchesModuleTaskLists(task, fields),
+    (a, b) => Number(a.number) - Number(b.number)
+  );
+}
+
+function toModuleTaskValue(row: FlowTypes.Data_listRow): IResolvedUpNextValue {
+  return {
+    module_id: row.id,
+    module_title: row.title,
+    course_id: row.tag_course,
+  };
+}
+
+function withCourseTitle(
+  value: IResolvedUpNextValue,
+  courses: FlowTypes.Data_listRow[]
+): IResolvedUpNextValue {
+  if (!value.course_id) {
+    return value;
+  }
+
+  const course = courses.find((row) => row.id === value.course_id);
+  if (!course?.title) {
+    return value;
+  }
+
+  return { ...value, course_title: course.title };
+}
+
+function toSettledValue(resolved?: IResolvedUpNextValue): IUpNextValue {
+  if (!resolved) {
+    return { check_complete: true };
+  }
+
+  return { ...resolved, check_complete: true };
+}
+
+function pickTask(
+  tasks: FlowTypes.Data_listRow[],
+  predicate: (task: FlowTypes.Data_listRow) => boolean,
+  sort: (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) => number
+): FlowTypes.Data_listRow | undefined {
+  const matches = tasks.filter(predicate).sort(sort);
+  return matches[0];
+}
+
+function matchesModuleTaskLists(
   task: FlowTypes.Data_listRow,
   fields: IModuleTaskFilterFields
 ): boolean {
-  if (!task.last_accessed_ts || task.completed_ts) {
-    return false;
-  }
-
   return (
     listIncludesOrUnset(task.tag_list, fields.child_age_tag) &&
     listIncludesOrUnset(task.age_list, fields.child_age) &&
@@ -106,14 +246,6 @@ function matchesInProgressModuleTask(
     listIncludesOrUnset(task.user_gender_list, fields.user_gender) &&
     listIncludesOrUnset(task.caregiver_relationship_list, fields.user_relationship)
   );
-}
-
-function toUpNextValue(row: FlowTypes.Data_listRow): IUpNextValue {
-  return {
-    module_id: row.id,
-    module_title: row.title,
-    course_id: row.tag_course,
-  };
 }
 
 /** Pass when the list is unset; otherwise require the value to be included. */

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -58,6 +58,7 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     super();
     this.shouldShow.set(false);
     effect((onCleanup) => {
+      this.rowSignal();
       const resolvedValue = this.resolved()?.value;
       if (!this.parent) return;
 
@@ -66,17 +67,16 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
         cancelled = true;
       });
 
-      void this.setValueIfChanged({ check_complete: false });
-
-      queueMicrotask(() => {
+      void (async () => {
+        await this.setValueIfChanged({ check_complete: false });
         if (cancelled) return;
 
         if (!resolvedValue) {
           console.log("no in progress ATM");
         }
 
-        void this.setValueIfChanged(toSettledValue(resolvedValue));
-      });
+        await this.setValueIfChanged(toSettledValue(resolvedValue));
+      })();
     });
   }
 
@@ -86,9 +86,9 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     });
   }
 
-  private setValueIfChanged(value: IUpNextValue) {
+  private async setValueIfChanged(value: IUpNextValue) {
     if (!isEqual(value, this._row?.value)) {
-      void this.setValue(value);
+      await this.setValue(value);
     }
   }
 }

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -1,19 +1,123 @@
-import { Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { FlowTypes } from "packages/data-models";
+import { isEqual } from "packages/shared/src/utils/object-utils";
 import {
   defineAuthorParameterSchema,
   TemplateBaseComponentWithParams,
 } from "src/app/shared/components/template/components/base";
+import { TemplateFieldService } from "src/app/shared/components/template/services/template-field.service";
+import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic-data.service";
+
+const MODULE_TASKS_DATA_LIST = "module_tasks";
+
+type IModuleTaskFilterFields = {
+  child_age_tag: unknown;
+  child_age: unknown;
+  child_gender: unknown;
+  user_gender: unknown;
+  user_relationship: unknown;
+};
+
+type IUpNextValue = {
+  module_id: string;
+  module_title: string;
+  course_id: string;
+};
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({}));
 
 @Component({
   selector: "plh-get-up-next",
   template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
 export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  private dynamicDataService = inject(DynamicDataService);
+  private templateFieldService = inject(TemplateFieldService);
+
+  private moduleTasks = toSignal(
+    this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", MODULE_TASKS_DATA_LIST),
+    { initialValue: [] as FlowTypes.Data_listRow[] }
+  );
+
+  /** Contact fields referenced by module task checks. */
+  private filterFields = computed<IModuleTaskFilterFields>(() => ({
+    child_age_tag: this.templateFieldService.getField("child_age_tag", false),
+    child_age: this.templateFieldService.getField("child_age", false),
+    child_gender: this.templateFieldService.getField("child_gender", false),
+    user_gender: this.templateFieldService.getField("user_gender", false),
+    user_relationship: this.templateFieldService.getField("user_relationship", false),
+  }));
+
+  /** Resolved module task for "up next", if any check finds a match. */
+  upNextTask = computed(() => resolveUpNextTask(this.moduleTasks(), this.filterFields()));
+
   constructor() {
     super();
     this.shouldShow.set(false);
+    effect(() => {
+      const nextTask = this.upNextTask();
+      if (!this.parent) return;
+
+      if (nextTask) {
+        const value = toUpNextValue(nextTask);
+        if (!isEqual(value, this._row?.value)) {
+          void this.setValue(value);
+        }
+        return;
+      }
+
+      console.log("no in progress ATM");
+    });
   }
+}
+
+function resolveUpNextTask(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return checkForInProgress(tasks, fields);
+  // Add further checks here when no in-progress task is found.
+}
+
+function checkForInProgress(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return tasks
+    .filter((task) => matchesInProgressModuleTask(task, fields))
+    .sort((a, b) => Number(b.last_accessed_ts) - Number(a.last_accessed_ts))[0];
+}
+
+function matchesInProgressModuleTask(
+  task: FlowTypes.Data_listRow,
+  fields: IModuleTaskFilterFields
+): boolean {
+  if (!task.last_accessed_ts || task.completed_ts) {
+    return false;
+  }
+
+  return (
+    listIncludesOrUnset(task.tag_list, fields.child_age_tag) &&
+    listIncludesOrUnset(task.age_list, fields.child_age) &&
+    listIncludesOrUnset(task.child_gender_list, fields.child_gender) &&
+    listIncludesOrUnset(task.user_gender_list, fields.user_gender) &&
+    listIncludesOrUnset(task.caregiver_relationship_list, fields.user_relationship)
+  );
+}
+
+function toUpNextValue(row: FlowTypes.Data_listRow): IUpNextValue {
+  return {
+    module_id: row.id,
+    module_title: row.title,
+    course_id: row.tag_course,
+  };
+}
+
+/** Pass when the list is unset; otherwise require the value to be included. */
+function listIncludesOrUnset(list: unknown, value: unknown): boolean {
+  if (!list) return true;
+  return Array.isArray(list) && list.includes(value);
 }

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
+import { distinctUntilChanged } from "rxjs";
 import { FlowTypes } from "packages/data-models";
 import { isEqual } from "packages/shared/src/utils/object-utils";
 import {
@@ -11,6 +12,7 @@ import { DynamicDataService } from "src/app/shared/services/dynamic-data/dynamic
 import {
   COURSES_DATA_LIST,
   IModuleTaskFilterFields,
+  IResolvedUpNextValue,
   IUpNextValue,
   MODULE_TASKS_DATA_LIST,
   resolveUpNextValue,
@@ -36,6 +38,7 @@ const FILTER_FIELD_NAMES = [
 export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
   private dynamicDataService = inject(DynamicDataService);
   private templateFieldService = inject(TemplateFieldService);
+  private lastPublishedResolved: IResolvedUpNextValue | undefined;
 
   private moduleTasks = this.queryDataList(MODULE_TASKS_DATA_LIST);
   private courses = this.queryDataList(COURSES_DATA_LIST);
@@ -58,9 +61,11 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     super();
     this.shouldShow.set(false);
     effect((onCleanup) => {
-      this.rowSignal();
       const resolvedValue = this.resolved()?.value;
       if (!this.parent) return;
+      if (isEqual(resolvedValue, this.lastPublishedResolved)) {
+        return;
+      }
 
       let cancelled = false;
       onCleanup(() => {
@@ -71,19 +76,23 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
         await this.setValueIfChanged({ check_complete: false });
         if (cancelled) return;
 
-        if (!resolvedValue) {
-          console.log("no in progress ATM");
-        }
-
         await this.setValueIfChanged(toSettledValue(resolvedValue));
+        if (!cancelled) {
+          this.lastPublishedResolved = resolvedValue;
+        }
       })();
     });
   }
 
   private queryDataList(listName: string) {
-    return toSignal(this.dynamicDataService.query$<FlowTypes.Data_listRow>("data_list", listName), {
-      initialValue: [] as FlowTypes.Data_listRow[],
-    });
+    return toSignal(
+      this.dynamicDataService
+        .query$<FlowTypes.Data_listRow>("data_list", listName)
+        .pipe(distinctUntilChanged(isEqual)),
+      {
+        initialValue: [] as FlowTypes.Data_listRow[],
+      }
+    );
   }
 
   private async setValueIfChanged(value: IUpNextValue) {

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -1,0 +1,19 @@
+import { Component } from "@angular/core";
+import {
+  defineAuthorParameterSchema,
+  TemplateBaseComponentWithParams,
+} from "src/app/shared/components/template/components/base";
+
+const AuthorSchema = defineAuthorParameterSchema((coerce) => ({}));
+
+@Component({
+  selector: "plh-get-up-next",
+  template: "",
+  standalone: false,
+})
+export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  constructor() {
+    super();
+    this.shouldShow.set(false);
+  }
+}

--- a/packages/components/plh/get-up-next/get-up-next.component.ts
+++ b/packages/components/plh/get-up-next/get-up-next.component.ts
@@ -38,7 +38,7 @@ const FILTER_FIELD_NAMES = [
 export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
   private dynamicDataService = inject(DynamicDataService);
   private templateFieldService = inject(TemplateFieldService);
-  private lastPublishedResolved: IResolvedUpNextValue | undefined;
+  private lastPublishedResolved: IResolvedUpNextValue | undefined | null = null;
 
   private moduleTasks = this.queryDataList(MODULE_TASKS_DATA_LIST);
   private courses = this.queryDataList(COURSES_DATA_LIST);
@@ -63,7 +63,10 @@ export class PlhGetUpNextComponent extends TemplateBaseComponentWithParams(Autho
     effect((onCleanup) => {
       const resolvedValue = this.resolved()?.value;
       if (!this.parent) return;
-      if (isEqual(resolvedValue, this.lastPublishedResolved)) {
+      if (
+        this.lastPublishedResolved !== null &&
+        isEqual(resolvedValue, this.lastPublishedResolved)
+      ) {
         return;
       }
 

--- a/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
@@ -110,6 +110,7 @@ describe("resolveUpNextValue", () => {
       ]
     );
 
+    expect(resolution?.task.id).toBe("b_next");
     expect(resolution?.value.module_id).toBe("b_next");
     expect(resolution?.value.course_id).toBe("course_b");
   });

--- a/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
@@ -68,4 +68,94 @@ describe("resolveUpNextValue", () => {
 
     expect(resolution).toBeUndefined();
   });
+
+  it("should advance to the next module in course B after completing in course B", () => {
+    const resolution = resolveUpNextValue(
+      [
+        {
+          id: "a_first",
+          title: "Course A first",
+          tag_course: "course_a",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "a_done",
+          title: "Course A done",
+          tag_course: "course_a",
+          number: 2,
+          completed_ts: "2025-01-01T10:00:00",
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "b_done",
+          title: "Course B done",
+          tag_course: "course_b",
+          number: 1,
+          completed_ts: "2025-06-01T10:00:00",
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "b_next",
+          title: "Course B next",
+          tag_course: "course_b",
+          number: 2,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      defaultFields,
+      [
+        { id: "course_a", title: "Course A" },
+        { id: "course_b", title: "Course B" },
+      ]
+    );
+
+    expect(resolution?.value.module_id).toBe("b_next");
+    expect(resolution?.value.course_id).toBe("course_b");
+  });
+
+  it("should sort completed_ts ISO strings by time rather than lexicographically", () => {
+    const resolution = resolveUpNextValue(
+      [
+        {
+          id: "a_first",
+          title: "Course A first",
+          tag_course: "course_a",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "a_done",
+          title: "Course A done",
+          tag_course: "course_a",
+          number: 2,
+          completed_ts: "2025-12-01T10:00:00",
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "b_done",
+          title: "Course B done",
+          tag_course: "course_b",
+          number: 1,
+          completed_ts: "2025-06-01T10:00:00",
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "b_next",
+          title: "Course B next",
+          tag_course: "course_b",
+          number: 2,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      defaultFields,
+      [
+        { id: "course_a", title: "Course A" },
+        { id: "course_b", title: "Course B" },
+      ]
+    );
+
+    expect(resolution?.value.module_id).toBe("a_first");
+    expect(resolution?.value.course_id).toBe("course_a");
+  });
 });

--- a/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.spec.ts
@@ -1,0 +1,71 @@
+import { resolveUpNextValue } from "./get-up-next.logic";
+
+const defaultFields = {
+  child_age_tag: "age_5_9",
+  child_age: "7",
+  child_gender: "female",
+  user_gender: "female",
+  user_relationship: "mother",
+};
+
+describe("resolveUpNextValue", () => {
+  it("should use getFirstItem when the last completed course has no following module", () => {
+    const resolution = resolveUpNextValue(
+      [
+        {
+          id: "i_calm_c",
+          title: "Mantener la calma cuando hay estrés",
+          tag_course: "relation_c",
+          number: 3,
+          completed_ts: 100,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "first_mood",
+          title: "First mood module",
+          tag_course: "mood_c",
+          number: 1,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      defaultFields,
+      [
+        { id: "relation_c", title: "Mejorar la relación con mi niña o niño" },
+        { id: "mood_c", title: "Mood course" },
+      ]
+    );
+
+    expect(resolution?.task.id).toBe("first_mood");
+    expect(resolution?.value).toEqual({
+      course_id: "mood_c",
+      course_title: "Mood course",
+      module_id: "first_mood",
+      module_title: "First mood module",
+    });
+  });
+
+  it("should return undefined when all modules are complete", () => {
+    const resolution = resolveUpNextValue(
+      [
+        {
+          id: "older_completed",
+          title: "Older module",
+          tag_course: "course_a",
+          completed_ts: 1,
+          tag_list: ["age_5_9"],
+        },
+        {
+          id: "newer_completed",
+          title: "Newer module",
+          tag_course: "course_b",
+          completed_ts: 2,
+          tag_list: ["age_5_9"],
+        },
+      ],
+      defaultFields,
+      [{ id: "course_b", title: "Course B" }]
+    );
+
+    expect(resolution).toBeUndefined();
+  });
+});

--- a/packages/components/plh/get-up-next/get-up-next.logic.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.ts
@@ -56,26 +56,28 @@ function resolveUpNext(
   tasks: FlowTypes.Data_listRow[],
   fields: IModuleTaskFilterFields
 ): IUpNextResolution | undefined {
+  // 1. Resume the most recently accessed incomplete module.
   const inProgress = checkForInProgress(tasks, fields);
   if (inProgress) {
     return { task: inProgress, value: toModuleTaskValue(inProgress) };
   }
 
+  // 2. After a completion, continue within that course if possible.
   const lastCompleted = checkForLastCompleted(tasks, fields);
   if (lastCompleted) {
     const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
     if (nextInModule) {
       return {
-        task: lastCompleted,
+        task: nextInModule,
         value: {
+          ...toModuleTaskValue(nextInModule),
           course_id: lastCompleted.tag_course,
-          module_id: nextInModule.id,
-          module_title: nextInModule.title,
         },
       };
     }
   }
 
+  // 3. Fall back to the first incomplete module globally.
   const firstItem = getFirstItem(tasks, fields);
   if (firstItem) {
     return { task: firstItem, value: toModuleTaskValue(firstItem) };

--- a/packages/components/plh/get-up-next/get-up-next.logic.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.ts
@@ -91,7 +91,7 @@ function checkForInProgress(
   return pickTask(
     tasks,
     (task) => !!task.last_accessed_ts && !task.completed_ts && matchesModuleTaskLists(task, fields),
-    sortByNumberDesc("last_accessed_ts")
+    sortByTimestampDesc("last_accessed_ts")
   );
 }
 
@@ -102,7 +102,7 @@ function checkForLastCompleted(
   return pickTask(
     tasks,
     (task) => !!task.completed_ts && matchesModuleTaskLists(task, fields),
-    sortByNumberDesc("completed_ts")
+    sortByTimestampDesc("completed_ts")
   );
 }
 
@@ -168,14 +168,36 @@ function pickTask(
   return tasks.filter(predicate).sort(sort)[0];
 }
 
-function sortByNumberDesc(field: string) {
+function sortByTimestampDesc(field: string) {
   return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
-    (Number(b[field]) || 0) - (Number(a[field]) || 0);
+    toTimestampMs(b[field]) - toTimestampMs(a[field]);
 }
 
 function sortByNumberAsc(field: string) {
   return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
-    (Number(a[field]) || 0) - (Number(b[field]) || 0);
+    toNumber(a[field]) - toNumber(b[field]);
+}
+
+function toTimestampMs(value: unknown): number {
+  if (value == null || value === "") {
+    return 0;
+  }
+
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  const ms = new Date(value as string | number).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+function toNumber(value: unknown): number {
+  const number = Number(value);
+  return Number.isNaN(number) ? 0 : number;
 }
 
 function matchesModuleTaskLists(

--- a/packages/components/plh/get-up-next/get-up-next.logic.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.ts
@@ -1,0 +1,207 @@
+import { FlowTypes } from "packages/data-models";
+
+export const MODULE_TASKS_DATA_LIST = "module_tasks";
+export const COURSES_DATA_LIST = "courses";
+
+export type IModuleTaskFilterFields = {
+  child_age_tag: unknown;
+  child_age: unknown;
+  child_gender: unknown;
+  user_gender: unknown;
+  user_relationship: unknown;
+};
+
+export type IResolvedUpNextValue = {
+  course_id?: string;
+  course_title?: string;
+  module_id?: string;
+  module_title?: string;
+};
+
+export type IUpNextValue = IResolvedUpNextValue & {
+  check_complete: boolean;
+};
+
+export type IUpNextResolution = {
+  value: IResolvedUpNextValue;
+  task: FlowTypes.Data_listRow;
+};
+
+/** Resolve up-next from module tasks, enrich with course title, ready for publishing. */
+export function resolveUpNextValue(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields,
+  courses: FlowTypes.Data_listRow[]
+): IUpNextResolution | undefined {
+  const resolution = resolveUpNext(tasks, fields);
+  if (!resolution) {
+    return undefined;
+  }
+
+  return {
+    ...resolution,
+    value: withCourseTitle(resolution.value, courses),
+  };
+}
+
+export function toSettledValue(resolved?: IResolvedUpNextValue): IUpNextValue {
+  if (!resolved) {
+    return { check_complete: true };
+  }
+
+  return { ...resolved, check_complete: true };
+}
+
+function resolveUpNext(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): IUpNextResolution | undefined {
+  const inProgress = checkForInProgress(tasks, fields);
+  if (inProgress) {
+    return { task: inProgress, value: toModuleTaskValue(inProgress) };
+  }
+
+  const lastCompleted = checkForLastCompleted(tasks, fields);
+  if (lastCompleted) {
+    return resolveFromLastCompleted(tasks, fields, lastCompleted);
+  }
+
+  const firstItem = getFirstItem(tasks, fields);
+  if (firstItem) {
+    return { task: firstItem, value: toModuleTaskValue(firstItem) };
+  }
+
+  return undefined;
+}
+
+function resolveFromLastCompleted(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields,
+  lastCompleted: FlowTypes.Data_listRow
+): IUpNextResolution {
+  const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
+  if (!nextInModule) {
+    return { task: lastCompleted, value: { course_id: lastCompleted.tag_course } };
+  }
+
+  return {
+    task: lastCompleted,
+    value: {
+      course_id: lastCompleted.tag_course,
+      module_id: nextInModule.id,
+      module_title: nextInModule.title,
+    },
+  };
+}
+
+function checkForInProgress(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) => !!task.last_accessed_ts && !task.completed_ts && matchesModuleTaskLists(task, fields),
+    sortByNumberDesc("last_accessed_ts")
+  );
+}
+
+function checkForLastCompleted(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) => !!task.completed_ts && matchesModuleTaskLists(task, fields),
+    sortByNumberDesc("completed_ts")
+  );
+}
+
+function getNextInModule(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields,
+  courseId: unknown
+): FlowTypes.Data_listRow | undefined {
+  return pickIncompleteTask(tasks, fields, courseId);
+}
+
+function getFirstItem(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields
+): FlowTypes.Data_listRow | undefined {
+  return pickIncompleteTask(tasks, fields);
+}
+
+function pickIncompleteTask(
+  tasks: FlowTypes.Data_listRow[],
+  fields: IModuleTaskFilterFields,
+  courseId?: unknown
+): FlowTypes.Data_listRow | undefined {
+  return pickTask(
+    tasks,
+    (task) =>
+      !task.completed_ts &&
+      matchesModuleTaskLists(task, fields) &&
+      (courseId === undefined || task.tag_course == courseId),
+    sortByNumberAsc("number")
+  );
+}
+
+function toModuleTaskValue(row: FlowTypes.Data_listRow): IResolvedUpNextValue {
+  return {
+    module_id: row.id,
+    module_title: row.title,
+    course_id: row.tag_course,
+  };
+}
+
+function withCourseTitle(
+  value: IResolvedUpNextValue,
+  courses: FlowTypes.Data_listRow[]
+): IResolvedUpNextValue {
+  if (!value.course_id) {
+    return value;
+  }
+
+  const course = courses.find((row) => row.id === value.course_id);
+  if (!course?.title) {
+    return value;
+  }
+
+  return { ...value, course_title: course.title };
+}
+
+function pickTask(
+  tasks: FlowTypes.Data_listRow[],
+  predicate: (task: FlowTypes.Data_listRow) => boolean,
+  sort: (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) => number
+): FlowTypes.Data_listRow | undefined {
+  return tasks.filter(predicate).sort(sort)[0];
+}
+
+function sortByNumberDesc(field: string) {
+  return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
+    Number(b[field]) - Number(a[field]);
+}
+
+function sortByNumberAsc(field: string) {
+  return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
+    Number(a[field]) - Number(b[field]);
+}
+
+function matchesModuleTaskLists(
+  task: FlowTypes.Data_listRow,
+  fields: IModuleTaskFilterFields
+): boolean {
+  return (
+    listIncludesOrUnset(task.tag_list, fields.child_age_tag) &&
+    listIncludesOrUnset(task.age_list, fields.child_age) &&
+    listIncludesOrUnset(task.child_gender_list, fields.child_gender) &&
+    listIncludesOrUnset(task.user_gender_list, fields.user_gender) &&
+    listIncludesOrUnset(task.caregiver_relationship_list, fields.user_relationship)
+  );
+}
+
+function listIncludesOrUnset(list: unknown, value: unknown): boolean {
+  if (!list) return true;
+  return Array.isArray(list) && list.includes(value);
+}

--- a/packages/components/plh/get-up-next/get-up-next.logic.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.ts
@@ -141,7 +141,7 @@ function pickIncompleteTask(
     (task) =>
       !task.completed_ts &&
       matchesModuleTaskLists(task, fields) &&
-      (courseId === undefined || task.tag_course == courseId),
+      (courseId === undefined || task.tag_course === courseId),
     sortByNumberAsc("number")
   );
 }
@@ -180,12 +180,12 @@ function pickTask(
 
 function sortByNumberDesc(field: string) {
   return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
-    Number(b[field]) - Number(a[field]);
+    (Number(b[field]) || 0) - (Number(a[field]) || 0);
 }
 
 function sortByNumberAsc(field: string) {
   return (a: FlowTypes.Data_listRow, b: FlowTypes.Data_listRow) =>
-    Number(a[field]) - Number(b[field]);
+    (Number(a[field]) || 0) - (Number(b[field]) || 0);
 }
 
 function matchesModuleTaskLists(

--- a/packages/components/plh/get-up-next/get-up-next.logic.ts
+++ b/packages/components/plh/get-up-next/get-up-next.logic.ts
@@ -63,7 +63,17 @@ function resolveUpNext(
 
   const lastCompleted = checkForLastCompleted(tasks, fields);
   if (lastCompleted) {
-    return resolveFromLastCompleted(tasks, fields, lastCompleted);
+    const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
+    if (nextInModule) {
+      return {
+        task: lastCompleted,
+        value: {
+          course_id: lastCompleted.tag_course,
+          module_id: nextInModule.id,
+          module_title: nextInModule.title,
+        },
+      };
+    }
   }
 
   const firstItem = getFirstItem(tasks, fields);
@@ -72,26 +82,6 @@ function resolveUpNext(
   }
 
   return undefined;
-}
-
-function resolveFromLastCompleted(
-  tasks: FlowTypes.Data_listRow[],
-  fields: IModuleTaskFilterFields,
-  lastCompleted: FlowTypes.Data_listRow
-): IUpNextResolution {
-  const nextInModule = getNextInModule(tasks, fields, lastCompleted.tag_course);
-  if (!nextInModule) {
-    return { task: lastCompleted, value: { course_id: lastCompleted.tag_course } };
-  }
-
-  return {
-    task: lastCompleted,
-    value: {
-      course_id: lastCompleted.tag_course,
-      module_id: nextInModule.id,
-      module_title: nextInModule.title,
-    },
-  };
 }
 
 function checkForInProgress(

--- a/packages/components/plh/index.ts
+++ b/packages/components/plh/index.ts
@@ -12,6 +12,7 @@ import { PlhParentGroupModule } from "./parent-group/plh-parent-group.module";
 import { PlhParentPointBoxComponent } from "./parent-point-box/parent-point-box.component";
 import { PlhParentPointCounterComponent } from "./parent-point-counter/parent-point-counter.component";
 import { PlhProgressBarComponent } from "./progress-bar/progress-bar.component";
+import { PlhGetUpNextComponent } from "./get-up-next/get-up-next.component";
 
 export {
   PlhActivityCheckInComponent,
@@ -28,6 +29,7 @@ export {
   PlhParentPointCounterComponent,
   PlhProgressPathComponent,
   PlhProgressBarComponent,
+  PlhGetUpNextComponent,
 };
 
 export const PLH_FEATURE_MODULES = [PlhCertificateModule, PlhParentGroupModule];
@@ -45,6 +47,7 @@ export const PLH_COMPONENTS = [
   PlhParentPointCounterComponent,
   PlhProgressPathComponent,
   PlhProgressBarComponent,
+  PlhGetUpNextComponent,
 ];
 
 export const PLH_COMPONENT_MAPPING = {
@@ -60,6 +63,7 @@ export const PLH_COMPONENT_MAPPING = {
   plh_module_list_item: PlhModuleListItemComponent,
   plh_progress_path: PlhProgressPathComponent,
   plh_progress_bar: PlhProgressBarComponent,
+  plh_get_up_next: PlhGetUpNextComponent,
 };
 
 export type PLHComponentName = keyof typeof PLH_COMPONENT_MAPPING;


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a new component, `plh-get-up-next`, a headless PLH template component with a very specific purpose for the `plh_kids_teens_pa` deployment.

The component resolves the user's next module/course from module_tasks and publishes it as a row value for use elsewhere in the app.

Resolution priority:

1. In progress — most recently accessed, incomplete task matching the current user/child filters
2. After completion — next incomplete task in the same course, or the course alone if the course is finished
3. Fallback — first incomplete task (by number) matching filters

The published value includes `module_id`, `module_title`, `course_id`, and `course_title` (from the `courses` list), plus a `check_complete` flag so downstream logic can wait for resolution to settle.

## Git Issues

Closes #

## Screenshots/Videos

See [debug_home_screen_header](https://docs.google.com/spreadsheets/d/1SkxfFFUzSjkUaxGKvYxiec-mx0szbeR6TaqBwfbBJyQ/edit?gid=1094395418#gid=1094395418)

<img width="1000" alt="Screenshot 2026-06-30 at 16 48 16" src="https://github.com/user-attachments/assets/516e4077-2694-4036-950c-da704e74f23d" />

<img width="800" alt="Screenshot 2026-06-30 at 16 49 24" src="https://github.com/user-attachments/assets/96249e23-05d8-4eae-a544-291640e8574a" />
