### PR TITLE
feat: resume interrupted remote asset pack downloads

### DIFF
--- a/src/app/shared/services/file-manager/file-manager.service.ts
+++ b/src/app/shared/services/file-manager/file-manager.service.ts
@@ -11,6 +11,14 @@ import { ErrorHandlerService } from "../error-handler/error-handler.service";
 import { DeploymentService } from "../deployment/deployment.service";
 import { basenameFromExternalUrl, isExternalHttpUrl } from "shared/src/utils/string-utils";
 
+/** Result of statting a file previously written via `FileManagerService.saveFile` */
+export interface ISavedFileInfo {
+  exists: boolean;
+  sizeBytes?: number;
+  /** Webview-usable path to the file, matching the `src` returned by `saveFile` */
+  src?: string;
+}
+
 @Injectable({
   providedIn: "root",
 })
@@ -198,21 +206,22 @@ export class FileManagerService extends SyncServiceBase {
 
   /**
    * Native only: check whether a file previously written via `saveFile` exists on disk, and if so
-   * return its size in bytes. Uses the same path rule as `saveFile` so callers do not re-derive it.
+   * return its size in bytes and the same `src` that `saveFile` would have returned for it. Uses the
+   * same path rule as `saveFile` so callers do not re-derive it.
    * Returns `{ exists: false }` when the file is not present (stat throws for a missing path).
    */
   public async getSavedFileInfo(
     targetPath: string,
     options: { directory?: keyof typeof Directory; subdirectory?: string } = {}
-  ): Promise<{ exists: boolean; sizeBytes?: number }> {
+  ): Promise<ISavedFileInfo> {
     if (!Capacitor.isNativePlatform()) {
       throw new Error("getSavedFileInfo() is only supported on native platforms");
     }
     const { directory = "Data", subdirectory = "" } = options;
     const path = (subdirectory ? subdirectory + "/" : "") + `${this.cacheName}/${targetPath}`;
     try {
-      const { size } = await Filesystem.stat({ path, directory: Directory[directory] });
-      return { exists: true, sizeBytes: size };
+      const { size, uri } = await Filesystem.stat({ path, directory: Directory[directory] });
+      return { exists: true, sizeBytes: size, src: Capacitor.convertFileSrc(uri) };
     } catch {
       return { exists: false };
     }

--- a/src/app/shared/services/file-manager/file-manager.service.ts
+++ b/src/app/shared/services/file-manager/file-manager.service.ts
@@ -197,6 +197,28 @@ export class FileManagerService extends SyncServiceBase {
   }
 
   /**
+   * Native only: check whether a file previously written via `saveFile` exists on disk, and if so
+   * return its size in bytes. Uses the same path rule as `saveFile` so callers do not re-derive it.
+   * Returns `{ exists: false }` when the file is not present (stat throws for a missing path).
+   */
+  public async getSavedFileInfo(
+    targetPath: string,
+    options: { directory?: keyof typeof Directory; subdirectory?: string } = {}
+  ): Promise<{ exists: boolean; sizeBytes?: number }> {
+    if (!Capacitor.isNativePlatform()) {
+      throw new Error("getSavedFileInfo() is only supported on native platforms");
+    }
+    const { directory = "Data", subdirectory = "" } = options;
+    const path = (subdirectory ? subdirectory + "/" : "") + `${this.cacheName}/${targetPath}`;
+    try {
+      const { size } = await Filesystem.stat({ path, directory: Directory[directory] });
+      return { exists: true, sizeBytes: size };
+    } catch {
+      return { exists: false };
+    }
+  }
+
+  /**
    * @returns a URL to access the file (not currently used)
    * Adapted from https://www.npmjs.com/package/capacitor-blob-writer
    */

--- a/src/app/shared/services/remote-asset/README.md
+++ b/src/app/shared/services/remote-asset/README.md
@@ -105,6 +105,14 @@ asset_pack: download | ensure_downloaded | cancel_download | reset
 | `cancel_download` | Abort all active downloads and mark them `cancelled` |
 | `reset` | Clear downloaded contents and pack metadata, back to the pre-download state (testing aid; does not yet delete files from the device) |
 
+Both `download` and `ensure_downloaded` accept `debug_download_delay_ms`, a manual testing aid that pauses for that many ms before each asset file:
+
+```yaml
+asset_pack | download: my_asset_pack | debug_download_delay_ms: 3000
+```
+
+This exists to open a reliable window for interrupting a download — force-quitting the app mid-pack, toggling airplane mode — which is otherwise hard to hit on a fast connection. It defaults to `0`, is scoped to the single action call that sets it, and an unparseable value is ignored rather than breaking the download. Note the delay applies to *skipped* files too, so with it on a resume won't look faster: verify resume by status and counts reaching completion, not by speed.
+
 Progress and status are exposed to authoring in two places:
 
 - **`asset_pack_download_in_progress`** — a system variable holding a boolean string, for showing or hiding UI while any download is running. Referenced as `@fields._asset_pack_download_in_progress`, or as `@system.asset_pack_download_in_progress` in deployments using `useReactiveTemplates`.

--- a/src/app/shared/services/remote-asset/README.md
+++ b/src/app/shared/services/remote-asset/README.md
@@ -1,0 +1,132 @@
+# Remote Assets
+
+Remote assets let a deployment ship large media (images, audio, video) **outside** the app bundle and fetch it on demand, instead of bloating every install with files most users may never see. Content is grouped into named **asset packs** hosted in cloud storage; the app downloads a pack when a template asks for it, and from then on the asset resolves exactly like a bundled one.
+
+The feature is a no-op unless the deployment opts in:
+
+```ts
+// deployment config
+remote_assets: {
+  provider: "supabase" | "firebase",
+  bucketName: "my-bucket",  // supabase only; firebase uses firebase.config.storageBucket
+  folderName: "assets",     // path prefix inside the bucket
+}
+```
+
+Without `remote_assets.provider` the service sets `remoteAssetsEnabled = false`, registers the template actions so authors get an explanatory error rather than a silent no-op, and does nothing else.
+
+## Files in this folder
+
+| File | Responsibility |
+| --- | --- |
+| `remote-asset.service.ts` | Everything stateful: init, download orchestration, per-file fetch/save/integrate, resume |
+| `remote-asset-metadata.service.ts` | Reads/writes pack status rows in the `_asset_packs` data list |
+| `remote-asset.actions.ts` | The `asset_pack: *` template actions and their param parsing |
+| `remote-asset.types.ts` | Shared types and the two protected data list names |
+| `providers/` | `IRemoteAssetProvider` plus Supabase and Firebase implementations |
+
+## The central idea: `_assets_contents`
+
+Everything hangs off one dynamic data list, `_assets_contents`. `TemplateAssetService` reads it to turn an authored asset reference into a real path, and it does not care where a row came from.
+
+At startup the list is seeded from the **bundled** (core) asset contents. Downloading a pack simply **overwrites rows in that same list** with paths that point at the newly available copies. That is why an author can write `my_image.png` without knowing whether it ships in the bundle or arrives from a pack — resolution is identical either way.
+
+```mermaid
+flowchart TD
+    Core["Bundled contents.json"] -->|seeds at init| Contents["_assets_contents (dynamic data)"]
+    Manifest["Pack manifest"] --> Native["Native: fetch bytes, write to Data dir"]
+    Manifest --> Web["Web: no fetch needed"]
+    Native -->|"filePath = local src"| Contents
+    Web -->|"filePath = provider CDN URL"| Contents
+    Contents --> Template["TemplateAssetService resolves asset references"]
+```
+
+Note the platform split: **native downloads files, web does not.** On web the browser can stream straight from the provider's CDN, so a "download" only rewrites `filePath` to a public URL. All the filesystem, resume and integrity logic below is native-only.
+
+## Slots
+
+A manifest row is one logical asset, but it can carry several files: the base file plus one override per theme/language combination. Each downloadable file is called a **slot** — one base slot (unless the entry is `overridesOnly`) plus one per override.
+
+Slots matter because they are the unit of nearly everything: progress counts, download success/failure, and resume decisions are all per-slot, even though `_assets_contents` stores them together in a single row keyed by the base asset id (overrides nested under `overrides[theme][language]`).
+
+## Download lifecycle
+
+A pack's state lives in the `_asset_packs` data list, one row per pack, with a `download_status` of:
+
+| Status | Meaning |
+| --- | --- |
+| `in_progress` | Actively downloading |
+| `waiting_for_connection` | Offline; parked and will continue automatically when connectivity returns |
+| `completed` | Every slot downloaded and integrated |
+| `error` | Something failed; needs an explicit re-trigger |
+| `cancelled` | The user/template cancelled it |
+
+Execution is deliberately serial: **one pack at a time, one file at a time** within it. Requesting a second, different pack while one is active is refused (see *Concurrency* below). There is no download queue yet — a `TODO` in `downloadAndIntegrateAssetPack` tracks this.
+
+A pack only reaches `completed` when **all** slots succeed. Per-slot failures are counted and returned as `failedCount`; a non-zero count throws, which either parks the pack (offline) or surfaces it as `error` (online). This matters: silently marking a pack complete with missing files leaves the app permanently referencing assets that will never arrive.
+
+## Resume after interruption
+
+Downloads run in the WebView's JS runtime, so killing or backgrounding the app kills the download. Recovery is *restart and skip what's already done*, not byte-range continuation.
+
+**On launch**, any pack still sitting at `in_progress` or `waiting_for_connection` is picked up automatically — process death skips cleanup, so a stale status *is* the interruption signal. `error` and `cancelled` packs never auto-resume: the first waits for an explicit re-trigger (either `asset_pack` action will do, since `ensure_downloaded` only skips packs already `completed`), the second reflects user intent.
+
+**Per slot**, the download is skipped only on *positive evidence* that a previous run finished this exact file. All three must hold:
+
+1. The file exists on disk (`FileManagerService.getSavedFileInfo`), and
+2. its size matches the manifest's `size_kb`, and
+3. the `_assets_contents` entry recorded for that slot carries the manifest's checksum **and** has a `filePath` that differs from the manifest's own value.
+
+Point 3 does the real work. Integrating a base asset writes the whole manifest entry, so the row also picks up every *override's* checksum before those files exist — a checksum alone would vouch for slots that were never downloaded, and only a rewritten `filePath` proves this app saved one. It is compared against the manifest value rather than against the expected local path so that platform path quirks (e.g. iOS `/private/var` vs `/var`) can't silently disable resume.
+
+Anything unverified re-downloads. The cost of a false negative is one wasted file fetch; the cost of a false positive is a corrupt asset that never heals, so the gate is deliberately biased toward re-downloading.
+
+**Not covered:** the on-disk bytes are never hashed. Web Crypto has no MD5, and hashing would only catch external corruption of an already-integrated file — out of scope for interrupt-resume, and better handled by a future `asset_pack: verify`/repair action that owns the MD5 dependency.
+
+### Concurrency
+
+Two different requests for the **same** pack join the same in-flight attempt rather than the second one failing — launch-time resume can easily race a template-triggered download for the same pack.
+
+A request for a **different** pack while one is active is refused, but the two entry points differ in what happens next:
+
+- **Background** (`awaitCompletion: false`, used by resume): the refused packs are retried once the active download settles, so the queue is not dropped.
+- **Awaited** (`awaitCompletion: true`, the default for `ensure_downloaded`): returns `false` immediately. This is intentional — an awaited call blocks the template action queue, and a pack parked in `waiting_for_connection` can wait indefinitely, so it must not be able to wedge the queue behind unrelated work.
+
+## Template API
+
+```yaml
+asset_pack: download | ensure_downloaded | cancel_download | reset
+```
+
+| Action | Behaviour |
+| --- | --- |
+| `download` | Download a single named pack. Always runs, even if the pack is already `completed`, and always blocks the action queue until it finishes |
+| `ensure_downloaded` | Download only packs not already `completed`. Takes `asset_pack` or `asset_pack_list` (array or JSON string), plus `await` (default `true`) to block the action queue or not |
+| `cancel_download` | Abort all active downloads and mark them `cancelled` |
+| `reset` | Clear downloaded contents and pack metadata, back to the pre-download state (testing aid; does not yet delete files from the device) |
+
+Progress and status are exposed to authoring in two places:
+
+- **`asset_pack_download_in_progress`** — a system variable holding a boolean string, for showing or hiding UI while any download is running. Referenced as `@fields._asset_pack_download_in_progress`, or as `@system.asset_pack_download_in_progress` in deployments using `useReactiveTemplates`.
+- **The `_asset_packs` data list** — one row per pack, carrying the full `download_status` plus fine-grained counts (`assets_downloaded_count` of `assets_total_count`, in slots) and the start/completion timestamps. This can be consumed, for example, to drive a progress bar, i.e. via `data_items`.
+
+## Where packs come from
+
+Asset packs are produced at sync time: assets destined for a pack are held out of the bundled app assets and written to `app_data/remote_assets/{packName}/` instead. Two config paths produce one:
+
+- An entry in `google_drive.assets_folders` marked `remote: true` — the folder's `name` becomes the pack name.
+- A Canto source folder with `remote_assets` entries — each declares a pack `name` plus a `condition` selecting which of that folder's files belong to it. Files matching no condition stay as core assets.
+
+Each pack folder gets a `{packName}.json` manifest in `asset_pack` flow format, carrying every entry's `size_kb` and `md5Checksum` — the same metadata the resume gate later relies on. A `contents.json` is written alongside it in the standard core-asset format; only the manifest is fetched at runtime, so the extra file is not currently used but is harmless to include in upload. Pack folders are then uploaded to the configured bucket (currently a manual process), where the app expects:
+
+```
+{folderName}/{packName}/{packName}.json   <- manifest
+{folderName}/{packName}/{relativePath}    <- each asset file
+```
+
+## Known limitations
+
+- **No background continuation.** Downloads stop when the app is backgrounded or killed and resume on next launch. Continuing while backgrounded needs a native downloader plugin and is not implemented.
+- **No download queue.** One pack and one file at a time; large packs are slow and cannot be parallelised.
+- **`reset` leaves files on disk.** It clears metadata and contents rows but does not reclaim storage.
+- **No integrity repair.** There is no way to detect or fix an already-integrated file that was corrupted after the fact.

--- a/src/app/shared/services/remote-asset/remote-asset.actions.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.actions.ts
@@ -1,6 +1,9 @@
 import type { IActionHandler } from "src/app/shared/components/template/services/instance/template-action.registry";
 import type { RemoteAssetService } from "./remote-asset.service";
-import type { IAssetPackEnsureDownloadedParams } from "./remote-asset.types";
+import type {
+  IAssetPackDownloadParams,
+  IAssetPackEnsureDownloadedParams,
+} from "./remote-asset.types";
 import { booleanStringToBoolean } from "../../utils";
 
 export class RemoteAssetActionFactory {
@@ -12,7 +15,9 @@ export class RemoteAssetActionFactory {
       download: async () => {
         if (this.service.remoteAssetsEnabled()) {
           const assetPackName = assetPackArgs[0];
-          await this.service.downloadAssetPackByName(assetPackName);
+          await this.service.downloadAssetPackByName(assetPackName, {
+            debugDownloadDelayMs: resolveDebugDownloadDelayMs(params as IAssetPackDownloadParams),
+          });
         } else {
           console.error(
             "The 'asset_pack: download' action is not available. To enable asset pack functionality, please ensure that the remote asset provider is configured in the deployment config."
@@ -37,6 +42,7 @@ export class RemoteAssetActionFactory {
         }
         await this.service.ensureAssetPacksDownloaded(assetPackList, {
           awaitCompletion: shouldAwaitEnsureDownloaded(params as IAssetPackEnsureDownloadedParams),
+          debugDownloadDelayMs: resolveDebugDownloadDelayMs(params as IAssetPackDownloadParams),
         });
       },
       cancel_download: async () => {
@@ -75,6 +81,23 @@ export function resolveEnsureDownloadedAssetPackList(
     return assetPackList;
   }
   return parseAssetPackNames(params?.asset_pack);
+}
+
+/**
+ * Read the `debug_download_delay_ms` testing param. Authoring values arrive as strings, and a bad
+ * value should never break a real download, so anything unparseable falls back to 0 (no delay).
+ */
+export function resolveDebugDownloadDelayMs(params?: IAssetPackDownloadParams): number {
+  const value = params?.debug_download_delay_ms;
+  if (value === undefined || value === null || value === "") {
+    return 0;
+  }
+  const delayMs = Number(value);
+  if (!Number.isFinite(delayMs) || delayMs < 0) {
+    console.warn("[REMOTE ASSETS] Ignoring invalid debug_download_delay_ms value:", value);
+    return 0;
+  }
+  return delayMs;
 }
 
 export function shouldAwaitEnsureDownloaded(params?: IAssetPackEnsureDownloadedParams) {

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from "@angular/core/testing";
+import { Capacitor } from "@capacitor/core";
 import { RemoteAssetService } from "./remote-asset.service";
 import { provideHttpClientTesting } from "@angular/common/http/testing";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
@@ -267,7 +268,7 @@ describe("RemoteAssetsService", () => {
       service.manifest = assetPackManifest;
       return assetPackManifest;
     });
-    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo({ failedCount: 0 });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
     const upsertRows = mockDynamicDataService.upsert.calls
@@ -407,7 +408,7 @@ describe("RemoteAssetsService", () => {
       service.manifest = assetPackManifest;
       return assetPackManifest;
     });
-    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo({ failedCount: 0 });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
     const upsertRows = mockDynamicDataService.upsert.calls
@@ -436,7 +437,7 @@ describe("RemoteAssetsService", () => {
       service.manifest = assetPackManifest;
       return assetPackManifest;
     });
-    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo({ failedCount: 0 });
 
     await service.downloadAssetPackByName("asset_pack_1");
 
@@ -497,6 +498,7 @@ describe("RemoteAssetsService", () => {
       abortController: new AbortController(),
       downloadStartedAt: new Date().toISOString(),
       removeConnectionStatusListener: () => undefined,
+      completion: Promise.resolve(false),
     });
     const manifestSpy = spyOn<any>(service, "getAssetPackManifest").and.resolveTo(null);
 
@@ -520,7 +522,9 @@ describe("RemoteAssetsService", () => {
     mockProvider.downloadFileAsText.and.resolveTo(null);
     service.provider = mockProvider;
     service.manifest = staleManifest;
-    const integrateSpy = spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    const integrateSpy = spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo({
+      failedCount: 0,
+    });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
 
@@ -596,7 +600,7 @@ describe("RemoteAssetsService", () => {
         });
     });
     spyOn<any>(service, "getAssetPackManifest").and.returnValue(manifestPromise);
-    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo();
+    spyOn<any>(service, "downloadAndIntegrateAssetPack").and.resolveTo({ failedCount: 0 });
     mockDynamicDataService.snapshot.and.resolveTo([]);
     mockSystemVariableService.set.calls.reset();
 
@@ -638,6 +642,246 @@ describe("RemoteAssetsService", () => {
       "ASSET_PACK_DOWNLOAD_IN_PROGRESS",
       "true"
     );
+  });
+
+  /**
+   * Configure a native download so the real download/integrate path runs against spies.
+   * Returns the provider `downloadFile` spy and the mocked file manager for per-test assertions.
+   * Spies are safe: this is invoked synchronously from within each `it`, so Jasmine still
+   * auto-restores them (the no-unsafe-spy rule cannot see through the helper call).
+   */
+  /* eslint-disable jasmine/no-unsafe-spy */
+  function setupNativeDownload(
+    manifestRows: FlowTypes.Data_listRow<IAssetEntry>[],
+    existingContentsRows: Partial<IAssetEntry>[] = []
+  ) {
+    spyOn(Capacitor, "isNativePlatform").and.returnValue(true);
+    spyOn<any>(service, "isOffline").and.returnValue(false);
+    const manifest: FlowTypes.AssetPack = {
+      flow_type: "asset_pack",
+      flow_name: "asset_pack_1",
+      rows: manifestRows,
+    };
+    spyOn<any>(service, "getAssetPackManifest").and.callFake(async () => {
+      service.manifest = manifest;
+      return manifest;
+    });
+    const downloadFileSpy = jasmine.createSpy("downloadFile").and.resolveTo(new Blob(["x"]));
+    service["provider"] = { downloadFile: downloadFileSpy } as any;
+
+    const fileManager = service["fileManagerService"];
+    const saveFileSpy = spyOn(fileManager, "saveFile").and.callFake(async ({ targetPath }) => ({
+      localFilepath: `file:///data/${targetPath}`,
+      src: `capacitor://localhost/_capacitor_file_/data/${targetPath}`,
+    }));
+    const getLocalFilepathSpy = spyOn(fileManager, "getLocalFilepath").and.callFake(
+      async (relativePath: string) => `capacitor://localhost/_capacitor_file_/data/${relativePath}`
+    );
+
+    // Stateful `_asset_packs` row + `_assets_contents` snapshot fed from `existingContentsRows`
+    let assetPackRow: IDBAssetPack | undefined;
+    mockDynamicDataService.upsert.and.callFake(async (_type, flow_name, row: any) => {
+      if (flow_name === "_asset_packs") assetPackRow = { ...row };
+    });
+    mockDynamicDataService.update.and.callFake(async (_type, flow_name, _id, update: any) => {
+      if (flow_name === "_asset_packs" && assetPackRow) {
+        assetPackRow = { ...assetPackRow, ...update };
+      }
+    });
+    mockDynamicDataService.snapshot.and.callFake(async (_type, flow_name) => {
+      if (flow_name === "_asset_packs") return assetPackRow ? ([assetPackRow] as any) : [];
+      if (flow_name === "_assets_contents") return existingContentsRows as any;
+      return [];
+    });
+
+    return {
+      downloadFileSpy,
+      saveFileSpy,
+      getLocalFilepathSpy,
+      getAssetPackRow: () => assetPackRow,
+    };
+  }
+  /* eslint-enable jasmine/no-unsafe-spy */
+
+  it("skips downloading a file already present on disk with matching size and recorded checksum", async () => {
+    const { downloadFileSpy, saveFileSpy, getLocalFilepathSpy, getAssetPackRow } =
+      setupNativeDownload(
+        [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
+        // Previously integrated from this manifest (recorded checksum matches) -> trustworthy on disk
+        [{ id: "images/asset.png", md5Checksum: MOCK_ASSET_ENTRY.md5Checksum, size_kb: 100 }]
+      );
+    // 102400 bytes -> size_kb 100, matching MOCK_ASSET_ENTRY
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
+      exists: true,
+      sizeBytes: 102400,
+    });
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).not.toHaveBeenCalled();
+    expect(saveFileSpy).not.toHaveBeenCalled();
+    expect(getLocalFilepathSpy).toHaveBeenCalledWith("images/asset.png");
+    // Still integrated into the contents list
+    expect(mockDynamicDataService.update).toHaveBeenCalledWith(
+      "asset_pack",
+      "_assets_contents",
+      "images/asset.png",
+      jasmine.objectContaining({
+        filePath: "capacitor://localhost/_capacitor_file_/data/images/asset.png",
+      }),
+      { upsert: true }
+    );
+    expect(getAssetPackRow()).toEqual(
+      jasmine.objectContaining({
+        download_status: "completed",
+        assets_total_count: 1,
+        assets_downloaded_count: 1,
+      })
+    );
+  });
+
+  it("re-downloads a present file whose on-disk size does not match the manifest", async () => {
+    const { downloadFileSpy, saveFileSpy } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
+      // Recorded checksum matches, so only the size mismatch should force a re-download
+      [{ id: "images/asset.png", md5Checksum: MOCK_ASSET_ENTRY.md5Checksum, size_kb: 100 }]
+    );
+    // Wrong size on disk (truncated / stale) -> must not be trusted
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
+      exists: true,
+      sizeBytes: 999,
+    });
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-downloads a present file whose recorded checksum differs from the manifest (stale pack)", async () => {
+    const { downloadFileSpy } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
+      // Previously integrated with a different checksum -> pack content changed
+      [{ id: "images/asset.png", md5Checksum: "OUTDATED-CHECKSUM", size_kb: 100 }]
+    );
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
+      exists: true,
+      sizeBytes: 102400,
+    });
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-downloads a present, correctly-sized file that was never integrated (no recorded checksum)", async () => {
+    // Interrupted after saveFile but before the contents upsert: the file exists with the right size
+    // but there is no recorded checksum to confirm it, so it must not be skipped on trust.
+    const { downloadFileSpy } = setupNativeDownload([
+      clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>,
+    ]);
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
+      exists: true,
+      sizeBytes: 102400,
+    });
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes per slot: skips a present base asset but downloads a missing override", async () => {
+    const { downloadFileSpy, saveFileSpy } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY_WITH_OVERRIDES) as FlowTypes.Data_listRow<IAssetEntry>],
+      // Base was integrated previously (recorded checksum matches); the override never was
+      [
+        {
+          id: "audio/asset_with_overrides.mp3",
+          md5Checksum: MOCK_ASSET_ENTRY_WITH_OVERRIDES.md5Checksum,
+          size_kb: 43.4,
+        },
+      ]
+    );
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.callFake(
+      async (targetPath: string) =>
+        // base present with matching size (44442 bytes -> 43.4kb); override missing
+        targetPath === "audio/asset_with_overrides.mp3"
+          ? { exists: true, sizeBytes: 44442 }
+          : { exists: false }
+    );
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+    expect(downloadFileSpy).toHaveBeenCalledWith(
+      "asset_pack_1/tz_sw/audio/asset_with_overrides.mp3"
+    );
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+    expect(saveFileSpy).toHaveBeenCalledWith(
+      jasmine.objectContaining({ targetPath: "tz_sw/audio/asset_with_overrides.mp3" })
+    );
+  });
+
+  it("marks a pack with a failed file as error rather than completed", async () => {
+    spyOn(console, "error");
+    const { downloadFileSpy, getAssetPackRow } = setupNativeDownload([
+      clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>,
+    ]);
+    // File not on disk, and the network download fails (null blob)
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({ exists: false });
+    downloadFileSpy.and.resolveTo(null);
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeFalse();
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+    expect(getAssetPackRow()).toEqual(jasmine.objectContaining({ download_status: "error" }));
+  });
+
+  it("resumes interrupted packs on init but not cancelled/error/completed ones", async () => {
+    const packs: IDBAssetPack[] = [
+      { id: "p_in_progress", download_status: "in_progress" } as IDBAssetPack,
+      { id: "p_waiting", download_status: "waiting_for_connection" } as IDBAssetPack,
+      { id: "p_error", download_status: "error" } as IDBAssetPack,
+      { id: "p_cancelled", download_status: "cancelled" } as IDBAssetPack,
+      { id: "p_completed", download_status: "completed" } as IDBAssetPack,
+    ];
+    mockDynamicDataService.snapshot.and.resolveTo(packs);
+    const ensureSpy = spyOn(service, "ensureAssetPacksDownloaded").and.resolveTo(true);
+
+    await service["resumeInterruptedAssetPackDownloads"]();
+
+    expect(ensureSpy).toHaveBeenCalledWith(["p_in_progress", "p_waiting"], {
+      awaitCompletion: false,
+    });
+  });
+
+  it("joins an in-flight download for the same pack instead of reporting failure", async () => {
+    const manifestSpy = spyOn<any>(service, "getAssetPackManifest").and.resolveTo(null);
+    service["activeAssetPackDownloads"].set("asset_pack_1", {
+      abortController: new AbortController(),
+      downloadStartedAt: new Date().toISOString(),
+      removeConnectionStatusListener: () => undefined,
+      completion: Promise.resolve(true),
+    });
+
+    const awaited = await service.downloadAssetPackByName("asset_pack_1");
+    expect(awaited).toBeTrue();
+
+    const onDownloadStarted = jasmine.createSpy("onDownloadStarted");
+    const started = await service.downloadAssetPackByName("asset_pack_1", {
+      awaitCompletion: false,
+      onDownloadStarted,
+    });
+    expect(started).toBeTrue();
+    expect(onDownloadStarted).toHaveBeenCalled();
+    // Joined the existing attempt; no new download was kicked off
+    expect(manifestSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -90,6 +90,14 @@ const MOCK_ASSET_ENTRY_OVERRIDES_ONLY: IAssetEntry = {
   overridesOnly: true,
 };
 
+/**
+ * The webview `src` that a file saved to local storage resolves to. A recorded `_assets_contents`
+ * filePath only looks like this once THIS app integrated the slot - manifest entries carry the
+ * pack-relative path instead - so tests use it to distinguish integrated slots from described ones.
+ */
+const localSrc = (targetPath: string) =>
+  `capacitor://localhost/_capacitor_file_/data/${targetPath}`;
+
 const MOCK_ASSET_CONTENTS_PACK_ROWS: FlowTypes.Data_listRow<IAssetEntry>[] = [
   clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>,
   clone(MOCK_ASSET_ENTRY_WITH_OVERRIDES) as FlowTypes.Data_listRow<IAssetEntry>,
@@ -644,6 +652,43 @@ describe("RemoteAssetsService", () => {
     );
   });
 
+  it("retries packs refused by a different in-flight download rather than dropping them", async () => {
+    mockDynamicDataService.snapshot.and.resolveTo([]);
+    // Drive each attempt by hand, mirroring the real cleanup that frees the single download slot
+    const attempted: string[] = [];
+    const settleAttempt: Record<string, () => void> = {};
+    spyOn<any>(service, "runAssetPackDownload").and.callFake(async (assetPackName: string) => {
+      attempted.push(assetPackName);
+      await new Promise<void>((resolve) => (settleAttempt[assetPackName] = resolve));
+      service["activeAssetPackDownloads"].delete(assetPackName);
+      return true;
+    });
+    /** Run every pending continuation; only microtasks are involved, so this settles the chain */
+    const flush = async () => {
+      for (let i = 0; i < 100; i++) await Promise.resolve();
+    };
+
+    await service.downloadAssetPackByName("asset_pack_1", { awaitCompletion: false });
+    const started = await service.ensureAssetPacksDownloaded(["asset_pack_2", "asset_pack_3"], {
+      awaitCompletion: false,
+    });
+
+    // Refused while asset_pack_1 holds the slot, but the queue must survive the refusal
+    expect(started).toBeFalse();
+    expect(attempted).toEqual(["asset_pack_1"]);
+
+    settleAttempt["asset_pack_1"]();
+    await flush();
+    expect(attempted).toEqual(["asset_pack_1", "asset_pack_2"]);
+
+    settleAttempt["asset_pack_2"]();
+    await flush();
+    expect(attempted).toEqual(["asset_pack_1", "asset_pack_2", "asset_pack_3"]);
+
+    settleAttempt["asset_pack_3"]();
+    await flush();
+  });
+
   /**
    * Configure a native download so the real download/integrate path runs against spies.
    * Returns the provider `downloadFile` spy and the mocked file manager for per-test assertions.
@@ -672,11 +717,8 @@ describe("RemoteAssetsService", () => {
     const fileManager = service["fileManagerService"];
     const saveFileSpy = spyOn(fileManager, "saveFile").and.callFake(async ({ targetPath }) => ({
       localFilepath: `file:///data/${targetPath}`,
-      src: `capacitor://localhost/_capacitor_file_/data/${targetPath}`,
+      src: localSrc(targetPath),
     }));
-    const getLocalFilepathSpy = spyOn(fileManager, "getLocalFilepath").and.callFake(
-      async (relativePath: string) => `capacitor://localhost/_capacitor_file_/data/${relativePath}`
-    );
 
     // Stateful `_asset_packs` row + `_assets_contents` snapshot fed from `existingContentsRows`
     let assetPackRow: IDBAssetPack | undefined;
@@ -697,23 +739,30 @@ describe("RemoteAssetsService", () => {
     return {
       downloadFileSpy,
       saveFileSpy,
-      getLocalFilepathSpy,
       getAssetPackRow: () => assetPackRow,
     };
   }
   /* eslint-enable jasmine/no-unsafe-spy */
 
   it("skips downloading a file already present on disk with matching size and recorded checksum", async () => {
-    const { downloadFileSpy, saveFileSpy, getLocalFilepathSpy, getAssetPackRow } =
-      setupNativeDownload(
-        [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
-        // Previously integrated from this manifest (recorded checksum matches) -> trustworthy on disk
-        [{ id: "images/asset.png", md5Checksum: MOCK_ASSET_ENTRY.md5Checksum, size_kb: 100 }]
-      );
+    const { downloadFileSpy, saveFileSpy, getAssetPackRow } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
+      // Previously integrated from this manifest (recorded checksum matches, filePath points at the
+      // local file) -> trustworthy on disk
+      [
+        {
+          id: "images/asset.png",
+          md5Checksum: MOCK_ASSET_ENTRY.md5Checksum,
+          size_kb: 100,
+          filePath: localSrc("images/asset.png"),
+        },
+      ]
+    );
     // 102400 bytes -> size_kb 100, matching MOCK_ASSET_ENTRY
     spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
       exists: true,
       sizeBytes: 102400,
+      src: localSrc("images/asset.png"),
     });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
@@ -721,15 +770,12 @@ describe("RemoteAssetsService", () => {
     expect(success).toBeTrue();
     expect(downloadFileSpy).not.toHaveBeenCalled();
     expect(saveFileSpy).not.toHaveBeenCalled();
-    expect(getLocalFilepathSpy).toHaveBeenCalledWith("images/asset.png");
     // Still integrated into the contents list
     expect(mockDynamicDataService.update).toHaveBeenCalledWith(
       "asset_pack",
       "_assets_contents",
       "images/asset.png",
-      jasmine.objectContaining({
-        filePath: "capacitor://localhost/_capacitor_file_/data/images/asset.png",
-      }),
+      jasmine.objectContaining({ filePath: localSrc("images/asset.png") }),
       { upsert: true }
     );
     expect(getAssetPackRow()).toEqual(
@@ -741,16 +787,52 @@ describe("RemoteAssetsService", () => {
     );
   });
 
+  it("skips a file whose recorded local path does not string-match the stat result", async () => {
+    // The recorded path comes from `saveFile` (convertFileSrc of a write_blob path); resume only has
+    // convertFileSrc of a `Filesystem.stat` uri. Those need not be byte-identical on device (e.g. iOS
+    // /private/var vs /var), and such a divergence must not silently disable resume: any path that is
+    // no longer the manifest's own value is proof this app integrated the slot.
+    const { downloadFileSpy } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
+      [
+        {
+          id: "images/asset.png",
+          md5Checksum: MOCK_ASSET_ENTRY.md5Checksum,
+          size_kb: 100,
+          filePath: "capacitor://localhost/_capacitor_file_/private/var/data/images/asset.png",
+        },
+      ]
+    );
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
+      exists: true,
+      sizeBytes: 102400,
+      src: localSrc("images/asset.png"),
+    });
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    expect(downloadFileSpy).not.toHaveBeenCalled();
+  });
+
   it("re-downloads a present file whose on-disk size does not match the manifest", async () => {
     const { downloadFileSpy, saveFileSpy } = setupNativeDownload(
       [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
-      // Recorded checksum matches, so only the size mismatch should force a re-download
-      [{ id: "images/asset.png", md5Checksum: MOCK_ASSET_ENTRY.md5Checksum, size_kb: 100 }]
+      // Fully integrated previously, so only the size mismatch should force a re-download
+      [
+        {
+          id: "images/asset.png",
+          md5Checksum: MOCK_ASSET_ENTRY.md5Checksum,
+          size_kb: 100,
+          filePath: localSrc("images/asset.png"),
+        },
+      ]
     );
     // Wrong size on disk (truncated / stale) -> must not be trusted
     spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
       exists: true,
       sizeBytes: 999,
+      src: localSrc("images/asset.png"),
     });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
@@ -764,11 +846,19 @@ describe("RemoteAssetsService", () => {
     const { downloadFileSpy } = setupNativeDownload(
       [clone(MOCK_ASSET_ENTRY) as FlowTypes.Data_listRow<IAssetEntry>],
       // Previously integrated with a different checksum -> pack content changed
-      [{ id: "images/asset.png", md5Checksum: "OUTDATED-CHECKSUM", size_kb: 100 }]
+      [
+        {
+          id: "images/asset.png",
+          md5Checksum: "OUTDATED-CHECKSUM",
+          size_kb: 100,
+          filePath: localSrc("images/asset.png"),
+        },
+      ]
     );
     spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
       exists: true,
       sizeBytes: 102400,
+      src: localSrc("images/asset.png"),
     });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
@@ -786,6 +876,7 @@ describe("RemoteAssetsService", () => {
     spyOn(service["fileManagerService"], "getSavedFileInfo").and.resolveTo({
       exists: true,
       sizeBytes: 102400,
+      src: localSrc("images/asset.png"),
     });
 
     const success = await service.downloadAssetPackByName("asset_pack_1");
@@ -794,15 +885,53 @@ describe("RemoteAssetsService", () => {
     expect(downloadFileSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("resumes per slot: skips a present base asset but downloads a missing override", async () => {
+  it("re-downloads an override recorded only by a previous base-asset integration", async () => {
+    // Integrating a base asset upserts the whole manifest entry, so the row also gains every
+    // override's checksum. That must not count as evidence for the override slots themselves: only
+    // the recorded filePath (still the pack-relative manifest path here) proves this app saved one.
     const { downloadFileSpy, saveFileSpy } = setupNativeDownload(
       [clone(MOCK_ASSET_ENTRY_WITH_OVERRIDES) as FlowTypes.Data_listRow<IAssetEntry>],
-      // Base was integrated previously (recorded checksum matches); the override never was
       [
         {
           id: "audio/asset_with_overrides.mp3",
           md5Checksum: MOCK_ASSET_ENTRY_WITH_OVERRIDES.md5Checksum,
           size_kb: 43.4,
+          filePath: localSrc("audio/asset_with_overrides.mp3"),
+          overrides: clone(MOCK_ASSET_ENTRY_WITH_OVERRIDES.overrides),
+        },
+      ]
+    );
+    // Both slots are present on disk at their manifest sizes (44442 -> 43.4kb, 22118 -> 21.6kb),
+    // so only the integration evidence separates them
+    spyOn(service["fileManagerService"], "getSavedFileInfo").and.callFake(
+      async (targetPath: string) => ({
+        exists: true,
+        sizeBytes: targetPath === "audio/asset_with_overrides.mp3" ? 44442 : 22118,
+        src: localSrc(targetPath),
+      })
+    );
+
+    const success = await service.downloadAssetPackByName("asset_pack_1");
+
+    expect(success).toBeTrue();
+    // Base skipped (genuinely integrated), override re-downloaded (only described by the manifest)
+    expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+    expect(downloadFileSpy).toHaveBeenCalledWith(
+      "asset_pack_1/tz_sw/audio/asset_with_overrides.mp3"
+    );
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes per slot: skips a present base asset but downloads a missing override", async () => {
+    const { downloadFileSpy, saveFileSpy } = setupNativeDownload(
+      [clone(MOCK_ASSET_ENTRY_WITH_OVERRIDES) as FlowTypes.Data_listRow<IAssetEntry>],
+      // Base was integrated previously (recorded checksum and filePath match); the override never was
+      [
+        {
+          id: "audio/asset_with_overrides.mp3",
+          md5Checksum: MOCK_ASSET_ENTRY_WITH_OVERRIDES.md5Checksum,
+          size_kb: 43.4,
+          filePath: localSrc("audio/asset_with_overrides.mp3"),
         },
       ]
     );
@@ -810,7 +939,7 @@ describe("RemoteAssetsService", () => {
       async (targetPath: string) =>
         // base present with matching size (44442 bytes -> 43.4kb); override missing
         targetPath === "audio/asset_with_overrides.mp3"
-          ? { exists: true, sizeBytes: 44442 }
+          ? { exists: true, sizeBytes: 44442, src: localSrc(targetPath) }
           : { exists: false }
     );
 

--- a/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.spec.ts
@@ -15,6 +15,7 @@ import type { IRemoteAssetProvider } from "./providers/base.remote-asset";
 import type { IDBAssetPack } from "./remote-asset.types";
 import { NetworkService } from "../network/network.service";
 import {
+  resolveDebugDownloadDelayMs,
   resolveEnsureDownloadedAssetPackList,
   shouldAwaitEnsureDownloaded,
   RemoteAssetActionFactory,
@@ -580,7 +581,10 @@ describe("RemoteAssetsService", () => {
     const success = await service.ensureAssetPacksDownloaded(["asset_pack_1", "asset_pack_2"]);
 
     expect(success).toBeTrue();
-    expect(downloadSpy.calls.allArgs()).toEqual([["asset_pack_1"], ["asset_pack_2"]]);
+    expect(downloadSpy.calls.allArgs()).toEqual([
+      ["asset_pack_1", { debugDownloadDelayMs: 0 }],
+      ["asset_pack_2", { debugDownloadDelayMs: 0 }],
+    ]);
   });
 
   it("downloads asset packs sequentially when using ensureAssetPacksDownloaded", async () => {
@@ -1093,6 +1097,7 @@ describe("RemoteAssetActionFactory ensure_downloaded", () => {
 
     expect(mockService.ensureAssetPacksDownloaded).toHaveBeenCalledWith(["asset_pack_1"], {
       awaitCompletion: false,
+      debugDownloadDelayMs: 0,
     });
   });
 
@@ -1114,6 +1119,70 @@ describe("RemoteAssetActionFactory ensure_downloaded", () => {
 
     expect(mockService.ensureAssetPacksDownloaded).toHaveBeenCalledWith(["asset_pack_1"], {
       awaitCompletion: true,
+      debugDownloadDelayMs: 0,
     });
+  });
+
+  it("passes an authored debug_download_delay_ms to ensureAssetPacksDownloaded", async () => {
+    const mockService = {
+      remoteAssetsEnabled: () => true,
+      ensureAssetPacksDownloaded: jasmine
+        .createSpy("ensureAssetPacksDownloaded")
+        .and.resolveTo(true),
+    } as unknown as RemoteAssetService;
+    const { asset_pack } = new RemoteAssetActionFactory(mockService);
+
+    await asset_pack({
+      trigger: "click",
+      action_id: "asset_pack",
+      args: ["ensure_downloaded"],
+      // Authoring params arrive as strings
+      params: { asset_pack: "asset_pack_1", debug_download_delay_ms: "3000" },
+    });
+
+    expect(mockService.ensureAssetPacksDownloaded).toHaveBeenCalledWith(["asset_pack_1"], {
+      awaitCompletion: true,
+      debugDownloadDelayMs: 3000,
+    });
+  });
+});
+
+describe("RemoteAssetActionFactory download", () => {
+  it("passes an authored debug_download_delay_ms to downloadAssetPackByName", async () => {
+    const mockService = {
+      remoteAssetsEnabled: () => true,
+      downloadAssetPackByName: jasmine.createSpy("downloadAssetPackByName").and.resolveTo(true),
+    } as unknown as RemoteAssetService;
+    const { asset_pack } = new RemoteAssetActionFactory(mockService);
+
+    await asset_pack({
+      trigger: "click",
+      action_id: "asset_pack",
+      args: ["download", "asset_pack_1"],
+      params: { debug_download_delay_ms: 3000 },
+    });
+
+    expect(mockService.downloadAssetPackByName).toHaveBeenCalledWith("asset_pack_1", {
+      debugDownloadDelayMs: 3000,
+    });
+  });
+});
+
+describe("resolveDebugDownloadDelayMs", () => {
+  it("defaults to no delay when the param is absent or empty", () => {
+    expect(resolveDebugDownloadDelayMs()).toBe(0);
+    expect(resolveDebugDownloadDelayMs({})).toBe(0);
+    expect(resolveDebugDownloadDelayMs({ debug_download_delay_ms: "" })).toBe(0);
+  });
+
+  it("parses authored numbers and numeric strings", () => {
+    expect(resolveDebugDownloadDelayMs({ debug_download_delay_ms: 3000 })).toBe(3000);
+    expect(resolveDebugDownloadDelayMs({ debug_download_delay_ms: "3000" })).toBe(3000);
+  });
+
+  it("falls back to no delay for unparseable or negative values", () => {
+    spyOn(console, "warn");
+    expect(resolveDebugDownloadDelayMs({ debug_download_delay_ms: "soon" })).toBe(0);
+    expect(resolveDebugDownloadDelayMs({ debug_download_delay_ms: -1 })).toBe(0);
   });
 });

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -33,12 +33,6 @@ import { RemoteAssetActionFactory } from "./remote-asset.actions";
 import { RemoteAssetMetadataService } from "./remote-asset-metadata.service";
 import { SystemVariableService } from "../system-variable/system-variable.service";
 
-/**
- * Manual testing aid: set to a positive value, e.g. 3000, to slow each asset entry donwload.
- * Keep at 0 outside local testing.
- */
-const REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS = 0;
-
 @Injectable({
   providedIn: "root",
 })
@@ -198,6 +192,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     }
 
     const awaitCompletion = options.awaitCompletion ?? true;
+    const debugDownloadDelayMs = options.debugDownloadDelayMs ?? 0;
     const assetPacks = await this.remoteAssetMetadataService.snapshotAssetPacks();
     const completedPackIds = new Set(
       assetPacks
@@ -221,12 +216,16 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       const [firstPendingPack, ...remainingPendingPacks] = pendingPacks;
       const downloadInBackground = (assetPackNames: string[]) => {
         if (!assetPackNames.length) return;
-        void this.ensureAssetPacksDownloaded(assetPackNames, { awaitCompletion: true }).catch(
-          (error) => console.error("[REMOTE ASSETS] Background ensure_downloaded failed", error)
+        void this.ensureAssetPacksDownloaded(assetPackNames, {
+          awaitCompletion: true,
+          debugDownloadDelayMs,
+        }).catch((error) =>
+          console.error("[REMOTE ASSETS] Background ensure_downloaded failed", error)
         );
       };
       const started = await this.downloadAssetPackByName(firstPendingPack, {
         awaitCompletion: false,
+        debugDownloadDelayMs,
         onDownloadStarted: (completion) => {
           if (!remainingPendingPacks.length) {
             return;
@@ -250,7 +249,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
 
     let allSucceeded = true;
     for (const assetPackName of pendingPacks) {
-      const success = await this.downloadAssetPackByName(assetPackName);
+      const success = await this.downloadAssetPackByName(assetPackName, { debugDownloadDelayMs });
       if (!success) {
         allSucceeded = false;
       }
@@ -299,6 +298,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       abortController,
       downloadStartedAt,
       removeAssetPackConnectionStatusListener,
+      debugDownloadDelayMs: options.debugDownloadDelayMs ?? 0,
     });
     const activeDownload: IActiveAssetPackDownload = {
       abortController,
@@ -327,10 +327,12 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       abortController,
       downloadStartedAt,
       removeAssetPackConnectionStatusListener,
+      debugDownloadDelayMs,
     }: {
       abortController: AbortController;
       downloadStartedAt: string;
       removeAssetPackConnectionStatusListener: () => void;
+      debugDownloadDelayMs: number;
     }
   ) {
     try {
@@ -369,7 +371,8 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
           });
           const { failedCount } = await this.downloadAndIntegrateAssetPack(
             { ...manifest, rows: assetEntries },
-            abortController.signal
+            abortController.signal,
+            debugDownloadDelayMs
           );
           this.throwIfDownloadCancelled(abortController.signal);
           if (failedCount > 0) {
@@ -476,14 +479,17 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     return signal?.aborted || (error instanceof Error && error.name === "AbortError");
   }
 
-  private waitForArtificialDownloadDelay(signal: AbortSignal) {
-    if (REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS <= 0) {
+  /**
+   * Manual testing aid: pause before an asset file so a download can be reliably interrupted.
+   * Driven by the `debug_download_delay_ms` action param, so it is 0 (a no-op) unless an author
+   * asked for it on this specific action call.
+   */
+  private waitForArtificialDownloadDelay(signal: AbortSignal, delayMs: number) {
+    if (delayMs <= 0) {
       return Promise.resolve();
     }
     this.throwIfDownloadCancelled(signal);
-    console.warn(
-      `[REMOTE ASSETS] Artificial download delay enabled: ${REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS}ms`
-    );
+    console.warn(`[REMOTE ASSETS] Artificial download delay enabled: ${delayMs}ms`);
 
     return new Promise<void>((resolve, reject) => {
       const handleAbort = () => {
@@ -493,7 +499,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       const timeout = setTimeout(() => {
         signal.removeEventListener("abort", handleAbort);
         resolve();
-      }, REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS);
+      }, delayMs);
       signal.addEventListener("abort", handleAbort, { once: true });
     });
   }
@@ -512,7 +518,8 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
 
   private async downloadAndIntegrateAssetPack(
     assetPackManifest: FlowTypes.AssetPack,
-    signal: AbortSignal
+    signal: AbortSignal,
+    debugDownloadDelayMs = 0
   ): Promise<{ failedCount: number }> {
     let failedCount = 0;
     try {
@@ -529,7 +536,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
         // TODO: implement queue system for downloads (see template-action service, or use of 3rd party p-queue elsewhere)
         for (const [index, assetEntry] of assetEntries.entries()) {
           this.throwIfDownloadCancelled(signal);
-          await this.waitForArtificialDownloadDelay(signal);
+          await this.waitForArtificialDownloadDelay(signal, debugDownloadDelayMs);
           failedCount += await this.handleAssetDownload(
             assetEntry,
             index,
@@ -545,7 +552,7 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       else {
         for (const [index, assetEntry] of assetEntries.entries()) {
           this.throwIfDownloadCancelled(signal);
-          await this.waitForArtificialDownloadDelay(signal);
+          await this.waitForArtificialDownloadDelay(signal, debugDownloadDelayMs);
           console.log(
             `[REMOTE ASSETS] Processing asset entry ${index + 1} of ${assetEntries.length}.`
           );

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -19,6 +19,7 @@ import { getRemoteAssetProvider } from "./providers";
 import { ASSET_CONTENTS_DATA_LIST } from "./remote-asset.types";
 import type {
   IActiveAssetPackDownload,
+  IAssetPackDownloadStatus,
   IDownloadAssetPackByNameOptions,
   IEnsureAssetPacksDownloadedOptions,
 } from "./remote-asset.types";
@@ -115,7 +116,38 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
         next: (dataRows) => this.assetContentsData.set(dataRows),
         error: (error) => console.error("[Remote Asset] Error in asset contents stream:", error),
       });
+
+      // Resume any downloads interrupted by a previous app session (e.g. app killed mid-download).
+      // Fire-and-forget: this is a blocking core service, so init must not wait on downloads.
+      void this.resumeInterruptedAssetPackDownloads().catch((error) =>
+        console.error("[REMOTE ASSETS] Failed to resume interrupted downloads", error)
+      );
     }
+  }
+
+  /**
+   * Restart downloads for packs left mid-flight by a previous session. A pack killed while
+   * downloading stays `in_progress`/`waiting_for_connection` in `_asset_packs` (process death skips
+   * cleanup), which is our resume signal. `error` packs wait for an explicit re-trigger and
+   * `cancelled` packs reflect user intent, so both are excluded.
+   */
+  private async resumeInterruptedAssetPackDownloads() {
+    const resumableStatuses: IAssetPackDownloadStatus[] = ["in_progress", "waiting_for_connection"];
+    const assetPacks = await this.remoteAssetMetadataService.snapshotAssetPacks();
+    const interruptedPackIds = assetPacks
+      .filter(
+        (assetPack) =>
+          resumableStatuses.includes(assetPack.download_status) &&
+          !this.activeAssetPackDownloads.has(assetPack.id)
+      )
+      .map((assetPack) => assetPack.id);
+    if (!interruptedPackIds.length) return;
+    console.log(
+      `[REMOTE ASSETS] Resuming ${interruptedPackIds.length} interrupted asset pack download(s):`,
+      interruptedPackIds
+    );
+    // Non-blocking: kicks off the first pack and chains the rest sequentially (existing behaviour).
+    await this.ensureAssetPacksDownloaded(interruptedPackIds, { awaitCompletion: false });
   }
 
   /************************************************************************************
@@ -222,8 +254,21 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       console.error("[REMOTE ASSETS] Please provide an asset pack name to download");
       return false;
     }
+    // If this exact pack is already downloading, join the in-flight attempt rather than reporting
+    // failure (auto-resume on launch can race a template-triggered download for the same pack).
+    const existingDownload = this.activeAssetPackDownloads.get(assetPackName);
+    if (existingDownload) {
+      console.log(
+        `[REMOTE ASSETS] Download already active for ${assetPackName}; joining in-flight attempt`
+      );
+      if (!awaitCompletion) {
+        options.onDownloadStarted?.(existingDownload.completion);
+        return true;
+      }
+      return existingDownload.completion;
+    }
     if (this.activeAssetPackDownloads.size > 0) {
-      console.warn("[REMOTE ASSETS] An asset pack download is already active");
+      console.warn("[REMOTE ASSETS] A different asset pack download is already active");
       return false;
     }
 
@@ -234,18 +279,22 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       assetPackName,
       downloadStartedAt
     );
-    this.activeAssetPackDownloads.set(assetPackName, {
-      abortController,
-      downloadStartedAt,
-      removeConnectionStatusListener: removeAssetPackConnectionStatusListener,
-    });
-    this.syncAssetPackDownloadInProgressSystemVariable();
-
+    // runAssetPackDownload runs synchronously up to its first await (no access to the downloads map
+    // in that prefix), so its promise is available to store on the record before we register it -
+    // guaranteeing any joiner always sees a `completion` to await.
     const completion = this.runAssetPackDownload(assetPackName, {
       abortController,
       downloadStartedAt,
       removeAssetPackConnectionStatusListener,
     });
+    const activeDownload: IActiveAssetPackDownload = {
+      abortController,
+      downloadStartedAt,
+      removeConnectionStatusListener: removeAssetPackConnectionStatusListener,
+      completion,
+    };
+    this.activeAssetPackDownloads.set(assetPackName, activeDownload);
+    this.syncAssetPackDownloadInProgressSystemVariable();
 
     if (!awaitCompletion) {
       options.onDownloadStarted?.(completion);
@@ -305,11 +354,19 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
             assetsTotalCount: total,
             assetsDownloadedCount: 0,
           });
-          await this.downloadAndIntegrateAssetPack(
+          const { failedCount } = await this.downloadAndIntegrateAssetPack(
             { ...manifest, rows: assetEntries },
             abortController.signal
           );
           this.throwIfDownloadCancelled(abortController.signal);
+          if (failedCount > 0) {
+            // Do not mark a pack completed while files are missing. Throwing hands control to the
+            // catch below: offline -> park and retry (cheap now that done files are skipped),
+            // online -> surface as `error` so the pack stays resumable via explicit re-trigger.
+            throw new Error(
+              `[REMOTE ASSETS] ${failedCount} file(s) failed to download for asset pack: ${assetPackName}`
+            );
+          }
           removeAssetPackConnectionStatusListener();
           await this.remoteAssetMetadataService.setDownloadStatus(assetPackName, "completed", {
             downloadStartedAt,
@@ -443,7 +500,8 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   private async downloadAndIntegrateAssetPack(
     assetPackManifest: FlowTypes.AssetPack,
     signal: AbortSignal
-  ) {
+  ): Promise<{ failedCount: number }> {
+    let failedCount = 0;
     try {
       this.currentAssetPackName = assetPackManifest.flow_name;
       const assetEntries = (assetPackManifest.rows || []) as IAssetEntry[];
@@ -451,11 +509,21 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       // If running on native device, download assets and populate to filesystem, adding local
       // filesystem path to asset entry in contents list for consumption by template asset service
       if (Capacitor.isNativePlatform()) {
+        // Snapshot the already-integrated contents once up front so per-file resume checks can
+        // detect stale files (a pack whose content changed) without re-reading per file. Reading
+        // it before any writes in this attempt keeps recorded checksums pointing at the old pack.
+        const existingContents = await this.snapshotAssetContents();
         // TODO: implement queue system for downloads (see template-action service, or use of 3rd party p-queue elsewhere)
         for (const [index, assetEntry] of assetEntries.entries()) {
           this.throwIfDownloadCancelled(signal);
           await this.waitForArtificialDownloadDelay(signal);
-          await this.handleAssetDownload(assetEntry, index, assetEntries.length, signal);
+          failedCount += await this.handleAssetDownload(
+            assetEntry,
+            index,
+            assetEntries.length,
+            signal,
+            existingContents
+          );
         }
       }
 
@@ -474,6 +542,16 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     } finally {
       this.currentAssetPackName = null;
     }
+    return { failedCount };
+  }
+
+  /** Snapshot the current `_assets_contents` rows as a hashmap keyed by id (asset relative path). */
+  private async snapshotAssetContents(): Promise<Record<string, IAssetEntry>> {
+    const rows = await this.dynamicDataService.snapshot<IAssetEntry & { id: string }>(
+      "asset_pack",
+      ASSET_CONTENTS_DATA_LIST
+    );
+    return arrayToHashmap(rows, "id") as Record<string, IAssetEntry>;
   }
 
   /**
@@ -506,27 +584,34 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   /**
    * Native platforms only:
    * Download an asset from an asset pack, including any overrides,
-   * and update the contents list so that the filepath is the path to the file in local storage
+   * and update the contents list so that the filepath is the path to the file in local storage.
+   * @returns the number of file slots (base and/or overrides) that failed to download.
    */
   private async handleAssetDownload(
     assetEntry: IAssetEntry,
     fileIndex: number,
-    totalFiles?: number,
-    signal?: AbortSignal
-  ) {
+    totalFiles: number | undefined,
+    signal: AbortSignal | undefined,
+    existingContents: Record<string, IAssetEntry>
+  ): Promise<number> {
+    let failedCount = 0;
     // Download the top level asset, unless overridesOnly is specified
     if (!assetEntry.overridesOnly) {
       try {
-        await this.downloadAssetAndUpdateContentsList(
+        const succeeded = await this.downloadAssetAndUpdateContentsList(
           assetEntry.id,
           assetEntry,
           fileIndex,
           totalFiles,
-          signal
+          signal,
+          undefined,
+          existingContents
         );
+        if (!succeeded) failedCount += 1;
       } catch (error) {
         if (this.isDownloadCancelled(error, signal)) throw error;
         console.error(error);
+        failedCount += 1;
       }
     }
 
@@ -536,21 +621,25 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
         for (const [languageCode, assetContentsEntry] of Object.entries(languageOverrides)) {
           const overrideProps = { themeName, languageCode };
           try {
-            await this.downloadAssetAndUpdateContentsList(
+            const succeeded = await this.downloadAssetAndUpdateContentsList(
               assetContentsEntry.filePath,
               assetEntry,
               fileIndex,
               totalFiles,
               signal,
-              overrideProps
+              overrideProps,
+              existingContents
             );
+            if (!succeeded) failedCount += 1;
           } catch (error) {
             if (this.isDownloadCancelled(error, signal)) throw error;
             console.error(error);
+            failedCount += 1;
           }
         }
       }
     }
+    return failedCount;
   }
 
   /**
@@ -588,16 +677,48 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
 
   /**
    * Native platforms only:
-   * Download a single asset from an asset pack, save to local native storage and update the assets contents list
+   * Download a single asset from an asset pack, save to local native storage and update the assets
+   * contents list. If a valid copy is already on disk (resume after interruption) the network fetch
+   * is skipped and the existing file is (re-)integrated instead.
+   * @returns true if the slot ended up present and integrated (downloaded or skipped), false on failure.
    * */
   private async downloadAssetAndUpdateContentsList(
     relativePath: string,
     assetEntry: IAssetEntry,
     fileIndex: number,
-    totalFiles?: number,
-    signal?: AbortSignal,
-    overrideProps?: IAssetOverrideProps
-  ) {
+    totalFiles: number | undefined,
+    signal: AbortSignal | undefined,
+    overrideProps: IAssetOverrideProps | undefined,
+    existingContents: Record<string, IAssetEntry>
+  ): Promise<boolean> {
+    const { targetPath, slotChecksum, slotSizeKb } = this.resolveAssetSlot(
+      assetEntry,
+      overrideProps
+    );
+
+    // Resume: if a valid copy already exists on disk, skip the network fetch and re-integrate it.
+    if (signal) this.throwIfDownloadCancelled(signal);
+    if (
+      await this.isAssetSlotAlreadyDownloaded(
+        targetPath,
+        slotChecksum,
+        slotSizeKb,
+        existingContents,
+        assetEntry.id,
+        overrideProps
+      )
+    ) {
+      console.log(
+        `[REMOTE ASSETS] Skipping already-downloaded file ${fileIndex + 1} of ${totalFiles || "?"}: ${targetPath}`
+      );
+      const src = await this.fileManagerService.getLocalFilepath(targetPath);
+      if (signal) this.throwIfDownloadCancelled(signal);
+      await this.updateAssetContents(assetEntry, src, overrideProps);
+      if (signal) this.throwIfDownloadCancelled(signal);
+      await this.incrementDownloadProgress();
+      return true;
+    }
+
     console.log(`[REMOTE ASSETS] Downloading file ${fileIndex + 1} of ${totalFiles || "?"}`);
 
     try {
@@ -607,28 +728,113 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       if (signal) this.throwIfDownloadCancelled(signal);
 
       if (blob) {
-        let targetPath = assetEntry.id;
-
-        // For overrides, use the nested override filepath as the path to save the file in local storage
-        if (overrideProps) {
-          const { themeName, languageCode } = overrideProps;
-          const overrideAssetEntry = assetEntry.overrides[themeName][languageCode];
-          targetPath = overrideAssetEntry.filePath;
-        }
-
         const { src } = await this.fileManagerService.saveFile({ data: blob, targetPath });
         if (signal) this.throwIfDownloadCancelled(signal);
         await this.updateAssetContents(assetEntry, src, overrideProps);
         if (signal) this.throwIfDownloadCancelled(signal);
         console.log(`[REMOTE ASSETS] File ${fileIndex + 1} of ${totalFiles} downloaded to cache`);
         await this.incrementDownloadProgress();
+        return true;
       } else {
         console.error(`[REMOTE ASSETS] Failed to download ${relativePath}`);
+        return false;
       }
     } catch (error) {
       if (this.isDownloadCancelled(error, signal)) throw error;
       console.error(`[REMOTE ASSETS] Error downloading ${relativePath}:`, error);
+      return false;
     }
+  }
+
+  /**
+   * Resolve the local storage target path and the manifest integrity metadata (checksum/size) for a
+   * single asset slot - either the base entry or a specific theme/language override.
+   */
+  private resolveAssetSlot(assetEntry: IAssetEntry, overrideProps?: IAssetOverrideProps) {
+    if (overrideProps) {
+      const { themeName, languageCode } = overrideProps;
+      const overrideAssetEntry = assetEntry.overrides[themeName][languageCode];
+      return {
+        targetPath: overrideAssetEntry.filePath,
+        slotChecksum: overrideAssetEntry.md5Checksum,
+        slotSizeKb: overrideAssetEntry.size_kb,
+      };
+    }
+    return {
+      targetPath: assetEntry.id,
+      slotChecksum: assetEntry.md5Checksum,
+      slotSizeKb: assetEntry.size_kb,
+    };
+  }
+
+  /**
+   * Native platforms only:
+   * Decide whether an asset slot already has a trustworthy file on disk and so can skip its download.
+   * Only skips on POSITIVE evidence: the file exists, its size matches the manifest, and a prior run
+   * integrated this exact file from the current manifest (recorded `_assets_contents` checksum equals
+   * the manifest checksum). Anything unverified re-downloads:
+   *  - no recorded checksum -> saved but never integrated (interrupted mid-write); bytes unconfirmed
+   *  - recorded checksum differs -> pack content changed and the on-disk file is stale
+   *  - size unverifiable or mismatched -> truncated / wrong file
+   * NB verifying on-disk bytes directly (MD5) is intentionally deferred to a future `asset_pack:
+   * verify` action; it needs an MD5 dependency and would only add value for external corruption of an
+   * already-integrated file, which is out of scope for interrupt-resume.
+   */
+  private async isAssetSlotAlreadyDownloaded(
+    targetPath: string,
+    slotChecksum: string | undefined,
+    slotSizeKb: number | undefined,
+    existingContents: Record<string, IAssetEntry>,
+    assetEntryId: string,
+    overrideProps: IAssetOverrideProps | undefined
+  ): Promise<boolean> {
+    const info = await this.fileManagerService.getSavedFileInfo(targetPath);
+    if (!info.exists) return false;
+
+    // Size gate: require a verifiable, matching size (cheap rejection of truncated/wrong files).
+    if (slotSizeKb === undefined || info.sizeBytes === undefined) {
+      console.warn(`[REMOTE ASSETS] Cannot verify size for ${targetPath}; re-downloading`);
+      return false;
+    }
+    const localSizeKb = Math.round(info.sizeBytes / 102.4) / 10;
+    if (localSizeKb !== slotSizeKb) {
+      console.log(
+        `[REMOTE ASSETS] On-disk size ${localSizeKb}kb != manifest ${slotSizeKb}kb for ${targetPath}; re-downloading`
+      );
+      return false;
+    }
+
+    // Integrity gate: only skip when a prior run integrated this exact file from the current manifest.
+    const recordedChecksum = this.getRecordedSlotChecksum(
+      existingContents,
+      assetEntryId,
+      overrideProps
+    );
+    if (!recordedChecksum || !slotChecksum || recordedChecksum !== slotChecksum) {
+      console.log(`[REMOTE ASSETS] No confirming checksum for ${targetPath}; re-downloading`);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Read the checksum recorded in a snapshot of `_assets_contents` for a given slot, or undefined if
+   * the slot has not been integrated yet. Rows are keyed by the base asset id; override checksums
+   * live nested under `overrides[theme][language]`.
+   */
+  private getRecordedSlotChecksum(
+    existingContents: Record<string, IAssetEntry>,
+    assetEntryId: string,
+    overrideProps?: IAssetOverrideProps
+  ): string | undefined {
+    const row = existingContents[assetEntryId];
+    if (!row) return undefined;
+    if (overrideProps) {
+      const { themeName, languageCode } = overrideProps;
+      return row.overrides?.[themeName]?.[languageCode]?.md5Checksum;
+    }
+    return row.md5Checksum;
   }
 
   /**

--- a/src/app/shared/services/remote-asset/remote-asset.service.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.service.ts
@@ -5,12 +5,17 @@ import { TemplateActionRegistry } from "../../components/template/services/insta
 import { FlowTypes } from "../../model";
 import { AppConfigService } from "../app-config/app-config.service";
 import { FileManagerService } from "../file-manager/file-manager.service";
+import type { ISavedFileInfo } from "../file-manager/file-manager.service";
 import { IAssetContents } from "src/app/data";
 import { BehaviorSubject, Subscription } from "rxjs";
 import { AppDataService } from "src/app/shared/services/data/app-data.service";
 import { TemplateAssetService } from "../../components/template/services/template-asset.service";
 import { AsyncServiceBase } from "../asyncService.base";
-import type { IAssetEntry, IAssetOverrideProps } from "packages/data-models";
+import type {
+  IAssetContentsEntryMinimal,
+  IAssetEntry,
+  IAssetOverrideProps,
+} from "packages/data-models";
 import { DynamicDataService } from "../dynamic-data/dynamic-data.service";
 import { arrayToHashmap, convertBlobToBase64, deepMergeObjects } from "../../utils";
 import { DeploymentService } from "../deployment/deployment.service";
@@ -214,6 +219,12 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
 
     if (!awaitCompletion) {
       const [firstPendingPack, ...remainingPendingPacks] = pendingPacks;
+      const downloadInBackground = (assetPackNames: string[]) => {
+        if (!assetPackNames.length) return;
+        void this.ensureAssetPacksDownloaded(assetPackNames, { awaitCompletion: true }).catch(
+          (error) => console.error("[REMOTE ASSETS] Background ensure_downloaded failed", error)
+        );
+      };
       const started = await this.downloadAssetPackByName(firstPendingPack, {
         awaitCompletion: false,
         onDownloadStarted: (completion) => {
@@ -221,15 +232,17 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
             return;
           }
           void completion
-            .finally(() =>
-              this.ensureAssetPacksDownloaded(remainingPendingPacks, { awaitCompletion: true })
-            )
+            .finally(() => downloadInBackground(remainingPendingPacks))
             .catch((error) =>
               console.error("[REMOTE ASSETS] Background ensure_downloaded failed", error)
             );
         },
       });
       if (!started) {
+        // The only way to be refused here is a *different* pack already downloading. Retry the whole
+        // list once that settles rather than silently dropping every pack the caller asked for
+        // (e.g. launch-time resume racing a template-triggered download).
+        void this.waitForActiveAssetPackDownloads().then(() => downloadInBackground(pendingPacks));
         return false;
       }
       return true;
@@ -691,29 +704,30 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     overrideProps: IAssetOverrideProps | undefined,
     existingContents: Record<string, IAssetEntry>
   ): Promise<boolean> {
-    const { targetPath, slotChecksum, slotSizeKb } = this.resolveAssetSlot(
+    const { targetPath, slotChecksum, slotSizeKb, manifestFilePath } = this.resolveAssetSlot(
       assetEntry,
       overrideProps
     );
 
     // Resume: if a valid copy already exists on disk, skip the network fetch and re-integrate it.
     if (signal) this.throwIfDownloadCancelled(signal);
+    const savedFileInfo = await this.fileManagerService.getSavedFileInfo(targetPath);
+    if (signal) this.throwIfDownloadCancelled(signal);
     if (
-      await this.isAssetSlotAlreadyDownloaded(
+      this.isSavedAssetSlotTrustworthy(savedFileInfo, {
         targetPath,
         slotChecksum,
         slotSizeKb,
+        manifestFilePath,
         existingContents,
-        assetEntry.id,
-        overrideProps
-      )
+        assetEntryId: assetEntry.id,
+        overrideProps,
+      })
     ) {
       console.log(
         `[REMOTE ASSETS] Skipping already-downloaded file ${fileIndex + 1} of ${totalFiles || "?"}: ${targetPath}`
       );
-      const src = await this.fileManagerService.getLocalFilepath(targetPath);
-      if (signal) this.throwIfDownloadCancelled(signal);
-      await this.updateAssetContents(assetEntry, src, overrideProps);
+      await this.updateAssetContents(assetEntry, savedFileInfo.src, overrideProps);
       if (signal) this.throwIfDownloadCancelled(signal);
       await this.incrementDownloadProgress();
       return true;
@@ -749,6 +763,9 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   /**
    * Resolve the local storage target path and the manifest integrity metadata (checksum/size) for a
    * single asset slot - either the base entry or a specific theme/language override.
+   * `manifestFilePath` is the slot's filePath *as the manifest ships it* (undefined for most base
+   * entries, the pack-relative path for overrides), i.e. the value a recorded entry still holds if
+   * integration has not overwritten it with a local path.
    */
   private resolveAssetSlot(assetEntry: IAssetEntry, overrideProps?: IAssetOverrideProps) {
     if (overrideProps) {
@@ -758,12 +775,14 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
         targetPath: overrideAssetEntry.filePath,
         slotChecksum: overrideAssetEntry.md5Checksum,
         slotSizeKb: overrideAssetEntry.size_kb,
+        manifestFilePath: overrideAssetEntry.filePath,
       };
     }
     return {
       targetPath: assetEntry.id,
       slotChecksum: assetEntry.md5Checksum,
       slotSizeKb: assetEntry.size_kb,
+      manifestFilePath: assetEntry.filePath,
     };
   }
 
@@ -771,32 +790,53 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
    * Native platforms only:
    * Decide whether an asset slot already has a trustworthy file on disk and so can skip its download.
    * Only skips on POSITIVE evidence: the file exists, its size matches the manifest, and a prior run
-   * integrated this exact file from the current manifest (recorded `_assets_contents` checksum equals
-   * the manifest checksum). Anything unverified re-downloads:
-   *  - no recorded checksum -> saved but never integrated (interrupted mid-write); bytes unconfirmed
-   *  - recorded checksum differs -> pack content changed and the on-disk file is stale
+   * integrated THIS slot from the current manifest - i.e. the recorded `_assets_contents` entry both
+   * carries the manifest checksum and has had its `filePath` rewritten away from the manifest value.
+   * Anything unverified re-downloads:
    *  - size unverifiable or mismatched -> truncated / wrong file
+   *  - no/differing recorded checksum -> never integrated, or pack content changed (file is stale)
+   *  - filePath still the manifest's -> saved but never integrated (interrupted mid-write)
+   * The filePath check is what makes the evidence per-slot: integrating a base asset writes the whole
+   * manifest entry, so it also copies in every override's checksum, and only a rewritten `filePath`
+   * distinguishes a slot this app actually saved from one merely described by the manifest. It is
+   * deliberately a "differs from the manifest" test rather than "equals the local path": the recorded
+   * value comes from `saveFile` (convertFileSrc of a write_blob path) while resume only has
+   * `convertFileSrc` of a `Filesystem.stat` uri, and those need not be byte-identical on device
+   * (e.g. iOS /private/var vs /var). Comparing against our own manifest keeps the gate independent of
+   * how any platform spells a local path - a mismatch there would silently disable resume entirely.
    * NB verifying on-disk bytes directly (MD5) is intentionally deferred to a future `asset_pack:
    * verify` action; it needs an MD5 dependency and would only add value for external corruption of an
    * already-integrated file, which is out of scope for interrupt-resume.
    */
-  private async isAssetSlotAlreadyDownloaded(
-    targetPath: string,
-    slotChecksum: string | undefined,
-    slotSizeKb: number | undefined,
-    existingContents: Record<string, IAssetEntry>,
-    assetEntryId: string,
-    overrideProps: IAssetOverrideProps | undefined
-  ): Promise<boolean> {
-    const info = await this.fileManagerService.getSavedFileInfo(targetPath);
-    if (!info.exists) return false;
+  private isSavedAssetSlotTrustworthy(
+    savedFileInfo: ISavedFileInfo,
+    slot: {
+      targetPath: string;
+      slotChecksum: string | undefined;
+      slotSizeKb: number | undefined;
+      manifestFilePath: string | undefined;
+      existingContents: Record<string, IAssetEntry>;
+      assetEntryId: string;
+      overrideProps: IAssetOverrideProps | undefined;
+    }
+  ): savedFileInfo is ISavedFileInfo & { src: string } {
+    const {
+      targetPath,
+      slotChecksum,
+      slotSizeKb,
+      manifestFilePath,
+      existingContents,
+      assetEntryId,
+      overrideProps,
+    } = slot;
+    if (!savedFileInfo.exists || !savedFileInfo.src) return false;
 
     // Size gate: require a verifiable, matching size (cheap rejection of truncated/wrong files).
-    if (slotSizeKb === undefined || info.sizeBytes === undefined) {
+    if (slotSizeKb === undefined || savedFileInfo.sizeBytes === undefined) {
       console.warn(`[REMOTE ASSETS] Cannot verify size for ${targetPath}; re-downloading`);
       return false;
     }
-    const localSizeKb = Math.round(info.sizeBytes / 102.4) / 10;
+    const localSizeKb = Math.round(savedFileInfo.sizeBytes / 102.4) / 10;
     if (localSizeKb !== slotSizeKb) {
       console.log(
         `[REMOTE ASSETS] On-disk size ${localSizeKb}kb != manifest ${slotSizeKb}kb for ${targetPath}; re-downloading`
@@ -805,13 +845,13 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
     }
 
     // Integrity gate: only skip when a prior run integrated this exact file from the current manifest.
-    const recordedChecksum = this.getRecordedSlotChecksum(
-      existingContents,
-      assetEntryId,
-      overrideProps
-    );
-    if (!recordedChecksum || !slotChecksum || recordedChecksum !== slotChecksum) {
+    const recordedSlot = this.getRecordedSlot(existingContents, assetEntryId, overrideProps);
+    if (!recordedSlot?.md5Checksum || !slotChecksum || recordedSlot.md5Checksum !== slotChecksum) {
       console.log(`[REMOTE ASSETS] No confirming checksum for ${targetPath}; re-downloading`);
+      return false;
+    }
+    if (!recordedSlot.filePath || recordedSlot.filePath === manifestFilePath) {
+      console.log(`[REMOTE ASSETS] ${targetPath} was saved but never integrated; re-downloading`);
       return false;
     }
 
@@ -819,22 +859,22 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
   }
 
   /**
-   * Read the checksum recorded in a snapshot of `_assets_contents` for a given slot, or undefined if
-   * the slot has not been integrated yet. Rows are keyed by the base asset id; override checksums
-   * live nested under `overrides[theme][language]`.
+   * Read the entry recorded in a snapshot of `_assets_contents` for a given slot, or undefined if the
+   * asset has no row yet. Rows are keyed by the base asset id; override entries live nested under
+   * `overrides[theme][language]`.
    */
-  private getRecordedSlotChecksum(
+  private getRecordedSlot(
     existingContents: Record<string, IAssetEntry>,
     assetEntryId: string,
     overrideProps?: IAssetOverrideProps
-  ): string | undefined {
+  ): IAssetContentsEntryMinimal | undefined {
     const row = existingContents[assetEntryId];
     if (!row) return undefined;
     if (overrideProps) {
       const { themeName, languageCode } = overrideProps;
-      return row.overrides?.[themeName]?.[languageCode]?.md5Checksum;
+      return row.overrides?.[themeName]?.[languageCode];
     }
-    return row.md5Checksum;
+    return row;
   }
 
   /**
@@ -982,6 +1022,16 @@ export class RemoteAssetService extends AsyncServiceBase implements OnDestroy {
       this.dynamicDataService.resetFlow("asset_pack", ASSET_CONTENTS_DATA_LIST),
       this.remoteAssetMetadataService.resetAssetPacks(),
     ]);
+  }
+
+  /**
+   * Resolve once every download attempt active at the time of the call has settled. Rejections are
+   * absorbed: callers wait for the slot to free up, they do not inherit the other pack's outcome.
+   */
+  private async waitForActiveAssetPackDownloads() {
+    const activeDownloads = [...this.activeAssetPackDownloads.values()];
+    if (!activeDownloads.length) return;
+    await Promise.allSettled(activeDownloads.map(({ completion }) => completion));
   }
 
   public async cancelActiveAssetPackDownloads() {

--- a/src/app/shared/services/remote-asset/remote-asset.types.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.types.ts
@@ -46,6 +46,11 @@ export interface IActiveAssetPackDownload {
   abortController: AbortController;
   downloadStartedAt: string;
   removeConnectionStatusListener: () => void;
+  /**
+   * Resolves with the download result. Set when the record is created so a concurrent request for
+   * the same pack can always join this in-flight attempt by awaiting it.
+   */
+  completion: Promise<boolean>;
 }
 
 export interface IAssetPackEnsureDownloadedParams {

--- a/src/app/shared/services/remote-asset/remote-asset.types.ts
+++ b/src/app/shared/services/remote-asset/remote-asset.types.ts
@@ -53,7 +53,18 @@ export interface IActiveAssetPackDownload {
   completion: Promise<boolean>;
 }
 
-export interface IAssetPackEnsureDownloadedParams {
+/** Params accepted by every `asset_pack` action that starts a download */
+export interface IAssetPackDownloadParams {
+  /**
+   * Manual testing aid: artificially pause for this many ms before each asset file, to open a
+   * reliable window for interrupting a download (e.g. force-quitting the app mid-pack).
+   * Omit outside local testing - the delay applies to skipped files too, so it also masks the
+   * speed-up that resume is supposed to give.
+   */
+  debug_download_delay_ms?: number | string;
+}
+
+export interface IAssetPackEnsureDownloadedParams extends IAssetPackDownloadParams {
   /** Single asset pack name */
   asset_pack?: string;
   /** One or more asset pack names, as an array or JSON string array */
@@ -62,14 +73,17 @@ export interface IAssetPackEnsureDownloadedParams {
   await?: boolean | string;
 }
 
-export interface IEnsureAssetPacksDownloadedOptions {
+/** Options shared by the service methods that start a download */
+interface IAssetPackDownloadOptions {
   /** When false, return once a download is registered without waiting for completion. Defaults to true. */
   awaitCompletion?: boolean;
+  /** See `IAssetPackDownloadParams.debug_download_delay_ms`. Defaults to 0 (no delay). */
+  debugDownloadDelayMs?: number;
 }
 
-export interface IDownloadAssetPackByNameOptions {
-  /** When false, return once a download is registered without waiting for completion. Defaults to true. */
-  awaitCompletion?: boolean;
+export type IEnsureAssetPacksDownloadedOptions = IAssetPackDownloadOptions;
+
+export interface IDownloadAssetPackByNameOptions extends IAssetPackDownloadOptions {
   /** Called synchronously once a background download is registered. Only used when awaitCompletion is false. */
   onDownloadStarted?: (completion: Promise<boolean>) => void;
 }


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

### Background

Remote asset packs download file-by-file in the WebView JS runtime, so if the app is killed or backgrounded mid-download the loop dies. Previously nothing resumed on next launch, and re-triggering a pack re-downloaded **every** file from scratch.

This is **Phase 1** of hardening asset-pack downloads: making an interrupted download resumable and self-restarting. Surviving a user force-quit is explicitly *not* a goal — a killed download is treated as "interrupted → resume on next open." (Phase 2, continuing downloads while the app is backgrounded via native transfers, is a separate follow-up — see below.)

### What changed

- **Skip already-downloaded files on resume** — before fetching each file (base asset and each theme/language override), the network download is skipped when there is *positive* evidence the local copy is good: the file exists on disk, its size matches the manifest, **and** a prior run integrated this exact slot (the `_assets_contents` entry recorded for it carries the manifest checksum **and** has had its `filePath` rewritten away from the manifest value). Anything unverified — including a file saved but never integrated (interrupted mid-write) — is re-downloaded.
- **Auto-resume on launch** — on startup, packs left `in_progress` / `waiting_for_connection` (process death skips cleanup) are automatically restarted without blocking app init. `error` packs wait for an explicit re-trigger; `cancelled` packs are left alone.
- **Correct completion accounting (bug fix)** — `downloadAndIntegrateAssetPack` now reports how many files failed, and a pack only reaches `completed` when every file is present. Previously per-file download errors were swallowed and the pack was still marked `completed` with missing files.
- **Concurrent same-pack requests join** — a download request for a pack that is already downloading now joins the in-flight attempt instead of returning failure (auto-resume can race a template-triggered `ensure_downloaded` for the same pack).
- **Queued packs survive a refusal** — when a background `ensure_downloaded` is refused because a *different* pack holds the single download slot, the remaining packs are retried once that download settles rather than being silently dropped. The awaited path still fails fast by design, so a pack parked in `waiting_for_connection` can't wedge the template action queue behind unrelated work.
- **`debug_download_delay_ms` action param** — `download` and `ensure_downloaded` accept an optional per-call pause before each asset file, e.g. `asset_pack | download: my_asset_pack | debug_download_delay_ms: 3000`, to open a reliable window for interrupting a download. This replaces the `REMOTE_ASSET_DOWNLOAD_DEBUG_DELAY_MS` module constant, which had to be edited in source and reset before merge — there is no longer a committed debug value to forget about.
- **New `FileManagerService.getSavedFileInfo`** — reports a previously saved file's existence/size/`src` using the same path rule as `saveFile`.
- **Feature README** — `src/app/shared/services/remote-asset/README.md` documents the feature end to end: the `_assets_contents` model, slots, download lifecycle, the resume gate, concurrency, the template API, and where packs come from at sync time.

### Notable behaviour / decisions

- The resume unit is the file "slot": a row can be partially done (base saved, overrides not), so the base and each override are checked independently.
- The `filePath` half of the resume gate is load-bearing. Integrating a base asset upserts the whole manifest entry, so the row also gains every *override's* checksum before those files exist — the checksum alone would wrongly vouch for overrides that were never downloaded. It is deliberately compared against the manifest's own value rather than against the expected local path: recorded paths come from `saveFile` while resume only has a `Filesystem.stat` uri, and a platform path-spelling difference (e.g. iOS `/private/var` vs `/var`) would otherwise silently disable resume and re-download every pack.
- On-disk content hashing (MD5) is intentionally **not** done here. `saveFile` resolves only after a complete write, so size + recorded-checksum give positive proof for integrated files at negligible cost. True byte verification (e.g. external corruption of an already-integrated file) is deferred to a future `asset_pack: verify`/repair action, which is where the MD5 dependency belongs.
- On resume, `_asset_packs.assets_downloaded_count` resets to 0 and climbs again (skipped files increment quickly) — this is expected; there is no separate pre-scan pass.

## Testing

I have created a debug sheet here for testing: [debug_remote_assets](https://docs.google.com/spreadsheets/d/1QPtxcCZEgUpXA26niqoXD0OQni2WAa3kgTPExonkCKU/edit?gid=1422144003#gid=1422144003)

**What to watch**: the **`_asset_packs`** table (`download_status`, `assets_downloaded_count` / `assets_total_count`, `download_started_at`, `download_completed_at`). You can also inspect the **`_assets_contents`** table on the `/user` page (each downloaded file's row gains a local `filePath` once integrated).

| # | Action | Expected in the tables |
|---|--------|------------------------|
| 1 | **Happy path** — trigger a download, let it finish | `_asset_packs`: `in_progress` → `completed`, `assets_downloaded_count` reaches `assets_total_count`, `download_completed_at` set. `_assets_contents`: the pack's file rows now have local `filePath`s |
| 2 | **Auto-resume after force-kill** — force-quit while `in_progress`, relaunch, do **not** re-trigger | `_asset_packs`: the row (left `in_progress`) gets a **new `download_started_at`** on its own and proceeds `in_progress` → `completed`, `downloaded == total` |
| 3 | **Prior work isn't lost** — during the resume, watch `assets_downloaded_count` | Resets to 0 then climbs (counter reset is expected); with no debug delay set, it jumps quickly past the already-downloaded count — finished files are re-integrated, not re-fetched |
| 4 | **Offline handling** — start a download, airplane mode on, then restore | `_asset_packs`: `waiting_for_connection` while offline → `in_progress` → `completed` after reconnect |
| 5 | **Cancel is not auto-resumed** — `asset_pack: cancel_download` mid-download, force-kill, relaunch | `_asset_packs`: `cancelled`, and after relaunch **stays `cancelled`** — no new `download_started_at`, count does not advance |

> The debug delay applies to *skipped* files too, so with it set a resume won't look *faster* — verify resume by status/count reaching completion (row 2), not by speed. Drop the param for a realistic timing check.

## Out of scope / follow-ups

- **Phase 2 — background downloads:** continue transfers while the app is backgrounded (native per-file transfers, e.g. `@capgo/capacitor-downloader`, gated on a spike confirming the iOS background-session setup). This PR's resume/reconcile is the groundwork it hands back to on relaunch.
- **On-disk content verification:** a future `asset_pack: verify`/repair action (would add an MD5 dependency).
- **Updated completed packs:** a pack already `completed` is not re-checked when its content changes server-side (no pack versioning yet); a changed file is only picked up if a pack is re-downloaded while incomplete.
- **Download queue:** downloads remain strictly serial — one pack at a time, one file at a time. Requesting a second pack is refused rather than queued (the retry above is a narrow fix, not a general queue).

## Git Issues

Relates to https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-mx-content/issues/14

## Screenshots/Videos
