### PR TITLE
Feat: radio button grid 'card' variant

### DIFF
--- a/src/app/shared/components/template/components/index.ts
+++ b/src/app/shared/components/template/components/index.ts
@@ -13,6 +13,7 @@ import { ComboBoxDropdownComponent } from "./combo-box/combo-box-dropdown/combo-
 import { FormComponent } from "./layout/form";
 import { NavGroupComponent } from "./layout/nav_group";
 import { PLHDebugToggleComponent } from "../../debug-toggle";
+import { RadioButtonGridCardComponent } from "./radio-button-grid/radio-button-grid-card/radio-button-grid-card.component";
 import { RoundIconButtonComponent } from "./round-icon-button/round-icon-button.component";
 import { SelectTextComponent } from "./select-text/select-text.component";
 import { SquareIconButtonComponent } from "./square-icon-button/square-icon-button.component";
@@ -92,6 +93,7 @@ export const TEMPLATE_COMPONENTS = [
   ComboBoxSearchComponent,
   FormComponent,
   NavGroupComponent,
+  RadioButtonGridCardComponent,
   RoundIconButtonComponent,
   SelectTextComponent,
   SquareIconButtonComponent,

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.html
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.html
@@ -1,0 +1,36 @@
+<div class="radio-buttons" [ngStyle]="gridStyle()" [attr.data-style]="styleVariant()">
+  <ion-radio-group [value]="value()" (ionChange)="onRadioChange($event.detail.value)">
+    @for (item of answerOptions(); track $index) {
+      <ion-item lines="none" (click)="selectOption(item)">
+        <ion-radio
+          labelPlacement="start"
+          justify="space-between"
+          alignment="start"
+          mode="md"
+          [value]="item[optionsKey()]"
+        >
+          <div class="item-content">
+            @if (item.image) {
+              <div class="item-image-container">
+                <img
+                  class="item-image"
+                  [src]="
+                    (item[optionsKey()] === value() && item.image_checked
+                      ? item.image_checked
+                      : item.image
+                    ) | plhAsset
+                  "
+                />
+              </div>
+            }
+            @if (item[optionsValue()]) {
+              <div class="item-text">
+                <p>{{ item[optionsValue()] }}</p>
+              </div>
+            }
+          </div>
+        </ion-radio>
+      </ion-item>
+    }
+  </ion-radio-group>
+</div>

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.scss
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.scss
@@ -1,0 +1,124 @@
+// Theme params for the boxed 'card' variant
+$background: var(--radio-button-grid-background, transparent);
+$background-selected: var(--radio-button-grid-background-selected, var(--ion-color-primary-100));
+$border-color: var(--radio-button-grid-border-color, var(--ion-color-gray-200));
+$border-color-selected: var(
+  --radio-button-grid-border-color-selected,
+  var(--ion-color-primary-200)
+);
+$background-selected-secondary: var(
+  --radio-button-grid-background-selected-secondary,
+  var(--ion-color-secondary-100)
+);
+$border-color-selected-secondary: var(
+  --radio-button-grid-border-color-selected-secondary,
+  var(--ion-color-secondary-200)
+);
+$radio-color-checked-secondary: var(
+  --radio-button-grid-radio-color-checked-secondary,
+  var(--ion-color-secondary)
+);
+
+$text-size: var(--radio-button-font-size, 1.25rem);
+$text-color: var(--radio-button-font-color, var(--ion-color-primary));
+
+// Boxed options using ion-radio, laid out in a grid: image top-left, radio
+// circle top-right. Grid columns/gap/width come from the parent's gridStyle()
+// (applied via [ngStyle]); this rule just provides `display: grid`.
+.radio-buttons {
+  display: grid;
+
+  // ion-radio-group (a scoped Ionic component) projects its radios into an
+  // inner `.radio-group-wrapper` element. Collapse both boxes with
+  // `display: contents` so the ion-items become direct grid items.
+  ion-radio-group {
+    display: contents;
+  }
+  ::ng-deep .radio-group-wrapper {
+    display: contents;
+  }
+
+  ion-item {
+    --background: #{$background};
+    // Symmetric inset so the image (top-left) and radio circle (top-right) are
+    // equidistant from the top and their respective sides. Applied via Ionic's
+    // native padding vars so it sits inside .item-native (background/ripple
+    // still fill the whole box).
+    --padding-start: 16px;
+    --padding-end: 16px;
+    --padding-top: 16px;
+    --padding-bottom: 16px;
+    --inner-padding-end: 0;
+    border: 2px solid $border-color;
+    border-radius: var(--ion-border-radius-small, 8px);
+    overflow: hidden;
+    cursor: pointer;
+
+    // The grid stretches each item to equal height (gridAutoRows: 1fr), but
+    // Ionic's `.item-native` (which paints --background and hosts the ripple)
+    // is only content-height by default. Force it to fill the box so the
+    // selected background and ripple span the whole item, not just the radio.
+    &::part(native) {
+      height: 100%;
+    }
+
+    &:has(ion-radio.radio-checked) {
+      --background: #{$background-selected};
+      border-color: $border-color-selected;
+    }
+  }
+
+  ion-radio {
+    width: 100%;
+    margin: 0;
+
+    // Pin the label content to the top of the box (alignment="start" on the
+    // ion-radio drives this) and strip Ionic's default label margins so the
+    // image top aligns with the circle top.
+    &::part(label) {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  .item-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--small-margin, 8px);
+  }
+
+  .item-image-container {
+    width: 64px;
+    height: 64px;
+
+    .item-image {
+      width: 64px;
+      height: 64px;
+      object-fit: contain;
+    }
+  }
+
+  .item-text {
+    text-align: start;
+    color: $text-color;
+
+    p {
+      margin: 0;
+      font-size: $text-size;
+    }
+  }
+
+  // 'secondary' style: recolour the selected card using secondary theme colours.
+  &[data-style="secondary"] {
+    // Recolour Ionic's checked radio dot (and its ring) to the secondary colour.
+    ion-radio {
+      --color-checked: #{$radio-color-checked-secondary};
+    }
+
+    ion-item:has(ion-radio.radio-checked) {
+      --background: #{$background-selected-secondary};
+      border-color: $border-color-selected-secondary;
+    }
+  }
+}

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.ts
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid-card/radio-button-grid-card.component.ts
@@ -1,0 +1,49 @@
+import { Component, input, output } from "@angular/core";
+import { IAnswerOption } from "src/app/shared/utils";
+
+/**
+ * Boxed 'card' variant of the radio button grid.
+ *
+ * Renders each option as a bordered card laid out in the grid, using an
+ * `ion-radio` (circle top-right) with the option image (top-left) and text.
+ * Kept as a dedicated component so its Ionic-specific markup and styling are
+ * isolated from the default grid variant. Selection is surfaced to the parent
+ * via `selectionChange`, mirroring the combo-box dropdown pattern.
+ */
+@Component({
+  selector: "radio-button-grid-card",
+  templateUrl: "./radio-button-grid-card.component.html",
+  styleUrls: ["./radio-button-grid-card.component.scss"],
+  standalone: false,
+})
+export class RadioButtonGridCardComponent {
+  /** Currently selected value (matched against `optionsKey`). */
+  public value = input<any>();
+  /** Options to render as cards. */
+  public answerOptions = input.required<IAnswerOption[]>();
+  /** Property key used for the option value. */
+  public optionsKey = input<string>("name");
+  /** Property key used for the option display text. */
+  public optionsValue = input<string>("text");
+  /** Grid layout styles computed by the parent (columns, gap, width, etc.). */
+  public gridStyle = input<Partial<CSSStyleDeclaration>>({});
+  /**
+   * Colour style, applied as a `data-style` attribute. Named `styleVariant`
+   * (not `style`) because Angular reserves the `[style]` binding for inline
+   * styles. Default 'default'; 'secondary' tints the selected state.
+   */
+  public styleVariant = input<string>("default");
+
+  /** Emitted with the selected option's value when the selection changes. */
+  public selectionChange = output<any>();
+
+  /** Select via a click anywhere on the card. */
+  public selectOption(item: IAnswerOption) {
+    this.selectionChange.emit(item[this.optionsKey()]);
+  }
+
+  /** Select via the ion-radio-group change event. */
+  public onRadioChange(value: any) {
+    this.selectionChange.emit(value);
+  }
+}

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
@@ -1,22 +1,22 @@
 <div
   class="radio-buttons"
-  [ngStyle]="gridStyle"
-  [attr.data-variant]="parameter_list.variant"
-  [attr.data-style]="parameter_list.style"
+  [ngStyle]="gridStyle()"
+  [attr.data-variant]="params().variant"
+  [attr.data-style]="params().style"
 >
-  @for (item of radioItems; track $index) {
+  @for (item of radioItems(); track $index) {
     <div
       class="item"
       (click)="handleItemClick(item)"
-      [attr.data-selected]="item.name === _row.value"
-      [style.--min-item-width]="parameter_list.item_width"
+      [attr.data-selected]="item.name === value()"
+      [style.--min-item-width]="params().itemWidth"
     >
       @if (item.image) {
         <div class="item-image-container">
           <img
             class="item-image"
             [src]="
-              (item.name === _row.value && item.image_checked ? item.image_checked : item.image)
+              (item.name === value() && item.image_checked ? item.image_checked : item.image)
                 | plhAsset
             "
           />

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
@@ -1,34 +1,46 @@
-<div
-  class="radio-buttons"
-  [ngStyle]="gridStyle()"
-  [attr.data-variant]="params().variant"
-  [attr.data-style]="params().style"
->
-  @for (item of radioItems(); track $index) {
-    <div
-      class="item"
-      (click)="handleItemClick(item)"
-      [attr.data-selected]="item[params().optionsKey] === value()"
-      [style.--min-item-width]="params().itemWidth"
-    >
-      @if (item.image) {
-        <div class="item-image-container">
-          <img
-            class="item-image"
-            [src]="
-              (item[params().optionsKey] === value() && item.image_checked
-                ? item.image_checked
-                : item.image
-              ) | plhAsset
-            "
-          />
-        </div>
-      }
-      @if (item[params().optionsValue]) {
-        <div class="item-text">
-          <p>{{ item[params().optionsValue] }}</p>
-        </div>
-      }
-    </div>
-  }
-</div>
+@if (params().variant === "card") {
+  <radio-button-grid-card
+    [value]="value()"
+    [answerOptions]="radioItems()"
+    [optionsKey]="params().optionsKey"
+    [optionsValue]="params().optionsValue"
+    [gridStyle]="gridStyle()"
+    [styleVariant]="params().style"
+    (selectionChange)="setValue($event)"
+  />
+} @else {
+  <div
+    class="radio-buttons"
+    [ngStyle]="gridStyle()"
+    [attr.data-variant]="params().variant"
+    [attr.data-style]="params().style"
+  >
+    @for (item of radioItems(); track $index) {
+      <div
+        class="item"
+        (click)="handleItemClick(item)"
+        [attr.data-selected]="item[params().optionsKey] === value()"
+        [style.--min-item-width]="params().itemWidth"
+      >
+        @if (item.image) {
+          <div class="item-image-container">
+            <img
+              class="item-image"
+              [src]="
+                (item[params().optionsKey] === value() && item.image_checked
+                  ? item.image_checked
+                  : item.image
+                ) | plhAsset
+              "
+            />
+          </div>
+        }
+        @if (item[params().optionsValue]) {
+          <div class="item-text">
+            <p>{{ item[params().optionsValue] }}</p>
+          </div>
+        }
+      </div>
+    }
+  </div>
+}

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.html
@@ -8,7 +8,7 @@
     <div
       class="item"
       (click)="handleItemClick(item)"
-      [attr.data-selected]="item.name === value()"
+      [attr.data-selected]="item[params().optionsKey] === value()"
       [style.--min-item-width]="params().itemWidth"
     >
       @if (item.image) {
@@ -16,15 +16,17 @@
           <img
             class="item-image"
             [src]="
-              (item.name === value() && item.image_checked ? item.image_checked : item.image)
-                | plhAsset
+              (item[params().optionsKey] === value() && item.image_checked
+                ? item.image_checked
+                : item.image
+              ) | plhAsset
             "
           />
         </div>
       }
-      @if (item.text) {
+      @if (item[params().optionsValue]) {
         <div class="item-text">
-          <p>{{ item.text }}</p>
+          <p>{{ item[params().optionsValue] }}</p>
         </div>
       }
     </div>

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
@@ -1,10 +1,10 @@
 import { Component, computed } from "@angular/core";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
-import { IAnswerListItem } from "src/app/shared/utils";
+import { IAnswerOption } from "src/app/shared/utils";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** List of options presented as radio items */
-  answer_list: coerce.objectArray<IAnswerListItem>([]),
+  answer_list: coerce.objectArray<IAnswerOption>([]),
   /** Minimum item width, will increase to fit grid. Default '200px'. */
   item_width: coerce.string("200px"),
   /** Maximum grid width, if specified will center items in available space. Default '100%'. */
@@ -15,6 +15,10 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   variant: coerce.allowedValues(["default", "circle-icon", "flex"], "default"),
   /** The 'secondary' style sets the colour of the buttons. Default 'default'. */
   style: coerce.allowedValues(["default", "secondary"], "default"),
+  /** The property key to use for the option value. Default 'name'. */
+  options_key: coerce.string("name"),
+  /** The property key to use for the option display text. Default 'text'. */
+  options_value: coerce.string("text"),
 }));
 
 @Component({
@@ -25,7 +29,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
 })
 export class TmplRadioButtonGridComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
   /** Computed item array from author parameters */
-  public radioItems = computed(() => this.params().answerList as IAnswerListItem[]);
+  public radioItems = computed(() => this.params().answerList as IAnswerOption[]);
 
   /** Computed grid style passed into ngStyle */
   public gridStyle = computed<Partial<CSSStyleDeclaration>>(() => {
@@ -43,7 +47,7 @@ export class TmplRadioButtonGridComponent extends TemplateBaseComponentWithParam
     };
   });
 
-  public async handleItemClick(item: IAnswerListItem) {
-    await this.setValue(item.name);
+  public async handleItemClick(item: IAnswerOption) {
+    await this.setValue(item[this.params().optionsKey]);
   }
 }

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
@@ -1,6 +1,9 @@
 import { Component, computed } from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { filter, map, switchMap } from "rxjs/operators";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
 import { IAnswerOption } from "src/app/shared/utils";
+import { DataItemsService } from "../data-items/data-items.service";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** List of options presented as radio items */
@@ -28,8 +31,14 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   standalone: false,
 })
 export class TmplRadioButtonGridComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
-  /** Computed item array from author parameters */
-  public radioItems = computed(() => this.params().answerList as IAnswerOption[]);
+  /** Computed item array from data_items child rows (if provided) or author parameters */
+  public radioItems = computed(() => {
+    return (this.dataItemRows() ?? this.params().answerList) as IAnswerOption[];
+  });
+
+  constructor(private dataItemsService: DataItemsService) {
+    super();
+  }
 
   /** Computed grid style passed into ngStyle */
   public gridStyle = computed<Partial<CSSStyleDeclaration>>(() => {
@@ -50,4 +59,18 @@ export class TmplRadioButtonGridComponent extends TemplateBaseComponentWithParam
   public async handleItemClick(item: IAnswerOption) {
     await this.setValue(item[this.params().optionsKey]);
   }
+
+  // Allow radio_button_grid to include data_items child row to define answer list
+  private dataItemRows = toSignal(
+    toObservable(this.rows).pipe(
+      map((rows) => rows.find((r) => r.type === "data_items")),
+      filter((row) => row !== undefined),
+      switchMap((row) =>
+        this.dataItemsService.getItemsObservable(
+          row,
+          this.parentContainerComponentRef.templateRowMap
+        )
+      )
+    )
+  );
 }

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
@@ -1,35 +1,21 @@
-import { Component, Input } from "@angular/core";
-import { TemplateBaseComponent } from "../base";
-import { FlowTypes } from "../../models";
-import {
-  getAnswerListParamFromTemplateRow,
-  getStringParamFromTemplateRow,
-  IAnswerListItem,
-} from "src/app/shared/utils";
+import { Component, computed } from "@angular/core";
+import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
+import { IAnswerListItem } from "src/app/shared/utils";
 
-interface IRadioButtonGridParams {
+const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** List of options presented as radio items */
-  answer_list: IAnswerListItem[];
-  /**
-   * Minimum item width, will increase to fit grid.
-   * Default '200px'
-   **/
-  item_width: string;
-  /**
-   * Maximum grid width, if specified will center items in available space.
-   * Default '100%'
-   **/
-  grid_width: string;
-  /**
-   * Spacing between grid items.
-   * Default '16px'
-   **/
-  grid_gap: string;
-  /* TEMPLATE PARAMETER: "variant". The style variant of the button_grid */
-  variant?: "default" | "circle-icon" | "flex";
-  /* TEMPLATE PARAMETER: "style". The "secondary" style sets the colour of the buttons */
-  style?: "secondary" | undefined;
-}
+  answer_list: coerce.objectArray<IAnswerListItem>([]),
+  /** Minimum item width, will increase to fit grid. Default '200px'. */
+  item_width: coerce.string("200px"),
+  /** Maximum grid width, if specified will center items in available space. Default '100%'. */
+  grid_width: coerce.string("100%"),
+  /** Spacing between grid items. Default '16px'. */
+  grid_gap: coerce.string("16px"),
+  /** The style variant of the button grid. Default 'default'. */
+  variant: coerce.allowedValues(["default", "circle-icon", "flex"], "default"),
+  /** The 'secondary' style sets the colour of the buttons. Default 'default'. */
+  style: coerce.allowedValues(["default", "secondary"], "default"),
+}));
 
 @Component({
   selector: "plh-radio-button-grid",
@@ -37,71 +23,27 @@ interface IRadioButtonGridParams {
   styleUrls: ["./radio-button-grid.component.scss"],
   standalone: false,
 })
-export class TmplRadioButtonGridComponent extends TemplateBaseComponent {
-  /**
-   * Computed item array from input parameters
-   * @ignore
-   */
-  public radioItems: Array<IAnswerListItem>;
+export class TmplRadioButtonGridComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
+  /** Computed item array from author parameters */
+  public radioItems = computed(() => this.params().answerList as IAnswerListItem[]);
 
-  /**
-   * Computed grid style from input parameters
-   * @ignore
-   */
-  public gridStyle: Partial<CSSStyleDeclaration>;
-
-  /**
-   * Authoring parameters
-   */
-  public parameter_list: IRadioButtonGridParams;
-
-  @Input() set row(row: FlowTypes.TemplateRow) {
-    this._row = row;
-    this.setParams();
-  }
-
-  /**
-   * S
-   * @ignore
-   */
-  public async handleItemClick(item: IAnswerListItem) {
-    await this.setValue(item.name);
-  }
-
-  private setParams() {
-    this.parameter_list = this._row.parameter_list || ({} as any);
-    this.radioItems = getAnswerListParamFromTemplateRow(this._row, "answer_list", []);
-    this.gridStyle = this.generateGridStyle();
-    this.parameter_list.style = getStringParamFromTemplateRow(
-      this._row,
-      "style",
-      undefined
-    ) as IRadioButtonGridParams["style"];
-    this.parameter_list.variant = getStringParamFromTemplateRow(this._row, "variant", "default")
-      .split(",")
-      .join(" ") as IRadioButtonGridParams["variant"];
-  }
-
-  /**
-   * Create a list of styles to be passed into ngStyle
-   * https://thesoftwayfarecoder.com/dynamically-creating-css-classes-in-angular/
-   */
-  private generateGridStyle() {
-    const minItemWidth = this.parameter_list.item_width || "200px";
-    const maxGridWidth = this.parameter_list.grid_width || "100%";
-    const gridGap = this.parameter_list.grid_gap || "16px";
-
-    const style: Partial<CSSStyleDeclaration> = {
+  /** Computed grid style passed into ngStyle */
+  public gridStyle = computed<Partial<CSSStyleDeclaration>>(() => {
+    const { itemWidth, gridWidth, gridGap } = this.params();
+    return {
       // center grid with maximum width
-      maxWidth: maxGridWidth,
+      maxWidth: gridWidth,
       margin: "auto",
       // apply fixed gap between grid items
       gap: gridGap,
       // fit columns with target item width
-      gridTemplateColumns: `repeat(auto-fit, minmax(${minItemWidth}, 1fr))`,
+      gridTemplateColumns: `repeat(auto-fit, minmax(${itemWidth}, 1fr))`,
       // make all rows same height
       gridAutoRows: "1fr",
     };
-    return style;
+  });
+
+  public async handleItemClick(item: IAnswerListItem) {
+    await this.setValue(item.name);
   }
 }

--- a/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
+++ b/src/app/shared/components/template/components/radio-button-grid/radio-button-grid.component.ts
@@ -15,7 +15,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** Spacing between grid items. Default '16px'. */
   grid_gap: coerce.string("16px"),
   /** The style variant of the button grid. Default 'default'. */
-  variant: coerce.allowedValues(["default", "circle-icon", "flex"], "default"),
+  variant: coerce.allowedValues(["default", "circle-icon", "flex", "card"], "default"),
   /** The 'secondary' style sets the colour of the buttons. Default 'default'. */
   style: coerce.allowedValues(["default", "secondary"], "default"),
   /** The property key to use for the option value. Default 'name'. */

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -6,8 +6,8 @@
   @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
       <ion-radio
-        [labelPlacement]="params().variant === 'boxed' ? 'start' : 'end'"
-        [justify]="params().variant === 'boxed' ? 'space-between' : 'start'"
+        [labelPlacement]="params().variant === 'card' ? 'start' : 'end'"
+        [justify]="params().variant === 'card' ? 'space-between' : 'start'"
         mode="md"
         [value]="item[params().optionsKey]"
       >

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.html
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.html
@@ -1,7 +1,16 @@
-<ion-radio-group [value]="value()" (ionChange)="handleItemClick($event.detail.value)">
+<ion-radio-group
+  [attr.data-variant]="params().variant"
+  [value]="value()"
+  (ionChange)="handleItemClick($event.detail.value)"
+>
   @for (item of answerOptions(); track item[params().optionsKey]) {
     <ion-item lines="none">
-      <ion-radio labelPlacement="end" justify="start" mode="md" [value]="item[params().optionsKey]">
+      <ion-radio
+        [labelPlacement]="params().variant === 'boxed' ? 'start' : 'end'"
+        [justify]="params().variant === 'boxed' ? 'space-between' : 'start'"
+        mode="md"
+        [value]="item[params().optionsKey]"
+      >
         <plh-tmpl-text
           [row]="{ _nested_name: '', name: '', type: 'text', value: item[params().optionsValue] }"
         >

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.scss
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.scss
@@ -1,4 +1,4 @@
-// Theme params for boxed variant
+// Theme params for card variant
 $background-selected: var(--radio-list-background-selected, var(--ion-color-primary-100));
 $border-color-selected: var(--radio-list-border-color-selected, var(--ion-color-primary-200));
 
@@ -12,7 +12,7 @@ ion-radio-group {
     margin-bottom: 0;
   }
 
-  &[data-variant="boxed"] {
+  &[data-variant="card"] {
     display: flex;
     flex-direction: column;
     gap: var(--small-margin, 8px);

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.scss
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.scss
@@ -1,3 +1,7 @@
+// Theme params for boxed variant
+$background-selected: var(--radio-list-background-selected, var(--ion-color-primary-100));
+$border-color-selected: var(--radio-list-border-color-selected, var(--ion-color-primary-200));
+
 // Remove default styling of ionic components to keep the design minimal
 ion-radio-group {
   ion-item {
@@ -6,5 +10,32 @@ ion-radio-group {
   ion-radio::part(label) {
     margin-top: 0;
     margin-bottom: 0;
+  }
+
+  &[data-variant="boxed"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--small-margin, 8px);
+
+    ion-item {
+      --padding-start: 16px;
+      --padding-end: 16px;
+      --inner-padding-end: 0;
+      --min-height: 55px;
+      border: 2px solid var(--ion-color-gray-200);
+      border-radius: var(--ion-border-radius-small, 8px);
+      overflow: hidden;
+      margin: var(--small-margin, 8px) 0;
+
+      &:has(ion-radio.radio-checked) {
+        --background: #{$background-selected};
+        border-color: $border-color-selected;
+      }
+    }
+
+    ion-radio {
+      width: 100%;
+      margin: 0;
+    }
   }
 }

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -2,15 +2,17 @@ import { Component, computed } from "@angular/core";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { filter, map, switchMap } from "rxjs/operators";
 import { defineAuthorParameterSchema, TemplateBaseComponentWithParams } from "../base";
-import { IAnswerListItem } from "../../../../utils";
+import { IAnswerOption } from "../../../../utils";
 import { DataItemsService } from "../data-items/data-items.service";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
-  answer_list: coerce.objectArray<IAnswerListItem>([
+  answer_list: coerce.objectArray<IAnswerOption>([
     { name: null, text: null, image: null, image_checked: null },
   ]),
   options_key: coerce.string("name"),
   options_value: coerce.string("text"),
+  /** The display variant of the radio list. Default 'default'. */
+  variant: coerce.allowedValues(["default", "boxed"], "default"),
 }));
 
 @Component({
@@ -21,7 +23,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
 })
 export class TmplRadioListComponent extends TemplateBaseComponentWithParams(AuthorSchema) {
   public answerOptions = computed(() => {
-    return this.dataItemRows() ?? this.params().answerList;
+    return (this.dataItemRows() ?? this.params().answerList) as IAnswerOption[];
   });
 
   constructor(private dataItemsService: DataItemsService) {

--- a/src/app/shared/components/template/components/radio-list/radio-list.component.ts
+++ b/src/app/shared/components/template/components/radio-list/radio-list.component.ts
@@ -12,7 +12,7 @@ const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   options_key: coerce.string("name"),
   options_value: coerce.string("text"),
   /** The display variant of the radio list. Default 'default'. */
-  variant: coerce.allowedValues(["default", "boxed"], "default"),
+  variant: coerce.allowedValues(["default", "card"], "default"),
 }));
 
 @Component({


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)
- [ ] Builds on #3574 (merge that first)
- [ ] Builds on #3576. Either merge that first, or review both sets of changes together in this PR

## Description

Adds a new `card` display variant to the `radio_button_grid` component: a grid of bordered, selectable cards, each showing an image (top-left, 64px), its label, and an Ionic radio circle (top-right)

## Dev notes
- New dedicated sub-component `radio-button-grid-card` (`RadioButtonGridCardComponent`), following the existing combo-box `dropdown` sub-component pattern. The parent delegates to it and passes through all needed values (`value`, `answerOptions`, `optionsKey`, `optionsValue`, `gridStyle`, `styleVariant`) and receives selection via a `selectionChange` output.
- Reuses the existing grid layout (`item_width` / `grid_width` / `grid_gap`) and the shared `options_key` / `options_value` and `data_items` support.
- Supports `style: secondary`, which recolours the selected card (background + border) and the radio dot using the secondary theme colour.

## Theming
Colours are overridable via CSS custom properties, e.g.:
- `--radio-button-grid-background[-selected]`
- `--radio-button-grid-border-color[-selected]`
- `--radio-button-grid-background-selected-secondary`
- `--radio-button-grid-border-color-selected-secondary`
- `--radio-button-grid-radio-color-checked-secondary`

## Git Issues

Closes #

## Screenshots/Videos

Demo of [example_radio_list](https://docs.google.com/spreadsheets/d/1m_c_RbdoDh9liZZlK9m321Q2BGiH2qv6NdqFZBsSM5o/edit?gid=710412931#gid=710412931) (with `plh_facilitator_mx` theme enabled)

https://github.com/user-attachments/assets/12c5b3b5-0cfd-470f-b824-6d2e1c2b5efc

