### PR TITLE
feat: radio-list 'card' variant

### DIFF
--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -6,8 +6,8 @@
   @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
       <ion-radio
-        [labelPlacement]="params().variant === 'boxed' ? 'start' : 'end'"
-        [justify]="params().variant === 'boxed' ? 'space-between' : 'start'"
+        [labelPlacement]="params().variant === 'card' ? 'start' : 'end'"
+        [justify]="params().variant === 'card' ? 'space-between' : 'start'"
         mode="md"
         [value]="item[params().optionsKey]"
       >

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -1,7 +1,16 @@
-<ion-radio-group [value]="value()" (ionChange)="handleItemClick($event.detail.value)">
+<ion-radio-group
+  [attr.data-variant]="params().variant"
+  [value]="value()"
+  (ionChange)="handleItemClick($event.detail.value)"
+>
   @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
-      <ion-radio labelPlacement="end" justify="start" mode="md" [value]="item[params().optionsKey]">
+      <ion-radio
+        [labelPlacement]="params().variant === 'boxed' ? 'start' : 'end'"
+        [justify]="params().variant === 'boxed' ? 'space-between' : 'start'"
+        mode="md"
+        [value]="item[params().optionsKey]"
+      >
         <plh-tmpl-text
           [row]="{ _nested_name: '', name: '', type: 'text', value: item[params().optionsValue] }"
         >

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.scss
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.scss
@@ -1,4 +1,4 @@
-// Theme params for boxed variant
+// Theme params for card variant
 $background-selected: var(--radio-list-background-selected, var(--ion-color-primary-100));
 $border-color-selected: var(--radio-list-border-color-selected, var(--ion-color-primary-200));
 
@@ -12,7 +12,7 @@ ion-radio-group {
     margin-bottom: 0;
   }
 
-  &[data-variant="boxed"] {
+  &[data-variant="card"] {
     display: flex;
     flex-direction: column;
     gap: var(--small-margin, 8px);

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.scss
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.scss
@@ -1,3 +1,7 @@
+// Theme params for boxed variant
+$background-selected: var(--radio-list-background-selected, var(--ion-color-primary-100));
+$border-color-selected: var(--radio-list-border-color-selected, var(--ion-color-primary-200));
+
 // Remove default styling of ionic components to keep the design minimal
 ion-radio-group {
   ion-item {
@@ -6,5 +10,32 @@ ion-radio-group {
   ion-radio::part(label) {
     margin-top: 0;
     margin-bottom: 0;
+  }
+
+  &[data-variant="boxed"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--small-margin, 8px);
+
+    ion-item {
+      --padding-start: 16px;
+      --padding-end: 16px;
+      --inner-padding-end: 0;
+      --min-height: 55px;
+      border: 2px solid var(--ion-color-gray-200);
+      border-radius: var(--ion-border-radius-small, 8px);
+      overflow: hidden;
+      margin: var(--small-margin, 8px) 0;
+
+      &:has(ion-radio.radio-checked) {
+        --background: #{$background-selected};
+        border-color: $border-color-selected;
+      }
+    }
+
+    ion-radio {
+      width: 100%;
+      margin: 0;
+    }
   }
 }

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -2,15 +2,17 @@ import { Component, computed } from "@angular/core";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { filter, map, switchMap } from "rxjs/operators";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
-import { IAnswerListItem } from "../../../../utils";
+import { IAnswerOption } from "../../../../utils";
 import { DataItemsService } from "../data-items/data-items.service";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
-  answer_list: coerce.objectArray<IAnswerListItem>([
+  answer_list: coerce.objectArray<IAnswerOption>([
     { name: null, text: null, image: null, image_checked: null },
   ]),
   options_key: coerce.string("name"),
   options_value: coerce.string("text"),
+  /** The display variant of the radio list. Default 'default'. */
+  variant: coerce.allowedValues(["default", "boxed"], "default"),
 }));
 
 @Component({
@@ -21,7 +23,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
 })
 export class TmplRadioListComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
   public answerOptions = computed(() => {
-    return this.dataItemRows() ?? this.params().answerList;
+    return (this.dataItemRows() ?? this.params().answerList) as IAnswerOption[];
   });
 
   constructor(private dataItemsService: DataItemsService) {

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -12,7 +12,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   options_key: coerce.string("name"),
   options_value: coerce.string("text"),
   /** The display variant of the radio list. Default 'default'. */
-  variant: coerce.allowedValues(["default", "boxed"], "default"),
+  variant: coerce.allowedValues(["default", "card"], "default"),
 }));
 
 @Component({


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Add a `card` variant to `radio_list` component
- Card layout: bordered options with label on the left and selection indicator on the right; selected option uses a darker highlight
- Expose selected styles as theme vars (`--radio-list-background-selected`, `--radio-list-border-color-selected`)
- Minor code tidying

## Git Issues

Addresses part of #3568 (does not fully close)

## Screenshots/Videos

[comp_radio_list](https://docs.google.com/spreadsheets/d/1ykG_OU7bZJhNyoVKzOGjjGJ2F0OHbdJC0sh_7d67fTY/edit?gid=569531329#gid=569531329)

<img width="800" alt="Screenshot 2026-07-14 at 15 26 33" src="https://github.com/user-attachments/assets/ffe6c5cd-76d3-41e4-8bd0-fd876b6eac07" />

<img width="300" alt="Screenshot 2026-07-14 at 15 27 53" src="https://github.com/user-attachments/assets/759a532c-6463-4622-90ff-3ff92b734be3" />
