### PR TITLE
Feature: Reactive popup

### DIFF
--- a/packages/test-e2e/cypress/e2e/components/popup.cy.ts
+++ b/packages/test-e2e/cypress/e2e/components/popup.cy.ts
@@ -34,7 +34,7 @@ describe("popup component", () => {
 
     cy.get("ion-modal").should("be.visible").find(".popup-container").contains("Override Value");
 
-    cy.get("ion-modal").find(".close-button").click();
+    cy.get("ion-modal").find(`[data-test='templatePopup.okButton']`).click();
 
     cy.get("ion-modal").should("not.be.visible");
   });

--- a/packages/test-e2e/cypress/e2e/components/popup.cy.ts
+++ b/packages/test-e2e/cypress/e2e/components/popup.cy.ts
@@ -1,0 +1,53 @@
+describe("popup component", () => {
+  beforeEach(() => {
+    cy.visit("/template/test_popup");
+  });
+
+  it("displays a dialog style popup", () => {
+    cy.getDataTest("inlinePopupButton").click();
+
+    cy.get("ion-modal")
+      .should("be.visible")
+      .find(".popup-container")
+      .contains("This is a dialog style popup");
+
+    cy.get("ion-modal").find(".close-button").click();
+
+    cy.get("ion-modal").should("not.be.visible");
+  });
+
+  it("displays a full screen popup", () => {
+    cy.getDataTest("fullscreenPopupButton").click();
+
+    cy.get("ion-modal")
+      .should("be.visible")
+      .find(".popup-container")
+      .contains("This is a full screen popup");
+
+    cy.get("ion-modal").find(".close-button").click();
+
+    cy.get("ion-modal").should("not.be.visible");
+  });
+
+  it("displays a template popup with override parameter", () => {
+    cy.getDataTest("templatePopupButton").click();
+
+    cy.get("ion-modal").should("be.visible").find(".popup-container").contains("Override Value");
+
+    cy.get("ion-modal").find(".close-button").click();
+
+    cy.get("ion-modal").should("not.be.visible");
+  });
+
+  it("displays a template popup with dynamic override parameter", () => {
+    cy.getDataTest("dynamicTemplatePopupValue").find("input").clear().type("Dynamic Text").blur();
+
+    cy.getDataTest("dynamicTemplatePopupButton").click();
+
+    cy.get("ion-modal").should("be.visible").find(".popup-container").contains("Dynamic Text");
+
+    cy.get("ion-modal").find(".close-button").click();
+
+    cy.get("ion-modal").should("not.be.visible");
+  });
+});

--- a/src/app/reactive-templates/reactive-components/components/display-group/display-group.component.html
+++ b/src/app/reactive-templates/reactive-components/components/display-group/display-group.component.html
@@ -9,5 +9,6 @@
   [attr.data-child-sizing]="params.childSizing.value()"
   [attr.data-test]="name()"
   [style.flex-wrap]="wrap()"
+  (emittedValue)="onEmittedValue($event)"
   class="display-group"
 ></oab-row-list>

--- a/src/app/reactive-templates/reactive-components/components/index.ts
+++ b/src/app/reactive-templates/reactive-components/components/index.ts
@@ -13,6 +13,7 @@ import { NavComponent } from "./nav/nav.component";
 import { SetGlobalComponent } from "./set-global/set-global.component";
 import { DisplayGroupComponent } from "./display-group/display-group.component";
 import { UpdateComponent } from "./update/update.component";
+import { PopupComponent } from "./popup/popup.component";
 
 export const REACTIVE_COMPONENT_MAP = {
   action: ActionComponent,
@@ -20,6 +21,7 @@ export const REACTIVE_COMPONENT_MAP = {
   display_group: DisplayGroupComponent,
   dropdown: DropdownComponent,
   loop: LoopComponent,
+  popup: PopupComponent,
   nav: NavComponent,
   set_global: SetGlobalComponent,
   set_variable: SetVariableComponent,

--- a/src/app/reactive-templates/reactive-components/components/loop/loop.component.html
+++ b/src/app/reactive-templates/reactive-components/components/loop/loop.component.html
@@ -3,5 +3,6 @@
     [namespace]="getName(item, $index)"
     [rows]="rows()"
     [attr.data-test]="getName(item, $index)"
+    (emittedValue)="onEmittedValue($event)"
   ></oab-row-list>
 }

--- a/src/app/reactive-templates/reactive-components/components/nested-template/nested-template.component.html
+++ b/src/app/reactive-templates/reactive-components/components/nested-template/nested-template.component.html
@@ -2,4 +2,5 @@
   [templateName]="value()"
   [namespace]="name()"
   [attr.data-test]="name()"
+  (emittedValue)="onEmittedValue($event)"
 ></oab-reactive-template>

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
@@ -41,6 +41,7 @@
 
 <ng-template #closeButton>
   <button
+    type="button"
     (click)="dismiss()"
     (keyup.escape)="dismiss()"
     class="close-button"

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
@@ -1,0 +1,46 @@
+<ion-modal
+  [isOpen]="isOpen()"
+  [class.dialog]="!params.fullscreen.value()"
+  [class.fullscreen]="params.fullscreen.value()"
+>
+  <ng-template>
+    @if (params.fullscreen.value()) {
+      <ion-header>
+        <ion-toolbar>
+          @if (params.showCloseButton.value()) {
+            <div slot="end">
+              <ng-container [ngTemplateOutlet]="closeButton"></ng-container>
+            </div>
+          }
+        </ion-toolbar>
+      </ion-header>
+    }
+
+    <div class="popup-container">
+      @if (!params.fullscreen.value() && params.showCloseButton.value()) {
+        <ng-container [ngTemplateOutlet]="closeButton"></ng-container>
+      }
+      <div class="popup-content">
+        @if (value()) {
+          <oab-nested-template [row]="row()" [namespace]="namespace()"></oab-nested-template>
+        } @else {
+          <oab-row-list [rows]="row().rows || []" [namespace]="namespace()"></oab-row-list>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ion-modal>
+
+<ng-template #closeButton>
+  <button
+    (click)="dismiss()"
+    (keyup.escape)="dismiss()"
+    class="close-button"
+    fill="clear"
+    tabindex="0"
+    role="button"
+    aria-label="Close popup"
+  >
+    <ion-icon slot="icon-only" name="close"></ion-icon>
+  </button>
+</ng-template>

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.html
@@ -22,9 +22,17 @@
       }
       <div class="popup-content">
         @if (value()) {
-          <oab-nested-template [row]="row()" [namespace]="namespace()"></oab-nested-template>
+          <oab-nested-template
+            [row]="row()"
+            [namespace]="namespace()"
+            (emittedValue)="onEmittedValue($event)"
+          ></oab-nested-template>
         } @else {
-          <oab-row-list [rows]="row().rows || []" [namespace]="namespace()"></oab-row-list>
+          <oab-row-list
+            [rows]="row().rows || []"
+            [namespace]="namespace()"
+            (emittedValue)="onEmittedValue($event)"
+          ></oab-row-list>
         }
       </div>
     </div>

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
@@ -71,4 +71,8 @@ ion-modal.fullscreen {
   .popup-container {
     height: 100%;
   }
+
+  .close-button {
+    margin-right: 8px;
+  }
 }

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
@@ -1,0 +1,74 @@
+// Note that --pop-up-background is always defined (populated by theme generation), so no fallback is needed
+// This avoids self-reference when re-defining --ion-background-color below
+$pop-up-background: var(--pop-up-background);
+$pop-up-padding: var(--pop-up-padding, 20px);
+
+// Set the background color var to the popup background color for any children
+:host {
+  --ion-background-color: var(--pop-up-background);
+}
+
+ion-modal {
+  &::part(content) {
+    overflow: visible;
+  }
+
+  .popup-container {
+    position: relative;
+    overflow: visible;
+  }
+
+  .popup-content {
+    height: fit-content;
+    max-height: 100%;
+    background: $pop-up-background;
+    border-radius: 20px;
+    padding: $pop-up-padding;
+    overflow: auto;
+  }
+  .popup-content::-webkit-scrollbar {
+    display: none;
+  }
+
+  .close-button {
+    background: white;
+    width: 40px;
+    height: 40px;
+    border-radius: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--ion-color-primary);
+    font-size: 24px;
+    z-index: 100;
+    box-shadow: var(--ion-default-box-shadow);
+    color: var(--ion-color-primary);
+    inset-inline-end: 0;
+    cursor: pointer;
+  }
+}
+
+ion-modal.dialog {
+  --width: fit-content;
+  --height: fit-content;
+  --min-width: 250px;
+  --border-radius: 20px;
+  --box-shadow: 0 28px 48px rgba(0, 0, 0, 0.4);
+
+  .close-button {
+    position: absolute;
+    top: 0;
+    transform: translate(50%, -50%);
+  }
+}
+
+ion-modal.fullscreen {
+  ion-toolbar {
+    height: var(--header-height);
+  }
+
+  .popup-container {
+    height: 100%;
+  }
+}

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.scss
@@ -71,8 +71,4 @@ ion-modal.fullscreen {
   .popup-container {
     height: 100%;
   }
-
-  .close-button {
-    margin-right: 8px;
-  }
 }

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
@@ -22,10 +22,9 @@ const parameters = () =>
   templateUrl: "./popup.component.html",
   styleUrl: "./popup.component.scss",
   imports: [
-    forwardRef(() => ReactiveTemplateComponent),
+    forwardRef(() => RowListComponent),
     IonicModule,
     NgTemplateOutlet,
-    RowListComponent,
     NestedTemplateComponent,
   ],
   providers: [{ provide: ROW_PARAMETERS, useFactory: parameters }],

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
@@ -1,0 +1,68 @@
+import { Component, forwardRef, inject, signal } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
+import { IonicModule } from "@ionic/angular";
+import { defineParameters, Parameter } from "../../parameters";
+import { ROW_PARAMETERS, RowBaseComponent } from "../../row-base.component";
+import { ReactiveTemplateComponent } from "src/app/reactive-templates/reactive-template/reactive-template.component";
+import { RowListComponent } from "../../row-list.component";
+import {
+  ActionRegistry,
+  IAction,
+  IActionParameter,
+} from "src/app/reactive-templates/services/action.registry";
+import { NestedTemplateComponent } from "../nested-template/nested-template.component";
+
+const parameters = () =>
+  defineParameters({
+    showCloseButton: new Parameter("show_close_button", true, "script"),
+    fullscreen: new Parameter("fullscreen", false, "script"),
+  });
+
+@Component({
+  templateUrl: "./popup.component.html",
+  styleUrl: "./popup.component.scss",
+  imports: [
+    forwardRef(() => ReactiveTemplateComponent),
+    IonicModule,
+    NgTemplateOutlet,
+    RowListComponent,
+    NestedTemplateComponent,
+  ],
+  providers: [{ provide: ROW_PARAMETERS, useFactory: parameters }],
+})
+/**
+ * When opening a template as a popup, provide a minimal interface and load
+ * the template directly as a regular template-container element
+ */
+export class PopupComponent
+  extends RowBaseComponent<ReturnType<typeof parameters>>
+  implements IAction
+{
+  private readonly actionRegistry = inject(ActionRegistry);
+
+  public isOpen = signal(false);
+
+  public execute(params?: IActionParameter[]): Promise<void> {
+    // todo: show modal.
+    this.isOpen.set(true);
+    return Promise.resolve();
+  }
+
+  public init(): void {
+    super.init();
+
+    this.actionRegistry.register(this);
+  }
+
+  public dismissOnBackdrop(e: Event) {
+    const el = e.target as HTMLElement;
+    if (el.classList.contains("popup-backdrop")) {
+      this.dismiss();
+    }
+  }
+
+  public dismiss(value?: { emit_value: string; emit_data: any }) {
+    // todo: close modal and emit completed/uncompleted value to parent template if needed
+    this.isOpen.set(false);
+  }
+}

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
@@ -19,7 +19,7 @@ const parameters = () =>
 
 @Component({
   templateUrl: "./popup.component.html",
-  styleUrl: "./popup.component.scss",
+  styleUrls: ["./popup.component.scss"],
   imports: [
     forwardRef(() => RowListComponent),
     IonicModule,

--- a/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
+++ b/src/app/reactive-templates/reactive-components/components/popup/popup.component.ts
@@ -3,7 +3,6 @@ import { NgTemplateOutlet } from "@angular/common";
 import { IonicModule } from "@ionic/angular";
 import { defineParameters, Parameter } from "../../parameters";
 import { ROW_PARAMETERS, RowBaseComponent } from "../../row-base.component";
-import { ReactiveTemplateComponent } from "src/app/reactive-templates/reactive-template/reactive-template.component";
 import { RowListComponent } from "../../row-list.component";
 import {
   ActionRegistry,
@@ -60,8 +59,15 @@ export class PopupComponent
     }
   }
 
-  public dismiss(value?: { emit_value: string; emit_data: any }) {
-    // todo: close modal and emit completed/uncompleted value to parent template if needed
+  public dismiss(value?: { emitValue: string; emitData: any }) {
     this.isOpen.set(false);
+  }
+
+  public onEmittedValue(event: { emitValue: string; emitData: any }) {
+    super.onEmittedValue(event);
+
+    if (["completed", "uncompleted"].includes(event.emitValue)) {
+      this.dismiss(event);
+    }
   }
 }

--- a/src/app/reactive-templates/reactive-components/row-base.component.ts
+++ b/src/app/reactive-templates/reactive-components/row-base.component.ts
@@ -8,6 +8,7 @@ import {
   input,
   OnDestroy,
   OnInit,
+  output,
   signal,
   Signal,
   WritableSignal,
@@ -23,6 +24,7 @@ export const defineBaseParameters = () =>
   });
 
 export type BaseParameters = ReturnType<typeof defineBaseParameters>;
+export type RowEmitEvent = { emitValue: string; emitData: any };
 
 /** Merges component-specific params with BaseParameters, handling null (components with no params) */
 export type MergeParams<TParams> = TParams extends null ? BaseParameters : TParams & BaseParameters;
@@ -52,6 +54,9 @@ export abstract class RowBaseComponent<TParams extends Parameters | null>
 {
   public row = input.required<FlowTypes.TemplateRow>();
   public namespace = input("");
+  public emittedValue = output<RowEmitEvent>();
+  public onEmit = input<((event: RowEmitEvent) => void) | undefined>(undefined);
+
   public name = computed(() =>
     this.namespaceService.getFullName(this.namespace(), this.row().name)
   );
@@ -161,6 +166,16 @@ export abstract class RowBaseComponent<TParams extends Parameters | null>
     this.rowRegistry.register(this);
   }
 
+  public onEmittedValue(event: RowEmitEvent) {
+    const emit = this.onEmit();
+    if (emit) {
+      emit(event);
+      return;
+    }
+
+    this.emittedValue.emit(event);
+  }
+
   /*
    * Sets the rows expression value and updates the variable store.
    */
@@ -173,6 +188,16 @@ export abstract class RowBaseComponent<TParams extends Parameters | null>
 
   public triggerActions(trigger: string) {
     this.actionService.handleActions(this, trigger, this.namespace());
+    const emitActions = this.row().action_list?.filter(
+      (a) => a.trigger === trigger && a.action_id === "emit"
+    );
+
+    for (const action of emitActions ?? []) {
+      this.onEmittedValue({
+        emitValue: action.args[0],
+        emitData: action.args[1],
+      });
+    }
   }
 
   // Override to transform the value before storing in variable store.

--- a/src/app/reactive-templates/reactive-components/row-list.component.ts
+++ b/src/app/reactive-templates/reactive-components/row-list.component.ts
@@ -47,7 +47,7 @@ export class RowListComponent {
     return {
       row,
       namespace: this.namespace(),
-      onInitialised: () => this.onRowInit(index),
+      onInitialised: this.onRowInit(index),
       onEmit: (event: RowEmitEvent) => this.onEmittedValue(event),
     };
   }

--- a/src/app/reactive-templates/reactive-components/row-list.component.ts
+++ b/src/app/reactive-templates/reactive-components/row-list.component.ts
@@ -1,17 +1,17 @@
 import { NgComponentOutlet } from "@angular/common";
-import { Component, computed, inject, input, Type } from "@angular/core";
+import { Component, computed, inject, input, output, Type } from "@angular/core";
 import { FlowTypes } from "packages/data-models";
 import { REACTIVE_COMPONENT_MAP } from "./components";
 import { DebugService } from "../services/debug.service";
 import { RowDebuggerComponent } from "./debug/row-debugger/row-debugger.component";
-import { RowBaseComponent } from "./row-base.component";
+import { RowBaseComponent, RowEmitEvent } from "./row-base.component";
 
 @Component({
   selector: "oab-row-list",
   template: `
     @for (row of rows(); track i; let i = $index) {
       @let component = getComponent(row);
-      @let outletInputs = { row, namespace: namespace(), onInitialised: onRowInit(i) };
+      @let outletInputs = getOutletInputs(row, i);
 
       @if (debug.isEnabled()) {
         <oab-row-debugger>
@@ -29,6 +29,7 @@ export class RowListComponent {
 
   public namespace = input("");
   public rows = input<FlowTypes.TemplateRow[]>([]);
+  public emittedValue = output<{ emitValue: string; emitData: any }>();
 
   public readonly initialised = computed(() => {
     // Initially zero rows will be reported we will
@@ -41,6 +42,19 @@ export class RowListComponent {
   });
 
   private rowsInitialised = new Set<number>();
+
+  public getOutletInputs(row: FlowTypes.TemplateRow, index: number) {
+    return {
+      row,
+      namespace: this.namespace(),
+      onInitialised: () => this.onRowInit(index),
+      onEmit: (event: RowEmitEvent) => this.onEmittedValue(event),
+    };
+  }
+
+  public onEmittedValue(event: { emitValue: string; emitData: any }) {
+    this.emittedValue.emit(event);
+  }
 
   public getComponent(row: FlowTypes.TemplateRow): Type<RowBaseComponent<any>> {
     return REACTIVE_COMPONENT_MAP[row.type] as Type<RowBaseComponent<any>>;

--- a/src/app/reactive-templates/reactive-components/row-list.component.ts
+++ b/src/app/reactive-templates/reactive-components/row-list.component.ts
@@ -29,7 +29,7 @@ export class RowListComponent {
 
   public namespace = input("");
   public rows = input<FlowTypes.TemplateRow[]>([]);
-  public emittedValue = output<{ emitValue: string; emitData: any }>();
+  public emittedValue = output<RowEmitEvent>();
 
   public readonly initialised = computed(() => {
     // Initially zero rows will be reported we will
@@ -52,7 +52,7 @@ export class RowListComponent {
     };
   }
 
-  public onEmittedValue(event: { emitValue: string; emitData: any }) {
+  public onEmittedValue(event: RowEmitEvent) {
     this.emittedValue.emit(event);
   }
 

--- a/src/app/reactive-templates/reactive-template/reactive-template.component.html
+++ b/src/app/reactive-templates/reactive-template/reactive-template.component.html
@@ -4,4 +4,8 @@
     [template]="template()"
   ></oab-template-debugger>
 }
-<oab-row-list [rows]="rows()" [namespace]="namespace()"></oab-row-list>
+<oab-row-list
+  [rows]="rows()"
+  [namespace]="namespace()"
+  (emittedValue)="onEmittedValue($event)"
+></oab-row-list>

--- a/src/app/reactive-templates/reactive-template/reactive-template.component.ts
+++ b/src/app/reactive-templates/reactive-template/reactive-template.component.ts
@@ -1,4 +1,13 @@
-import { Component, computed, effect, forwardRef, input, signal, viewChild } from "@angular/core";
+import {
+  Component,
+  computed,
+  effect,
+  forwardRef,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { FlowTypes } from "packages/data-models";
 import { TemplateService } from "src/app/shared/components/template/services/template.service";
 import { RowListComponent } from "../reactive-components/row-list.component";
@@ -17,12 +26,17 @@ export class ReactiveTemplateComponent {
 
   public template = signal<FlowTypes.Template | undefined>(undefined);
   public rows = computed(() => this.template()?.rows || []);
+  public emittedValue = output<{ emitValue: string; emitData: any }>();
 
   private rowListComponent = viewChild.required(RowListComponent);
 
   public readonly initialised = computed(() => {
     return this.rowListComponent().initialised();
   });
+
+  public onEmittedValue(event: { emitValue: string; emitData: any }) {
+    this.emittedValue.emit(event);
+  }
 
   constructor(
     private templateService: TemplateService,

--- a/src/app/reactive-templates/reactive-template/reactive-template.component.ts
+++ b/src/app/reactive-templates/reactive-template/reactive-template.component.ts
@@ -13,6 +13,7 @@ import { TemplateService } from "src/app/shared/components/template/services/tem
 import { RowListComponent } from "../reactive-components/row-list.component";
 import { DebugService } from "../services/debug.service";
 import { TemplateDebuggerComponent } from "../reactive-components/debug/template-debugger/template-debugger.component";
+import { RowEmitEvent } from "../reactive-components/row-base.component";
 
 @Component({
   selector: "oab-reactive-template",
@@ -26,7 +27,7 @@ export class ReactiveTemplateComponent {
 
   public template = signal<FlowTypes.Template | undefined>(undefined);
   public rows = computed(() => this.template()?.rows || []);
-  public emittedValue = output<{ emitValue: string; emitData: any }>();
+  public emittedValue = output<RowEmitEvent>();
 
   private rowListComponent = viewChild.required(RowListComponent);
 
@@ -34,7 +35,7 @@ export class ReactiveTemplateComponent {
     return this.rowListComponent().initialised();
   });
 
-  public onEmittedValue(event: { emitValue: string; emitData: any }) {
+  public onEmittedValue(event: RowEmitEvent) {
     this.emittedValue.emit(event);
   }
 

--- a/src/app/reactive-templates/services/core-actions.service.ts
+++ b/src/app/reactive-templates/services/core-actions.service.ts
@@ -64,7 +64,6 @@ export class CoreActionsService {
       },
       emit: async (action) => {
         // todo: Find out what this is and then implement it using reactive templates.
-
         throw new ActionNotImplementedError("emit");
       },
     });

--- a/src/app/reactive-templates/services/core-actions.service.ts
+++ b/src/app/reactive-templates/services/core-actions.service.ts
@@ -63,8 +63,7 @@ export class CoreActionsService {
         throw new ActionNotImplementedError("trigger_actions");
       },
       emit: async (action) => {
-        // todo: Find out what this is and then implement it using reactive templates.
-        throw new ActionNotImplementedError("emit");
+        // todo: This logs a completed event in the old template system. Should we implement this in the new system?
       },
     });
   }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Adds a reactive Popup component.

### Declared inline

If a value is not specified, this is an inline modal and works using a row list component

<img alt="image" src="https://github.com/user-attachments/assets/b9cf9209-0f09-4008-93e6-b5933addb78f" />

### As a nested template

If a value is specified the popup component will be populated using a nested template

<img alt="image" src="https://github.com/user-attachments/assets/e815d2f9-498b-411d-83a1-f9408be764df" />

### Emit Events

Emit events have also been implemented and a similar way to the existing templates. Any emitted events will be propogated to their parent events. "completed" & "uncompleted" events can be used to close modals.

<img alt="image" src="https://github.com/user-attachments/assets/4dcd1ade-faf0-44f8-b0db-1f1574614a20" />

## Screenshots/Videos

### Modal Popup

<img height="851" alt="image" src="https://github.com/user-attachments/assets/05671985-49eb-4b28-9c9a-e508e25630bf" />

### Fullscreen Popup

<img height="851" alt="image" src="https://github.com/user-attachments/assets/3ef0af93-e689-4168-9ee4-f128cce92b2c" />

