### PR TITLE
feat: expose on_progress action trigger on progress bar

### DIFF
--- a/packages/components/plh/progress-bar/progress-bar.component.spec.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.spec.ts
@@ -3,6 +3,10 @@ import { IonicModule } from "@ionic/angular";
 
 import { PlhProgressBarComponent } from "./progress-bar.component";
 
+/**
+ * Call standalone tests via:
+ * yarn ng test --include packages/components/plh/progress-bar/progress-bar.component.spec.ts
+ */
 describe("PlhProgressBarComponent", () => {
   let component: PlhProgressBarComponent;
   let fixture: ComponentFixture<PlhProgressBarComponent>;
@@ -15,6 +19,17 @@ describe("PlhProgressBarComponent", () => {
 
     fixture = TestBed.createComponent(PlhProgressBarComponent);
     component = fixture.componentInstance;
+    component.parentContainerComponentRef = {
+      handleActions: jasmine.createSpy("handleActions").and.resolveTo(undefined),
+    } as any;
+    component.row = {
+      name: "progress_bar",
+      _nested_name: "progress_bar",
+      type: "plh_progress_bar",
+      value: 0,
+      action_list: [],
+      parameter_list: {},
+    } as any;
     fixture.detectChanges();
   }));
 

--- a/packages/components/plh/progress-bar/progress-bar.component.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.ts
@@ -41,6 +41,9 @@ export class PlhProgressBarComponent
   private animationElapsedMs = 0;
   private animationDuration = 0;
 
+  /** Last observed progress, used to detect upward crossings of `on_progress` thresholds. */
+  private previousProgress: number | null = null;
+
   /** Local display value while auto-playing; avoids row refresh races from per-frame setValue. */
   private localProgress = signal<number | null>(null);
 
@@ -107,6 +110,32 @@ export class PlhProgressBarComponent
           this.animationFrameId = undefined;
         }
       });
+    });
+
+    // Fire `on_progress: <percentage>` actions when the displayed progress crosses each threshold.
+    // The threshold is read from the trigger argument (parsed in app-data-action.utils.ts). A crossing
+    // fires once on the way up and re-arms if progress later drops back below the threshold.
+    effect(() => {
+      const progress = this.displayProgress();
+      const previous = this.previousProgress;
+      this.previousProgress = progress;
+      // Establish a baseline on first run without firing, so a bar that mounts already at or above a
+      // threshold does not fire on load; only fire on genuine upward crossings thereafter.
+      if (previous === null || progress <= previous) {
+        return;
+      }
+      const crossed = untracked(() => this.actionList())
+        .filter((a) => a.trigger === "on_progress")
+        .map((action) => ({ action, threshold: Number(action.trigger_args?.[0]) }))
+        .filter(
+          ({ threshold }) =>
+            !Number.isNaN(threshold) && threshold > previous && threshold <= progress
+        )
+        .sort((a, b) => a.threshold - b.threshold)
+        .map(({ action }) => action);
+      if (crossed.length > 0) {
+        void this.parentContainerComponentRef.handleActions(crossed, this._row);
+      }
     });
   }
 

--- a/packages/components/plh/progress-bar/progress-bar.component.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.ts
@@ -3,6 +3,7 @@ import {
   defineAuthorParameterSchema,
   TemplateBaseComponentWithParams,
 } from "src/app/shared/components/template/components/base";
+import { selectOnProgressActions } from "./progress-bar.logic";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** Text displayed above the progress bar. */
@@ -41,11 +42,14 @@ export class PlhProgressBarComponent
   private animationElapsedMs = 0;
   private animationDuration = 0;
 
-  /** `on_progress` thresholds already fired; each fires at most once. */
-  private firedProgressThresholds = new Set<number>();
+  /** `on_progress` thresholds already handled (seeded or fired); each fires at most once. */
+  private handledProgressThresholds = new Set<number>();
 
-  /** Whether thresholds already met when the bar loaded have been recorded (they don't fire). */
-  private initialThresholdsSeeded = false;
+  /**
+   * Last observed progress for detecting upward threshold crossings.
+   * `null` until the first observation (used to seed without firing).
+   */
+  private previousProgress: number | null = null;
 
   /** Display value while animating or paused; avoids row-refresh races from per-frame setValue. */
   private localProgress = signal<number | null>(null);
@@ -78,7 +82,8 @@ export class PlhProgressBarComponent
       if (!autoPlay) {
         const pausedAt = untracked(() => this.localProgress());
         if (pausedAt !== null) {
-          void this.setValue(pausedAt);
+          // Commit then clear local (same as completion) so external value updates apply while paused.
+          void this.commitProgress(pausedAt);
         }
         return;
       }
@@ -114,27 +119,20 @@ export class PlhProgressBarComponent
       });
     });
 
-    // Fire each `on_progress: <percentage>` action once, when progress first reaches its threshold.
-    // Latch fired thresholds so async re-observations of progress can't fire the same one twice.
+    // Fire each `on_progress: <percentage>` action once when progress first reaches its threshold.
+    // See `selectOnProgressActions` for seed / latch / NaN behaviour (`on_progress: 0` is seeded
+    // without firing when the bar mounts at 0).
     effect(() => {
       const progress = this.displayProgress();
-      const reached = untracked(() => this.actionList())
-        .filter((a) => a.trigger === "on_progress")
-        .map((action) => ({ action, threshold: Number(action.trigger_args?.[0]) }))
-        .filter(
-          ({ threshold }) => threshold <= progress && !this.firedProgressThresholds.has(threshold)
-        )
-        .sort((a, b) => a.threshold - b.threshold);
-      reached.forEach(({ threshold }) => this.firedProgressThresholds.add(threshold));
-
-      // On load, record thresholds the bar is already past without firing them; only thresholds
-      // reached afterwards fire (on_progress means reaching a threshold, not loading in past it).
-      const seedingInitialThresholds = !this.initialThresholdsSeeded;
-      this.initialThresholdsSeeded = true;
-      if (seedingInitialThresholds || reached.length === 0) return;
-
-      const actions = reached.map(({ action }) => action);
-      void this.parentContainerComponentRef.handleActions(actions, this._row);
+      const { previousProgress, toFire } = selectOnProgressActions({
+        progress,
+        previousProgress: this.previousProgress,
+        actions: this.actionList(),
+        handledThresholds: this.handledProgressThresholds,
+      });
+      this.previousProgress = previousProgress;
+      if (toFire.length === 0) return;
+      void this.parentContainerComponentRef.handleActions(toFire, this._row);
     });
   }
 

--- a/packages/components/plh/progress-bar/progress-bar.component.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.ts
@@ -3,7 +3,7 @@ import {
   defineAuthorParameterSchema,
   TemplateBaseComponentWithParams,
 } from "src/app/shared/components/template/components/base";
-import { selectOnProgressActions } from "./progress-bar.logic";
+import { selectCompleted, selectOnProgressActions } from "./progress-bar.logic";
 
 const AuthorSchema = defineAuthorParameterSchema((coerce) => ({
   /** Text displayed above the progress bar. */
@@ -50,6 +50,9 @@ export class PlhProgressBarComponent
    * `null` until the first observation (used to seed without firing).
    */
   private previousProgress: number | null = null;
+
+  /** Whether the "completed" trigger has fired (or was seeded at mount); it emits at most once. */
+  private completedEmitted = false;
 
   /** Display value while animating or paused; avoids row-refresh races from per-frame setValue. */
   private localProgress = signal<number | null>(null);
@@ -119,20 +122,32 @@ export class PlhProgressBarComponent
       });
     });
 
-    // Fire each `on_progress: <percentage>` action once when progress first reaches its threshold.
-    // See `selectOnProgressActions` for seed / latch / NaN behaviour (`on_progress: 0` is seeded
-    // without firing when the bar mounts at 0).
+    // Fire each `on_progress: <percentage>` action once when progress first reaches its threshold,
+    // and emit the built-in "completed" trigger once when progress first reaches 100%.
+    // See `selectOnProgressActions` / `selectCompleted` for seed / latch / NaN behaviour.
     effect(() => {
       const progress = this.displayProgress();
+      const previous = this.previousProgress;
+
       const { previousProgress, toFire } = selectOnProgressActions({
         progress,
-        previousProgress: this.previousProgress,
+        previousProgress: previous,
         actions: this.actionList(),
         handledThresholds: this.handledProgressThresholds,
       });
       this.previousProgress = previousProgress;
-      if (toFire.length === 0) return;
-      void this.parentContainerComponentRef.handleActions(toFire, this._row);
+
+      const completed = selectCompleted({
+        progress,
+        previousProgress: previous,
+        completedEmitted: this.completedEmitted,
+      });
+      this.completedEmitted = completed.completedEmitted;
+
+      if (toFire.length > 0) {
+        void this.parentContainerComponentRef.handleActions(toFire, this._row);
+      }
+      if (completed.emit) this.triggerActions("completed");
     });
   }
 

--- a/packages/components/plh/progress-bar/progress-bar.component.ts
+++ b/packages/components/plh/progress-bar/progress-bar.component.ts
@@ -41,10 +41,13 @@ export class PlhProgressBarComponent
   private animationElapsedMs = 0;
   private animationDuration = 0;
 
-  /** Last observed progress, used to detect upward crossings of `on_progress` thresholds. */
-  private previousProgress: number | null = null;
+  /** `on_progress` thresholds already fired; each fires at most once. */
+  private firedProgressThresholds = new Set<number>();
 
-  /** Local display value while auto-playing; avoids row refresh races from per-frame setValue. */
+  /** Whether thresholds already met when the bar loaded have been recorded (they don't fire). */
+  private initialThresholdsSeeded = false;
+
+  /** Display value while animating or paused; avoids row-refresh races from per-frame setValue. */
   private localProgress = signal<number | null>(null);
 
   accentColor = computed(() => this.params().color || "var(--ion-color-primary)");
@@ -75,7 +78,6 @@ export class PlhProgressBarComponent
       if (!autoPlay) {
         const pausedAt = untracked(() => this.localProgress());
         if (pausedAt !== null) {
-          this.localProgress.set(null);
           void this.setValue(pausedAt);
         }
         return;
@@ -112,30 +114,27 @@ export class PlhProgressBarComponent
       });
     });
 
-    // Fire `on_progress: <percentage>` actions when the displayed progress crosses each threshold.
-    // The threshold is read from the trigger argument (parsed in app-data-action.utils.ts). A crossing
-    // fires once on the way up and re-arms if progress later drops back below the threshold.
+    // Fire each `on_progress: <percentage>` action once, when progress first reaches its threshold.
+    // Latch fired thresholds so async re-observations of progress can't fire the same one twice.
     effect(() => {
       const progress = this.displayProgress();
-      const previous = this.previousProgress;
-      this.previousProgress = progress;
-      // Establish a baseline on first run without firing, so a bar that mounts already at or above a
-      // threshold does not fire on load; only fire on genuine upward crossings thereafter.
-      if (previous === null || progress <= previous) {
-        return;
-      }
-      const crossed = untracked(() => this.actionList())
+      const reached = untracked(() => this.actionList())
         .filter((a) => a.trigger === "on_progress")
         .map((action) => ({ action, threshold: Number(action.trigger_args?.[0]) }))
         .filter(
-          ({ threshold }) =>
-            !Number.isNaN(threshold) && threshold > previous && threshold <= progress
+          ({ threshold }) => threshold <= progress && !this.firedProgressThresholds.has(threshold)
         )
-        .sort((a, b) => a.threshold - b.threshold)
-        .map(({ action }) => action);
-      if (crossed.length > 0) {
-        void this.parentContainerComponentRef.handleActions(crossed, this._row);
-      }
+        .sort((a, b) => a.threshold - b.threshold);
+      reached.forEach(({ threshold }) => this.firedProgressThresholds.add(threshold));
+
+      // On load, record thresholds the bar is already past without firing them; only thresholds
+      // reached afterwards fire (on_progress means reaching a threshold, not loading in past it).
+      const seedingInitialThresholds = !this.initialThresholdsSeeded;
+      this.initialThresholdsSeeded = true;
+      if (seedingInitialThresholds || reached.length === 0) return;
+
+      const actions = reached.map(({ action }) => action);
+      void this.parentContainerComponentRef.handleActions(actions, this._row);
     });
   }
 

--- a/packages/components/plh/progress-bar/progress-bar.logic.spec.ts
+++ b/packages/components/plh/progress-bar/progress-bar.logic.spec.ts
@@ -1,5 +1,5 @@
 import { FlowTypes } from "packages/data-models";
-import { selectOnProgressActions } from "./progress-bar.logic";
+import { selectCompleted, selectOnProgressActions } from "./progress-bar.logic";
 
 function onProgressAction(threshold: number | undefined): FlowTypes.TemplateRowAction {
   return {
@@ -121,5 +121,37 @@ describe("selectOnProgressActions", () => {
       handledThresholds: handled,
     });
     expect(later.toFire).toEqual([]);
+  });
+});
+
+describe("selectCompleted", () => {
+  it("emits when progress first reaches 100% after starting lower", () => {
+    expect(
+      selectCompleted({ progress: 100, previousProgress: 90, completedEmitted: false })
+    ).toEqual({ emit: true, completedEmitted: true });
+  });
+
+  it("does not emit when the bar mounts at 100%, but latches it", () => {
+    expect(
+      selectCompleted({ progress: 100, previousProgress: null, completedEmitted: false })
+    ).toEqual({ emit: false, completedEmitted: true });
+  });
+
+  it("does not re-emit once completed (e.g. after a dip and rise)", () => {
+    expect(
+      selectCompleted({ progress: 100, previousProgress: 40, completedEmitted: true })
+    ).toEqual({
+      emit: false,
+      completedEmitted: true,
+    });
+  });
+
+  it("does not emit below 100%", () => {
+    expect(
+      selectCompleted({ progress: 99, previousProgress: 10, completedEmitted: false })
+    ).toEqual({
+      emit: false,
+      completedEmitted: false,
+    });
   });
 });

--- a/packages/components/plh/progress-bar/progress-bar.logic.spec.ts
+++ b/packages/components/plh/progress-bar/progress-bar.logic.spec.ts
@@ -1,0 +1,125 @@
+import { FlowTypes } from "packages/data-models";
+import { selectOnProgressActions } from "./progress-bar.logic";
+
+function onProgressAction(threshold: number | undefined): FlowTypes.TemplateRowAction {
+  return {
+    trigger: "on_progress",
+    action_id: "set_local",
+    args: ["my_var"],
+    trigger_args: threshold === undefined ? undefined : [threshold],
+  } as FlowTypes.TemplateRowAction;
+}
+
+describe("selectOnProgressActions", () => {
+  it("seeds thresholds already met on first observation without firing", () => {
+    const handled = new Set<number>();
+    const action50 = onProgressAction(50);
+    const action80 = onProgressAction(80);
+
+    const result = selectOnProgressActions({
+      progress: 60,
+      previousProgress: null,
+      actions: [action50, action80],
+      handledThresholds: handled,
+    });
+
+    expect(result.toFire).toEqual([]);
+    expect(result.previousProgress).toBe(60);
+    expect(handled.has(50)).toBe(true);
+    expect(handled.has(80)).toBe(false);
+  });
+
+  it("fires thresholds crossed upward after the seed", () => {
+    const handled = new Set<number>();
+    const action25 = onProgressAction(25);
+    const action50 = onProgressAction(50);
+
+    selectOnProgressActions({
+      progress: 0,
+      previousProgress: null,
+      actions: [action25, action50],
+      handledThresholds: handled,
+    });
+
+    const result = selectOnProgressActions({
+      progress: 50,
+      previousProgress: 0,
+      actions: [action25, action50],
+      handledThresholds: handled,
+    });
+
+    expect(result.toFire).toEqual([action25, action50]);
+    expect(handled.has(25)).toBe(true);
+    expect(handled.has(50)).toBe(true);
+  });
+
+  it("does not re-fire a latched threshold after progress drops and rises again", () => {
+    const handled = new Set<number>([50]);
+    const action50 = onProgressAction(50);
+
+    const result = selectOnProgressActions({
+      progress: 80,
+      previousProgress: 40,
+      actions: [action50],
+      handledThresholds: handled,
+    });
+
+    expect(result.toFire).toEqual([]);
+  });
+
+  it("seeds late-bound actions already at/below current progress without firing", () => {
+    const handled = new Set<number>();
+    const action50 = onProgressAction(50);
+
+    const result = selectOnProgressActions({
+      progress: 60,
+      previousProgress: 60,
+      actions: [action50],
+      handledThresholds: handled,
+    });
+
+    expect(result.toFire).toEqual([]);
+    expect(handled.has(50)).toBe(true);
+  });
+
+  it("ignores missing or non-numeric trigger args", () => {
+    const handled = new Set<number>();
+    const missing = onProgressAction(undefined);
+    const invalid = {
+      ...onProgressAction(0),
+      trigger_args: ["not-a-number"],
+    } as FlowTypes.TemplateRowAction;
+
+    const result = selectOnProgressActions({
+      progress: 100,
+      previousProgress: 0,
+      actions: [missing, invalid],
+      handledThresholds: handled,
+    });
+
+    expect(result.toFire).toEqual([]);
+    expect(handled.size).toBe(0);
+  });
+
+  it("does not fire on_progress: 0 when seeding at 0", () => {
+    const handled = new Set<number>();
+    const action0 = onProgressAction(0);
+
+    const seeded = selectOnProgressActions({
+      progress: 0,
+      previousProgress: null,
+      actions: [action0],
+      handledThresholds: handled,
+    });
+    expect(seeded.toFire).toEqual([]);
+    expect(handled.has(0)).toBe(true);
+
+    const later = selectOnProgressActions({
+      progress: 10,
+      previousProgress: 0,
+      actions: [action0],
+      handledThresholds: handled,
+    });
+    expect(later.toFire).toEqual([]);
+  });
+});

--- a/packages/components/plh/progress-bar/progress-bar.logic.ts
+++ b/packages/components/plh/progress-bar/progress-bar.logic.ts
@@ -1,0 +1,38 @@
+import { FlowTypes } from "packages/data-models";
+
+/**
+ * Decide which `on_progress` actions to fire for a progress update.
+ * Mutates `handledThresholds` to latch handled thresholds (seeded or fired).
+ */
+export function selectOnProgressActions(options: {
+  progress: number;
+  previousProgress: number | null;
+  actions: FlowTypes.TemplateRowAction[];
+  handledThresholds: Set<number>;
+}): { previousProgress: number; toFire: FlowTypes.TemplateRowAction[] } {
+  const { progress, previousProgress, actions, handledThresholds } = options;
+
+  const candidates = actions
+    .filter((a) => a.trigger === "on_progress")
+    .map((action) => ({ action, threshold: Number(action.trigger_args?.[0]) }))
+    .filter(
+      ({ threshold }) =>
+        !Number.isNaN(threshold) && threshold <= progress && !handledThresholds.has(threshold)
+    )
+    .sort((a, b) => a.threshold - b.threshold);
+
+  candidates.forEach(({ threshold }) => handledThresholds.add(threshold));
+
+  // First observation: seed thresholds already at/below progress without firing.
+  if (previousProgress === null) {
+    return { previousProgress: progress, toFire: [] };
+  }
+
+  // Only fire thresholds crossed upward since the last observation. Late-bound actions that
+  // appear already at/below current progress are latched above but not fired.
+  const toFire = candidates
+    .filter(({ threshold }) => threshold > previousProgress && threshold <= progress)
+    .map(({ action }) => action);
+
+  return { previousProgress: progress, toFire };
+}

--- a/packages/components/plh/progress-bar/progress-bar.logic.ts
+++ b/packages/components/plh/progress-bar/progress-bar.logic.ts
@@ -36,3 +36,21 @@ export function selectOnProgressActions(options: {
 
   return { previousProgress: progress, toFire };
 }
+
+/**
+ * Decide whether to emit the built-in "completed" trigger for a progress update, and the next latch
+ * state. Emits once, when progress first reaches 100%. A bar that loads already at 100% is latched
+ * silently (so it doesn't emit), and a later dip/rise can't re-emit.
+ */
+export function selectCompleted(options: {
+  progress: number;
+  previousProgress: number | null;
+  completedEmitted: boolean;
+}): { emit: boolean; completedEmitted: boolean } {
+  const { progress, previousProgress, completedEmitted } = options;
+  if (completedEmitted || progress < 100) {
+    return { emit: false, completedEmitted };
+  }
+  // Reached 100% for the first time: emit unless this is the seeding first observation (mount at 100%).
+  return { emit: previousProgress !== null, completedEmitted: true };
+}

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -423,9 +423,9 @@ export namespace FlowTypes {
     | "data_changed"
     | "info_click"
     | "nav_resume" // return to template after navigation or popup close;
-    | "on_progress" // component value crosses a threshold provided as a trigger arg, e.g. `on_progress: 50`
     | "notification_interacted"
     | "notification_received"
+    | "on_progress" // fires once when value first reaches a threshold trigger arg, e.g. `on_progress: 50`
     | "sent" // notification sent
     | "uncompleted";
 

--- a/packages/data-models/flowTypes.ts
+++ b/packages/data-models/flowTypes.ts
@@ -423,6 +423,7 @@ export namespace FlowTypes {
     | "data_changed"
     | "info_click"
     | "nav_resume" // return to template after navigation or popup close;
+    | "on_progress" // component value crosses a threshold provided as a trigger arg, e.g. `on_progress: 50`
     | "notification_interacted"
     | "notification_received"
     | "sent" // notification sent
@@ -490,6 +491,8 @@ export namespace FlowTypes {
   export interface TemplateRowAction<ParamsType = any> {
     /** actions have an associated trigger */
     trigger: TemplateRowActionTrigger;
+    /** optional arguments provided to the trigger itself, e.g. the `50` in `on_progress: 50` */
+    trigger_args?: any[];
     action_id: (typeof ACTION_ID_LIST)[number];
     args: any[]; // should be boolean | string, but breaks type-checking for templates;
     rawArgs?: any; // original args before evaluation

--- a/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.spec.ts
+++ b/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.spec.ts
@@ -46,4 +46,14 @@ describe("parseAppDataActionString", () => {
     const action = parseAppDataActionString("on_progress: true | some_action");
     expect(action.trigger_args).toEqual([true]);
   });
+
+  it("parses on_progress without a trigger argument", () => {
+    // Authors should pass a percentage (`on_progress: 50`); without one, trigger_args is unset
+    // and the progress bar ignores the action (NaN threshold).
+    const action = parseAppDataActionString("on_progress | set_local: my_var");
+    expect(action.trigger).toEqual("on_progress");
+    expect(action.trigger_args).toBeUndefined();
+    expect(action.action_id).toEqual("set_local");
+    expect(action.args).toEqual(["my_var"]);
+  });
 });

--- a/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.spec.ts
+++ b/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.spec.ts
@@ -1,0 +1,49 @@
+import { parseAppDataActionString } from "./app-data-action.utils";
+
+/** yarn workspace scripts test -t app-data-action.utils.spec.ts */
+describe("parseAppDataActionString", () => {
+  it("parses a basic trigger + action + params", () => {
+    const action = parseAppDataActionString("click | set_value | hide_intro:true");
+    expect(action).toMatchObject({
+      trigger: "click",
+      action_id: "set_value",
+      args: [],
+      params: { hide_intro: true },
+    });
+    expect(action.trigger_args).toBeUndefined();
+  });
+
+  it("defaults to the click trigger when none is specified", () => {
+    const action = parseAppDataActionString("set_value | hide_intro:true");
+    expect(action.trigger).toEqual("click");
+    expect(action.trigger_args).toBeUndefined();
+  });
+
+  it("parses action_id args split on ':'", () => {
+    const action = parseAppDataActionString("completed | emit:completed");
+    expect(action).toMatchObject({ trigger: "completed", action_id: "emit", args: ["completed"] });
+    expect(action.trigger_args).toBeUndefined();
+  });
+
+  it("does not treat existing triggers as taking arguments", () => {
+    // regression guard: no existing trigger segment contains a ':'
+    const action = parseAppDataActionString("nav_resume | emit:nav_resume");
+    expect(action.trigger).toEqual("nav_resume");
+    expect(action.trigger_args).toBeUndefined();
+  });
+
+  it("parses a trigger argument, e.g. `on_progress: 50`", () => {
+    const action = parseAppDataActionString("on_progress: 50 | set_local: my_var | value: 3");
+    expect(action.trigger).toEqual("on_progress");
+    expect(action.trigger_args).toEqual(["50"]);
+    // the child action and its params remain cleanly separated from the trigger argument
+    expect(action.action_id).toEqual("set_local");
+    expect(action.args).toEqual(["my_var"]);
+    expect(action.params).toEqual({ value: 3 });
+  });
+
+  it("coerces boolean-like trigger arguments", () => {
+    const action = parseAppDataActionString("on_progress: true | some_action");
+    expect(action.trigger_args).toEqual([true]);
+  });
+});

--- a/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.ts
+++ b/packages/scripts/src/lib/app-data/convert/utils/app-data-action.utils.ts
@@ -32,6 +32,7 @@ export function parseAppDataActionString(actionString: string): FlowTypes.Templa
     notification_interacted: true,
     notification_received: true,
     nav_resume: true,
+    on_progress: true,
     sent: true,
     uncompleted: true,
   };
@@ -39,18 +40,22 @@ export function parseAppDataActionString(actionString: string): FlowTypes.Templa
     actionString = `click | ${actionString}`;
   }
   const parts = actionString.split("|").map((s) => s.trim());
-  const trigger = parts[0] as any;
+  // A trigger may optionally take arguments provided after a `:`, e.g. `on_progress: 50`.
+  const [trigger, ...trigger_args] = parts[0].split(":").map((s) => s.trim());
   const action: FlowTypes.TemplateRowAction = {
-    trigger,
-    action_id: null,
+    trigger: trigger as any,
+    action_id: null as any,
     args: [],
     _raw,
   };
+  if (trigger_args.length > 0) {
+    action.trigger_args = trigger_args.map((arg: string) => booleanStringToBoolean(arg));
+  }
   if (parts[1]) {
     // e.g `completed | emit:completed`
     let [action_id, ...args] = parts[1].split(":").map((s) => s.trim()) as any;
     action.action_id = action_id;
-    action.args = args.map((arg) => booleanStringToBoolean(arg));
+    action.args = args.map((arg: string) => booleanStringToBoolean(arg));
   }
   if (parts[2]) {
     // e.g. `click | pop_up:my_template | fullscreen:true`


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

## Summary

Adds progress-based action triggers on the `plh_progress_bar` component, so authors can run actions as the bar fills.

### Authoring

**`on_progress: <percentage>`** — run an action the first time progress reaches that percentage:

```
on_progress: 50 | set_local: halfway: true;
on_progress: 100 | set_local: done: true;
```

**`completed`** — also fires once when the bar first reaches 100% (same pattern as other components):

```
completed | set_local: bar_finished: true
```

### Behaviour (worth knowing)

- Each `on_progress` threshold fires **at most once**.
- Thresholds the bar is **already past on load** do not fire (e.g. a bar that mounts at 60% will not fire `on_progress: 50`).
- Same for `completed`: a bar that loads already at 100% does not emit `completed`.

### Dev notes

- Action strings can take **trigger args** after `:`, parsed into `trigger_args` on the action (e.g. `on_progress: 50`).
- Threshold / completed selection lives in `progress-bar.logic.ts` with unit tests.

## Git Issues

Closes #3570

## Screenshots/Videos

[comp_plh_progress_bar](https://docs.google.com/spreadsheets/d/1F5_69ZGcqDtisPhE5KDHVbfqlSX20E7-yTlktBPNEwc/edit?gid=569531329#gid=569531329). Note use of `nav_resume` action to handle restarting the loading animation on pop-up close.

https://github.com/user-attachments/assets/a1ecb0a6-d05e-40ab-b87d-a26cde09db6f

