### PR TITLE
chore: expose 'year' type param on datetime picker

### DIFF
--- a/src/app/shared/components/template/components/date-time-picker/date-time-picker.component.md
+++ b/src/app/shared/components/template/components/date-time-picker/date-time-picker.component.md
@@ -20,7 +20,8 @@
 | disabled	            | true                | Disables the button and greys it out |
 | type                  | date-time (default) | Allows date and time to be selected  |
 | type                  | date                | Allows date only to be selected      |  
-| type                  | time                | Allows time only to be selected      |  
+| type                  | time                | Allows time only to be selected      |
+| type                  | year                | Allows year only to be selected      |
 
 ## Events
 

--- a/src/app/shared/components/template/components/date-time-picker/date-time-picker.component.ts
+++ b/src/app/shared/components/template/components/date-time-picker/date-time-picker.component.ts
@@ -5,8 +5,8 @@ import { generateUUID } from "src/app/shared/utils";
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** If true, date time picker is disabled and greyed out */
   disabled: coerce.boolean(),
-  /** Type of picker: date & time ('date-time'), date only ('date') or time only ('time'). Default 'date-time'. */
-  type: coerce.allowedValues(["date", "date-time", "time"], "date-time"),
+  /** Type of picker: date & time ('date-time'), date only ('date'), time only ('time'), or year only ('year'). Default 'date-time'. */
+  type: coerce.allowedValues(["date", "date-time", "time", "year"], "date-time"),
   /** Minimum selectable date/time (ISO 8601 string). When empty, no minimum is applied. */
   min: coerce.string(""),
   /** Maximum selectable date/time (ISO 8601 string). When empty, no maximum is applied. */


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds `year` as an allowed `type` parameter on the date-time-picker component, enabling Ionic's year-only presentation mode via `parameter_list.type: year`.

## Git Issues

Closes #3551

## Screenshots/Videos

[comp_date_time_picker](https://docs.google.com/spreadsheets/d/1Ff1QbrAKWpENp6QNeHVAw6_7KtkXz6zngRTSKqHMssw/edit?gid=569531329#gid=569531329)


<img width="288" height="596" alt="Screenshot 2026-07-02 at 14 57 52" src="https://github.com/user-attachments/assets/5e964bf8-d568-437d-900c-1faadc0527f4" />
