### PR TITLE
fix: notification sent_recorded_timestamp; notification metadata in DB

### DIFF
--- a/src/app/feature/campaign/campaign.service.ts
+++ b/src/app/feature/campaign/campaign.service.ts
@@ -35,6 +35,10 @@ type IScheduledNotificationsHashmap = {
 
 interface ICampaignNotificationExtra {
   campaign_id: string;
+  /** Authored campaign row id */
+  row_id: string;
+  /** Authored campaign row name, when provided */
+  row_name?: string;
   action_list?: FlowTypes.TemplateRowAction[];
 }
 
@@ -278,7 +282,12 @@ export class CampaignService extends AsyncServiceBase {
     // HACK - remove markdown form title and text as not currently supported in capacitor notifications
     row.text = this.hackStripNotificationMarkdown(row.text);
     row.title = this.hackStripNotificationMarkdown(row.title);
-    const extra: ICampaignNotificationExtra = { campaign_id, action_list: row.action_list };
+    const extra: ICampaignNotificationExtra = {
+      campaign_id,
+      row_id: row.id,
+      row_name: row.name,
+      action_list: row.action_list,
+    };
 
     const notificationSchedule: ILocalNotification = {
       schedule: { at: _schedule_at },

--- a/src/app/shared/services/notification/local-notification-persist.adapter.ts
+++ b/src/app/shared/services/notification/local-notification-persist.adapter.ts
@@ -91,6 +91,13 @@ export class LocalNotificationPersistAdapter {
         notification_id,
       } as any;
     }
-    await this.db.put({ ...entry, ...update, _sync_status: "pending" });
+    await this.db.put({
+      ...entry,
+      ...update,
+      ...(entry.sent_recorded_timestamp
+        ? { sent_recorded_timestamp: entry.sent_recorded_timestamp }
+        : {}),
+      _sync_status: "pending",
+    });
   }
 }

--- a/src/app/shared/services/notification/local-notification-persist.adapter.ts
+++ b/src/app/shared/services/notification/local-notification-persist.adapter.ts
@@ -53,7 +53,7 @@ export class LocalNotificationPersistAdapter {
         const update: Partial<ILocalNotificationInteraction> = {
           action_id: actionId,
           action_recorded_timestamp: generateTimestamp(),
-          notification_meta: notification.extra,
+          notification_meta: this.buildNotificationMeta(notification),
         };
         if (inputValue) {
           update.action_meta = { inputValue };
@@ -70,13 +70,29 @@ export class LocalNotificationPersistAdapter {
         const timestamp = generateTimestamp();
         for (const notification of notifications) {
           await this.recordNotificationInteraction(notification.id, {
-            notification_meta: notification.extra,
+            notification_meta: this.buildNotificationMeta(notification),
             schedule_timestamp: generateTimestamp(notification.schedule.at),
             sent_recorded_timestamp: timestamp,
           });
         }
         this.loadInteractedNotifications();
       });
+  }
+
+  /** Persist campaign extra plus display fields for analytics */
+  private buildNotificationMeta(notification: {
+    title?: string;
+    body?: string;
+    extra?: Record<string, any>;
+    _row_id?: string;
+  }) {
+    return {
+      ...notification.extra,
+      // Prefer authored row id from extra; fall back to local _row_id when present
+      row_id: notification.extra?.row_id ?? notification._row_id,
+      title: notification.title,
+      text: notification.body,
+    };
   }
 
   private async recordNotificationInteraction(


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

See #3581 for description of the bug.

- Stop overwriting `sent_recorded_timestamp` on session notification refreshes
- Keep the first recorded sent time so it no longer drifts forward while the app stays open (which could make action time appear earlier than sent time)

Also improve what we store in `notification_meta` for campaign notifications:

- Include authored `row_id` and `row_name` in notification `extra` when scheduling
- Persist `title` and `text` alongside existing meta (`campaign_id`, `action_list`, etc.)

The changes are entirely client-side so nothing is required to be updated on the server. They will not fix existing bad rows in the DB, and already-scheduled notifications keep the old meta until replaced; both only apply from future app versions / newly scheduled notifications.

## Testing

In theory, the testing procedure might be:

- [ ] Schedule a notification, open the app so it is recorded as sent, then tap it
- [ ] Keep the app open through at least one notification sync cycle
- [ ] Confirm `sent_recorded_timestamp` stays unchanged in the DB and remains at or before `action_recorded_timestamp`
- [ ] Confirm new interaction rows include `row_id`, `row_name`, `title`, and `text` in `notification_meta`

However the changes are minimal and this procedure could be time-consuming, so it may be sensible to merge with minimal testing.

## Git Issues

Closes #3581

## Screenshots/Videos

