### PR TITLE
chore: add system of retrying failing downloads as part of sync from Canto

### DIFF
--- a/packages/scripts/src/tasks/providers/canto/download.spec.ts
+++ b/packages/scripts/src/tasks/providers/canto/download.spec.ts
@@ -1,0 +1,152 @@
+jest.mock("../../../commands/workflow/run", () => ({
+  WorkflowRunner: { config: {} },
+}));
+
+jest.mock("node-fetch");
+jest.mock("fs-extra", () => ({
+  outputFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+import fetch from "node-fetch";
+import * as fs from "fs-extra";
+import { downloadFile, isRetryableDownloadError } from "./download";
+import type { CantoDownloadedFolder, CantoManifestEntry } from "./types";
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+const mockOutputFile = fs.outputFile as jest.MockedFunction<typeof fs.outputFile>;
+
+const createFile = (
+  overrides: Partial<CantoManifestEntry> & Pick<CantoManifestEntry, "name"> = { name: "asset.svg" }
+): CantoManifestEntry => ({
+  id: "file-id",
+  scheme: "image",
+  url: { directUrlOriginal: "https://cdn.example.com/asset.svg" },
+  relatedAlbums: [
+    {
+      id: "album-id",
+      idPath: "root/source-folder-id/theme_default",
+      namePath: "Root/Source Folder/theme_default",
+      name: "theme_default",
+      scheme: "album",
+    },
+  ],
+  ...overrides,
+});
+
+const downloadedFolder: CantoDownloadedFolder = {
+  path: "/tmp/canto-output",
+  folderConfig: { id: "source-folder-id", name: "Test Folder" },
+};
+
+const createNetworkError = (code: string) =>
+  Object.assign(new Error(`request failed, reason: ${code}`), { code, type: "system" });
+
+const createOkResponse = (body = "file-bytes") =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    buffer: jest.fn().mockResolvedValue(Buffer.from(body)),
+  }) as any;
+
+const createHttpResponse = (status: number, statusText: string) =>
+  ({
+    ok: false,
+    status,
+    statusText,
+    buffer: jest.fn(),
+  }) as any;
+
+/** yarn workspace scripts test -t download.spec.ts */
+describe("Canto download retries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("isRetryableDownloadError", () => {
+    it("treats common network codes as retryable", () => {
+      expect(isRetryableDownloadError(createNetworkError("ECONNRESET"))).toEqual(true);
+      expect(isRetryableDownloadError(createNetworkError("ETIMEDOUT"))).toEqual(true);
+    });
+
+    it("treats retryable HTTP statuses as retryable", () => {
+      expect(isRetryableDownloadError(Object.assign(new Error("503"), { status: 503 }))).toEqual(
+        true
+      );
+      expect(isRetryableDownloadError(Object.assign(new Error("429"), { status: 429 }))).toEqual(
+        true
+      );
+    });
+
+    it("does not retry non-retryable HTTP statuses", () => {
+      expect(isRetryableDownloadError(Object.assign(new Error("403"), { status: 403 }))).toEqual(
+        false
+      );
+      expect(isRetryableDownloadError(Object.assign(new Error("404"), { status: 404 }))).toEqual(
+        false
+      );
+    });
+  });
+
+  describe("downloadFile", () => {
+    it("succeeds after a transient ECONNRESET on the first attempt", async () => {
+      mockFetch
+        .mockRejectedValueOnce(createNetworkError("ECONNRESET"))
+        .mockResolvedValueOnce(createOkResponse());
+
+      const promise = downloadFile(createFile(), downloadedFolder);
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockOutputFile).toHaveBeenCalledTimes(1);
+      expect(mockOutputFile).toHaveBeenCalledWith(
+        expect.stringContaining("asset.svg"),
+        Buffer.from("file-bytes")
+      );
+    });
+
+    it("retries a retryable 503 HTTP status then succeeds", async () => {
+      mockFetch
+        .mockResolvedValueOnce(createHttpResponse(503, "Service Unavailable"))
+        .mockResolvedValueOnce(createOkResponse());
+
+      const promise = downloadFile(createFile(), downloadedFolder);
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockOutputFile).toHaveBeenCalledTimes(1);
+      expect(mockOutputFile).toHaveBeenCalledWith(
+        expect.stringContaining("asset.svg"),
+        Buffer.from("file-bytes")
+      );
+    });
+
+    it("does not retry a non-retryable 403", async () => {
+      mockFetch.mockResolvedValueOnce(createHttpResponse(403, "Forbidden"));
+
+      await expect(downloadFile(createFile(), downloadedFolder)).rejects.toThrow(
+        /after 1 attempt\(s\).*403 Forbidden/
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockOutputFile).not.toHaveBeenCalled();
+    });
+
+    it("exhausts retries and throws on persistent network failure", async () => {
+      mockFetch.mockRejectedValue(createNetworkError("ECONNRESET"));
+
+      const promise = downloadFile(createFile(), downloadedFolder);
+      const assertion = expect(promise).rejects.toThrow(/after 4 attempt\(s\).*ECONNRESET/);
+      await jest.runAllTimersAsync();
+      await assertion;
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockOutputFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/scripts/src/tasks/providers/canto/download.ts
+++ b/packages/scripts/src/tasks/providers/canto/download.ts
@@ -38,8 +38,47 @@ interface ICantoSyncActions {
 }
 
 const DOWNLOAD_CONCURRENCY = 5;
+/** 1 initial attempt + 3 retries */
+const DOWNLOAD_MAX_ATTEMPTS = 4;
+const DOWNLOAD_RETRY_BASE_DELAY_MS = 500;
 const FOLDER_LIST_PAGE_SIZE = 1000;
 const MANIFEST_FILENAME = "manifest.json";
+
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+]);
+const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+const isRetryableDownloadError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const err = error as { code?: string; errno?: string; status?: number };
+  if (typeof err.status === "number") {
+    return RETRYABLE_HTTP_STATUSES.has(err.status);
+  }
+  const code = err.code || err.errno;
+  return typeof code === "string" && RETRYABLE_NETWORK_CODES.has(code);
+};
+
+const getRetryDelayMs = (failedAttempt: number): number => {
+  const base = DOWNLOAD_RETRY_BASE_DELAY_MS * Math.pow(2, failedAttempt - 1);
+  const jitter = Math.random() * DOWNLOAD_RETRY_BASE_DELAY_MS * 0.25;
+  return base + jitter;
+};
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const createHttpDownloadError = (status: number, statusText: string) => {
+  const error = new Error(`${status} ${statusText}`) as Error & { status: number };
+  error.status = status;
+  return error;
+};
 
 const listFiles = async () => {
   const { sourceFolders } = getCantoConfig();
@@ -283,15 +322,48 @@ const downloadFile = async (
 ) => {
   const url = fileEntry.url.directUrlOriginal;
   const filePath = getFilePath(fileEntry, downloadedFolder.folderConfig.id);
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(
-      `Canto file download failed for "${fileEntry.name}": ${response.status} ${response.statusText}`
-    );
-  }
-  const buffer = await response.buffer();
   const fullPath = path.join(downloadedFolder.path, filePath);
-  await fs.outputFile(fullPath, buffer);
+  let lastError: unknown;
+  let attemptsMade = 0;
+
+  for (let attempt = 1; attempt <= DOWNLOAD_MAX_ATTEMPTS; attempt++) {
+    attemptsMade = attempt;
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw createHttpDownloadError(response.status, response.statusText);
+      }
+      const buffer = await response.buffer();
+      await fs.outputFile(fullPath, buffer);
+      return;
+    } catch (error) {
+      lastError = error;
+      const canRetry = isRetryableDownloadError(error) && attempt < DOWNLOAD_MAX_ATTEMPTS;
+      if (!canRetry) {
+        break;
+      }
+      const delayMs = Math.round(getRetryDelayMs(attempt));
+      console.warn(
+        `Retrying Canto download for "${fileEntry.name}" (attempt ${attempt}/${DOWNLOAD_MAX_ATTEMPTS} failed: ${
+          error instanceof Error ? error.message : String(error)
+        }). Waiting ${delayMs}ms...`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Canto file download failed for "${fileEntry.name}" after ${attemptsMade} attempt(s): ${reason}`,
+    { cause: lastError }
+  );
 };
 
-export { createManifests, downloadFiles, getDownloadedFolders, listFiles };
+export {
+  createManifests,
+  downloadFile,
+  downloadFiles,
+  getDownloadedFolders,
+  isRetryableDownloadError,
+  listFiles,
+};


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

- Add retry with exponential backoff for Canto CloudFront asset downloads so transient network failures (e.g. `FetchError: … read ECONNRESET`) no longer abort `canto_assets_dl` on the first blip
- Still fail the sync after retries are exhausted; non-retryable HTTP errors like 403 fail immediately
- Cover retry success, non-retryable 403, and exhausted retries in unit tests

## Test plan
- [x] Run `yarn workflow deployment sync` on a deployment with Canto assets and confirm downloads complete (or only fail after retries with a clear file-named error)

## Git Issues

Closes #

## Screenshots/Videos

_If useful, provide screenshot or capture to highlight main changes_
