### PR TITLE
fix: auth profile picture handling

### DIFF
--- a/src/app/shared/components/template/services/template-asset.service.ts
+++ b/src/app/shared/components/template/services/template-asset.service.ts
@@ -17,7 +17,7 @@ const ASSETS_GLOBAL_FOLDER_NAME = "global";
 const DEFAULT_THEME_NAME = "theme_default";
 
 /** URL prefixes that indicate external or native file paths that should not be modified */
-const EXTERNAL_URL_PREFIXES = ["http", "file://", "content://", "capacitor://"];
+const EXTERNAL_URL_PREFIXES = ["blob:", "http", "file://", "content://", "capacitor://"];
 
 @Injectable({ providedIn: "root" })
 export class TemplateAssetService extends AsyncServiceBase {

--- a/src/app/shared/services/auth/auth-profile-picture.service.spec.ts
+++ b/src/app/shared/services/auth/auth-profile-picture.service.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from "@angular/core/testing";
+import { Capacitor } from "@capacitor/core";
+import { AuthProfilePictureService } from "./auth-profile-picture.service";
+import { SystemVariableService } from "../system-variable/system-variable.service";
+import { FileManagerService } from "../file-manager/file-manager.service";
+
+/** Flush microtasks after fire-and-forget setFromRemoteUrl calls */
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("AuthProfilePictureService", () => {
+  let service: AuthProfilePictureService;
+  let systemVariableService: jasmine.SpyObj<SystemVariableService>;
+
+  beforeEach(() => {
+    systemVariableService = jasmine.createSpyObj("SystemVariableService", ["set", "remove"]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthProfilePictureService,
+        { provide: SystemVariableService, useValue: systemVariableService },
+        { provide: FileManagerService, useValue: {} },
+      ],
+    });
+    service = TestBed.inject(AuthProfilePictureService);
+  });
+
+  it("should cache via FileManager on native and store src in AUTH_USER_PICTURE", async () => {
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(true);
+    spyOn(service as any, "cacheViaFileManager").and.resolveTo({
+      src: "capacitor://localhost/_capacitor_file_/profile.jpg",
+      revoke: () => {},
+    });
+
+    service.setFromRemoteUrl("https://lh3.googleusercontent.com/a/example=s96-c");
+    await flushAsync();
+
+    expect((service as any).cacheViaFileManager).toHaveBeenCalledWith(
+      "https://lh3.googleusercontent.com/a/example=s96-c"
+    );
+    expect(systemVariableService.set).toHaveBeenCalledWith(
+      "AUTH_USER_PICTURE",
+      "capacitor://localhost/_capacitor_file_/profile.jpg"
+    );
+  });
+
+  it("should cache via Image element on web", async () => {
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(false);
+    const cached = {
+      src: "blob:http://localhost/cached-picture",
+      revoke: jasmine.createSpy("revoke"),
+    };
+    spyOn(service as any, "cacheViaImageElement").and.resolveTo(cached);
+
+    service.setFromRemoteUrl("https://lh3.googleusercontent.com/a/example=s96-c");
+    await flushAsync();
+
+    expect((service as any).cacheViaImageElement).toHaveBeenCalledWith(
+      "https://lh3.googleusercontent.com/a/example=s96-c"
+    );
+    expect(systemVariableService.set).toHaveBeenCalledWith(
+      "AUTH_USER_PICTURE",
+      "blob:http://localhost/cached-picture"
+    );
+  });
+
+  it("should dedupe concurrent requests for the same URL", async () => {
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(false);
+    let resolveCache: (value: { src: string; revoke: () => void }) => void;
+    const cachePromise = new Promise<{ src: string; revoke: () => void }>((resolve) => {
+      resolveCache = resolve;
+    });
+    spyOn(service as any, "cacheViaImageElement").and.returnValue(cachePromise);
+
+    const url = "https://lh3.googleusercontent.com/a/example=s96-c";
+    service.setFromRemoteUrl(url);
+    service.setFromRemoteUrl(url);
+
+    resolveCache!({ src: "blob:http://localhost/shared", revoke: () => {} });
+    await flushAsync();
+
+    expect((service as any).cacheViaImageElement).toHaveBeenCalledTimes(1);
+    expect(systemVariableService.set).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not throw when caching fails", async () => {
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(false);
+    spyOn(service as any, "cacheViaImageElement").and.rejectWith(new Error("Network error"));
+
+    expect(() => service.setFromRemoteUrl("https://example.com/photo.jpg")).not.toThrow();
+    await flushAsync();
+
+    expect(systemVariableService.set).toHaveBeenCalledWith("AUTH_USER_PICTURE", "");
+  });
+
+  it("should clear AUTH_USER_PICTURE when remote URL is empty", async () => {
+    service.setFromRemoteUrl("");
+    await flushAsync();
+
+    expect(systemVariableService.set).toHaveBeenCalledWith("AUTH_USER_PICTURE", "");
+  });
+
+  it("should remove AUTH_USER_PICTURE on clear", () => {
+    service.clear();
+
+    expect(systemVariableService.remove).toHaveBeenCalledWith("AUTH_USER_PICTURE");
+  });
+
+  it("should not throw when clear fails during revoke", () => {
+    (service as any).revoke = () => {
+      throw new Error("Revoke failed");
+    };
+
+    expect(() => service.clear()).not.toThrow();
+    expect(systemVariableService.remove).toHaveBeenCalledWith("AUTH_USER_PICTURE");
+  });
+});

--- a/src/app/shared/services/auth/auth-profile-picture.service.ts
+++ b/src/app/shared/services/auth/auth-profile-picture.service.ts
@@ -29,8 +29,8 @@ export class AuthProfilePictureService {
   private sessionRemoteUrl: string | undefined;
   private sessionSrc: string | undefined;
 
-  /** Dedupes concurrent setFromRemoteUrl calls for the same URL */
-  private pendingByUrl = new Map<string, Promise<void>>();
+  /** Tracks the in-flight remote URL to dedupe concurrent requests */
+  private latestRemoteUrl: string | undefined;
 
   constructor(
     private fileManagerService: FileManagerService,
@@ -42,18 +42,21 @@ export class AuthProfilePictureService {
    * in AUTH_USER_PICTURE. Fire-and-forget: never throws or blocks callers.
    */
   public setFromRemoteUrl(remoteUrl: string): void {
-    if (this.pendingByUrl.has(remoteUrl)) {
+    if (remoteUrl === this.latestRemoteUrl) {
       return;
     }
 
-    const task = this.applyRemoteUrl(remoteUrl)
+    this.latestRemoteUrl = remoteUrl;
+
+    this.applyRemoteUrl(remoteUrl)
       .catch((error) => {
         console.warn(LOG_PREFIX, "Unhandled error caching profile picture:", error);
       })
       .finally(() => {
-        this.pendingByUrl.delete(remoteUrl);
+        if (this.latestRemoteUrl === remoteUrl) {
+          this.latestRemoteUrl = undefined;
+        }
       });
-    this.pendingByUrl.set(remoteUrl, task);
   }
 
   private async applyRemoteUrl(remoteUrl: string) {
@@ -103,7 +106,7 @@ export class AuthProfilePictureService {
       this.cacheGeneration++;
       this.sessionRemoteUrl = undefined;
       this.sessionSrc = undefined;
-      this.pendingByUrl.clear();
+      this.latestRemoteUrl = undefined;
       this.revokeCached();
       this.systemVariableService.remove("AUTH_USER_PICTURE");
     } catch (error) {

--- a/src/app/shared/services/auth/auth-profile-picture.service.ts
+++ b/src/app/shared/services/auth/auth-profile-picture.service.ts
@@ -1,0 +1,199 @@
+import { Injectable } from "@angular/core";
+import { Capacitor } from "@capacitor/core";
+import { FileManagerService } from "../file-manager/file-manager.service";
+import { SystemVariableService } from "../system-variable/system-variable.service";
+
+/** Fixed path for native profile picture storage (overwritten on each login) */
+const AUTH_PROFILE_PICTURE_PATH = "auth/profile-picture.jpg";
+
+const LOG_PREFIX = "[Auth Profile Picture]";
+
+export interface ICachedProfilePicture {
+  src: string;
+  revoke: () => void;
+}
+
+/**
+ * Downloads and caches auth provider profile pictures (e.g. Google) to local
+ * display-ready URLs for use in AUTH_USER_PICTURE.
+ */
+@Injectable({ providedIn: "root" })
+export class AuthProfilePictureService {
+  /** Tracks in-flight cache requests so sign-out can invalidate stale updates */
+  private cacheGeneration = 0;
+
+  /** Revoke callback for web blob URLs created during profile picture caching */
+  private revoke: (() => void) | undefined;
+
+  /** Remote URL and src cached in the current session */
+  private sessionRemoteUrl: string | undefined;
+  private sessionSrc: string | undefined;
+
+  /** Dedupes concurrent setFromRemoteUrl calls for the same URL */
+  private pendingByUrl = new Map<string, Promise<void>>();
+
+  constructor(
+    private fileManagerService: FileManagerService,
+    private systemVariableService: SystemVariableService
+  ) {}
+
+  /**
+   * Download and cache a remote profile picture, then store a display-ready URL
+   * in AUTH_USER_PICTURE. Fire-and-forget: never throws or blocks callers.
+   */
+  public setFromRemoteUrl(remoteUrl: string): void {
+    if (this.pendingByUrl.has(remoteUrl)) {
+      return;
+    }
+
+    const task = this.applyRemoteUrl(remoteUrl)
+      .catch((error) => {
+        console.warn(LOG_PREFIX, "Unhandled error caching profile picture:", error);
+      })
+      .finally(() => {
+        this.pendingByUrl.delete(remoteUrl);
+      });
+    this.pendingByUrl.set(remoteUrl, task);
+  }
+
+  private async applyRemoteUrl(remoteUrl: string) {
+    const generation = this.cacheGeneration;
+
+    if (!remoteUrl) {
+      this.sessionRemoteUrl = undefined;
+      this.sessionSrc = undefined;
+      this.revokeCached();
+      this.systemVariableService.set("AUTH_USER_PICTURE", "");
+      return;
+    }
+
+    if (remoteUrl === this.sessionRemoteUrl && this.sessionSrc) {
+      this.systemVariableService.set("AUTH_USER_PICTURE", this.sessionSrc);
+      return;
+    }
+
+    try {
+      const cached = await this.resolveSrc(remoteUrl);
+
+      if (generation !== this.cacheGeneration) {
+        this.safeRevoke(cached.revoke);
+        return;
+      }
+
+      this.revokeCached();
+      this.revoke = cached.revoke;
+      this.sessionRemoteUrl = remoteUrl;
+      this.sessionSrc = cached.src;
+      this.systemVariableService.set("AUTH_USER_PICTURE", cached.src);
+    } catch (error) {
+      console.warn(LOG_PREFIX, "Failed to cache profile picture, clearing picture field:", error);
+      if (generation !== this.cacheGeneration) {
+        return;
+      }
+      this.sessionRemoteUrl = undefined;
+      this.sessionSrc = undefined;
+      this.revokeCached();
+      this.systemVariableService.set("AUTH_USER_PICTURE", "");
+    }
+  }
+
+  /** Invalidate in-flight updates and clear cached blob URLs. Never throws. */
+  public clear() {
+    try {
+      this.cacheGeneration++;
+      this.sessionRemoteUrl = undefined;
+      this.sessionSrc = undefined;
+      this.pendingByUrl.clear();
+      this.revokeCached();
+      this.systemVariableService.remove("AUTH_USER_PICTURE");
+    } catch (error) {
+      console.warn(LOG_PREFIX, "Error clearing profile picture cache:", error);
+    }
+  }
+
+  /**
+   * Resolve a remote profile picture URL to a local display-ready src.
+   * Provider URLs block fetch/ky on web and in the native WebView, so:
+   * - Web: Image element + canvas → blob URL
+   * - Native: FileManager.saveFile → capacitor file URL, with Image fallback
+   */
+  private async resolveSrc(remoteUrl: string): Promise<ICachedProfilePicture> {
+    if (Capacitor.isNativePlatform()) {
+      try {
+        return await this.cacheViaFileManager(remoteUrl);
+      } catch {
+        return this.cacheViaImageElement(remoteUrl);
+      }
+    }
+
+    return this.cacheViaImageElement(remoteUrl);
+  }
+
+  /** Native: download via fetch and save to app data directory */
+  private async cacheViaFileManager(remoteUrl: string): Promise<ICachedProfilePicture> {
+    const response = await fetch(remoteUrl, { referrerPolicy: "no-referrer" });
+    if (!response.ok) {
+      throw new Error(`Failed to download profile picture (${response.status})`);
+    }
+    const blob = await response.blob();
+    const { src } = await this.fileManagerService.saveFile({
+      data: blob,
+      targetPath: AUTH_PROFILE_PICTURE_PATH,
+    });
+    return { src, revoke: () => {} };
+  }
+
+  /**
+   * Load via Image (no CORS required to display), then export to a blob URL.
+   * Used on web; also fallback on native when fetch to disk fails.
+   */
+  private async cacheViaImageElement(remoteUrl: string): Promise<ICachedProfilePicture> {
+    const blob = await this.loadImageBlob(remoteUrl);
+    const src = URL.createObjectURL(blob);
+    return { src, revoke: () => URL.revokeObjectURL(src) };
+  }
+
+  private loadImageBlob(url: string): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = "anonymous";
+      img.referrerPolicy = "no-referrer";
+      img.onload = () => {
+        try {
+          const canvas = document.createElement("canvas");
+          canvas.width = img.naturalWidth;
+          canvas.height = img.naturalHeight;
+          const ctx = canvas.getContext("2d");
+          if (!ctx) {
+            reject(new Error("Canvas not supported"));
+            return;
+          }
+          ctx.drawImage(img, 0, 0);
+          canvas.toBlob(
+            (blob) => (blob ? resolve(blob) : reject(new Error("Failed to create image blob"))),
+            "image/jpeg",
+            0.92
+          );
+        } catch (error) {
+          reject(error);
+        }
+      };
+      img.onerror = () => reject(new Error("Failed to load profile picture"));
+      img.src = url;
+    });
+  }
+
+  private revokeCached() {
+    this.safeRevoke(this.revoke);
+    this.revoke = undefined;
+  }
+
+  private safeRevoke(revoke?: () => void) {
+    if (!revoke) return;
+    try {
+      revoke();
+    } catch (error) {
+      console.warn(LOG_PREFIX, "Error revoking cached profile picture URL:", error);
+    }
+  }
+}

--- a/src/app/shared/services/auth/auth.service.spec.ts
+++ b/src/app/shared/services/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { TemplateService } from "../../components/template/services/template.ser
 import { ServerService } from "../server/server.service";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
+import { AuthProfilePictureService } from "./auth-profile-picture.service";
 
 describe("AuthService", () => {
   let service: AuthService;
@@ -20,6 +21,10 @@ describe("AuthService", () => {
         { provide: DeploymentService, useValue: new MockDeploymentService() },
         { provide: TemplateService, useValue: {} },
         { provide: ServerService, useValue: {} },
+        {
+          provide: AuthProfilePictureService,
+          useValue: { setFromRemoteUrl: () => {}, clear: () => {} },
+        },
       ],
     });
     service = TestBed.inject(AuthService);

--- a/src/app/shared/services/auth/auth.service.ts
+++ b/src/app/shared/services/auth/auth.service.ts
@@ -14,6 +14,7 @@ import type { IServerUser } from "../server/server.types";
 import { DynamicDataService } from "../dynamic-data/dynamic-data.service";
 import { SystemVariableService } from "../system-variable/system-variable.service";
 import { UserMetaService } from "../userMeta/userMeta.service";
+import { AuthProfilePictureService } from "./auth-profile-picture.service";
 
 @Injectable({
   providedIn: "root",
@@ -35,7 +36,8 @@ export class AuthService extends AsyncServiceBase {
     private http: HttpClient,
     private dynamicDataService: DynamicDataService,
     private systemVariableService: SystemVariableService,
-    private userMetaService: UserMetaService
+    private userMetaService: UserMetaService,
+    private authProfilePictureService: AuthProfilePictureService
   ) {
     super("Auth");
     this.provider = getAuthProvider(this.config.provider);
@@ -170,7 +172,7 @@ export class AuthService extends AsyncServiceBase {
     this.systemVariableService.set("AUTH_USER_NAME", auth_user.name || "");
     this.systemVariableService.set("AUTH_USER_FAMILY_NAME", auth_user.family_name || "");
     this.systemVariableService.set("AUTH_USER_GIVEN_NAME", auth_user.given_name || "");
-    this.systemVariableService.set("AUTH_USER_PICTURE", auth_user.picture || "");
+    this.authProfilePictureService.setFromRemoteUrl(auth_user.picture || "");
   }
 
   /**
@@ -188,10 +190,14 @@ export class AuthService extends AsyncServiceBase {
   }
 
   private clearUserData() {
+    try {
+      this.authProfilePictureService.clear();
+    } catch (error) {
+      console.warn("[Auth] Failed to clear profile picture:", error);
+    }
     this.systemVariableService.remove("AUTH_USER_ID");
     this.systemVariableService.remove("AUTH_USER_NAME");
     this.systemVariableService.remove("AUTH_USER_FAMILY_NAME");
     this.systemVariableService.remove("AUTH_USER_GIVEN_NAME");
-    this.systemVariableService.remove("AUTH_USER_PICTURE");
   }
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Fixes an issue where, after signing in with Google, the expected profile picture would show a broken link. This is resolved by changing the way that the profile picture asset is used (it is downloaded/cached once on sign in rather than attempting to fetch directly from google on use), and also provides safety around not setting the `_auth_user_picture` field when no image is available, meaning the broken link should never show. 

## Dev notes

Caches auth provider profile pictures (currently only Google as Apple does not provide a profile picture) locally instead of storing the remote URL in `AUTH_USER_PICTURE`. Remote Google URLs are unreliable as `<img>` `src` due to referrer/hotlink restrictions, and `fetch` to those URLs fails on web and in the native WebView.

- Adds `AuthProfilePictureService` to download and cache profile pictures:
  - **Web:** Image element + canvas → `blob:` URL
  - **Native:** `FileManager.saveFile` → Capacitor file URL, with Image element fallback
- Updates `AuthService` to delegate picture handling to the new service; other auth system variables are set synchronously as before
- Fixes `translatedAsset` rewriting `blob:` URLs as asset paths by adding `blob:` to `EXTERNAL_URL_PREFIXES` in `TemplateAssetService`
- Caching is fire-and-forget and fully error-safe — failures clear `AUTH_USER_PICTURE` and never block sign-in, sign-out, or app init

## Git Issues

Addresses https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-pa-content/issues/219

## Screenshots/Videos

iOS:

<img width="400" alt="ios" src="https://github.com/user-attachments/assets/a47738a2-3eac-4413-ab17-d98d16d9f253" />

Android:

My local Android Studio setup is playing up, but testing on Android can be done at a later stage.