### PR TITLE
fix: delay in remote functions triggering on iOS

### DIFF
--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -8,5 +8,7 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>production</string>
 </dict>
 </plist>

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -8,6 +8,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        #if DEBUG
+        // App Attest is unavailable on simulators, so debug builds initialise app check with the
+        // debug provider instead (see src/app/feature/remote-function/README.md). Store a fixed
+        // token so a single registered token can be shared, rather than the sdk generating and
+        // logging a random one per install. Must match APP_CHECK_DEBUG_TOKEN in the js provider.
+        // Overridden if the AppCheckDebugToken or FIRAAppCheckDebugToken env variables are set.
+        UserDefaults.standard.set("00000000-0000-4000-a000-000000000000", forKey: "GACAppCheckDebugToken")
+        #endif
         return true
     }
 

--- a/src/app/feature/remote-function/README.md
+++ b/src/app/feature/remote-function/README.md
@@ -50,11 +50,31 @@ https://firebase.google.com/docs/app-check/android/play-integrity-provider
 Additional platform setup not required as integrated with `capacitor-firebase/app-check`
 
 ### App Check - IOS
-Follow instructions to integrate `DeviceCheck` on older devices (ios 11+)
-https://firebase.google.com/docs/app-check/ios/devicecheck-provider
-
-Follow instructions to integrate `App Attest` on newer devices (ios 14+)
+Follow instructions to integrate `App Attest`
 https://firebase.google.com/docs/app-check/ios/app-attest-provider
+
+This requires the `com.apple.developer.devicecheck.appattest-environment` entitlement, declared in
+`ios/App/App/App.entitlements`, and the app's bundle id and team id to be registered in the firebase
+console. Note that `capacitor-firebase/app-check` uses App Attest on all ios 14+ devices with no
+`DeviceCheck` fallback, and the project targets ios 14 as a minimum - so `DeviceCheck` is never used
+and does not need configuring.
+
+### App Check - Debug provider (native)
+
+Attestation is unavailable on simulators and emulators, so non-production builds initialise app check
+with the debug provider instead. Unlike web the debug token value cannot be set from javascript, so
+must be provided per-platform. Register the resulting token in the firebase console under
+App Check -> Apps -> (app) -> Manage Debug Tokens.
+
+- **IOS** - handled in `AppDelegate.swift`, which stores the same token used on web (under `#if DEBUG`)
+  so that only one token needs registering. To use a different token without editing the file, set an
+  `AppCheckDebugToken` or `FIRAAppCheckDebugToken` environment variable on the Xcode scheme
+  (Product -> Scheme -> Edit Scheme -> Run -> Arguments); these take precedence. NOTE - scheme files
+  are gitignored, so any such override applies only to your local checkout.
+- **Android** - the sdk generates a random token and logs it to logcat on launch (filter for
+  `DebugAppCheckProvider`).
+
+Production builds are unaffected, and always use the attestation providers above.
 
 ## Testing
 Remote functions can be tested locally from a debug page, with support for whitelisted device tokens.

--- a/src/app/feature/remote-function/pages/debug/remote-function-debug.page.ts
+++ b/src/app/feature/remote-function/pages/debug/remote-function-debug.page.ts
@@ -44,7 +44,9 @@ export class RemoteFunctionDebugPage implements OnInit {
     await this.service.ready();
   }
   public refreshAppCheck() {
-    return this.firebaseProvider()?.initialise(true);
+    // NOTE - only the token is refreshed; provider registration is one-shot and must not be
+    // re-run, as that could race with an in-flight init or function invocation
+    return this.firebaseProvider()?.refreshAppCheckToken();
   }
 
   // --- Param management ---

--- a/src/app/feature/remote-function/providers/firebase.spec.ts
+++ b/src/app/feature/remote-function/providers/firebase.spec.ts
@@ -1,0 +1,195 @@
+import { Injector, runInInjectionContext } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { GetTokenResult } from "@capacitor-firebase/app-check";
+import { CallByNameResult } from "@capacitor-firebase/functions";
+
+import { FirebaseFunctionProvider } from "./firebase";
+import { RemoteFunctionInvokeParams } from "./base";
+import { DeploymentService } from "src/app/shared/services/deployment/deployment.service";
+import { MockDeploymentService } from "src/app/shared/services/deployment/deployment.service.mock.spec";
+
+const MOCK_TOKEN: GetTokenResult = { token: "mock-token", expireTimeMillis: 0 };
+const MOCK_FUNCTION_RESULT: CallByNameResult = { data: { result: "ok" } };
+
+/**
+ * Stubs the native plugin calls so behaviour of the provider itself can be asserted.
+ * Individual specs override the `*Handler` properties to simulate failure or hanging calls
+ */
+class TestFirebaseFunctionProvider extends FirebaseFunctionProvider {
+  public setupCallCount = 0;
+  public tokenCallCount = 0;
+  public tokenForceRefreshCalls: boolean[] = [];
+
+  /** Kept short so the timeout path can be asserted without waiting on the production value */
+  public override appCheckTokenTimeoutMs = 20;
+
+  public setupHandler: () => Promise<void> = async () => {};
+  public tokenHandler: () => Promise<GetTokenResult> = async () => MOCK_TOKEN;
+  public functionHandler: () => Promise<CallByNameResult> = async () => MOCK_FUNCTION_RESULT;
+
+  protected override async setupAppCheck() {
+    this.setupCallCount++;
+    return this.setupHandler();
+  }
+
+  protected override async getAppCheckToken(forceRefresh: boolean) {
+    this.tokenCallCount++;
+    this.tokenForceRefreshCalls.push(forceRefresh);
+    return this.tokenHandler();
+  }
+
+  protected override async callFunction(name: string, params: RemoteFunctionInvokeParams) {
+    return this.functionHandler();
+  }
+}
+
+/** Promise that never settles, to simulate a hanging native call (e.g. iOS App Attest) */
+const neverResolves = () => new Promise<never>(() => {});
+
+/** Allow any pending (deliberately un-awaited) background work to settle */
+const flushPending = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Call standalone tests via:
+ * yarn ng test --include src/app/feature/remote-function/providers/firebase.spec.ts
+ */
+describe("FirebaseFunctionProvider", () => {
+  let provider: TestFirebaseFunctionProvider;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: DeploymentService, useValue: new MockDeploymentService() }],
+    });
+    const injector = TestBed.inject(Injector);
+    provider = runInInjectionContext(
+      injector,
+      () => new TestFirebaseFunctionProvider(injector)
+    ) as TestFirebaseFunctionProvider;
+  });
+
+  it("registers the appCheck provider once, regardless of how many times initialise is called", async () => {
+    await Promise.all([provider.initialise(), provider.initialise(), provider.initialise()]);
+    expect(provider.setupCallCount).toEqual(1);
+  });
+
+  it("invokes a function without waiting for the appCheck token", async () => {
+    // Simulate iOS App Attest hanging indefinitely
+    provider.tokenHandler = neverResolves;
+
+    const { data, error } = await provider.invoke("testFunction", {});
+
+    expect(error).toBeUndefined();
+    expect(data).toEqual(MOCK_FUNCTION_RESULT);
+  });
+
+  it("still invokes a function when appCheck setup fails, and does not retry setup", async () => {
+    provider.setupHandler = async () => {
+      throw new Error("appCheck unavailable");
+    };
+
+    const first = await provider.invoke("testFunction", {});
+    const second = await provider.invoke("testFunction", {});
+
+    expect(first.data).toEqual(MOCK_FUNCTION_RESULT);
+    expect(second.data).toEqual(MOCK_FUNCTION_RESULT);
+    expect(provider.setupCallCount).toEqual(1);
+    expect(provider.appCheckTokenError()).toEqual("appCheck unavailable");
+    // No token should be requested if the provider was never registered
+    expect(provider.tokenCallCount).toEqual(0);
+  });
+
+  it("populates the token signal from the background fetch triggered on initialise", async () => {
+    await provider.initialise();
+    // Background fetch is deliberately not awaited by initialise
+    await flushPending();
+
+    expect(provider.appCheckToken()).toEqual(MOCK_TOKEN);
+    expect(provider.appCheckTokenError()).toBeUndefined();
+    expect(provider.tokenForceRefreshCalls).toEqual([false]);
+  });
+
+  it("reports token failure without rejecting", async () => {
+    provider.tokenHandler = async () => {
+      throw new Error("no attestation");
+    };
+
+    await provider.refreshAppCheckToken();
+
+    expect(provider.appCheckToken()).toBeUndefined();
+    expect(provider.appCheckTokenError()).toEqual("no attestation");
+  });
+
+  it("reports a timeout when token retrieval hangs", async () => {
+    provider.tokenHandler = neverResolves;
+
+    await provider.refreshAppCheckToken();
+
+    expect(provider.appCheckToken()).toBeUndefined();
+    expect(provider.appCheckTokenError()).toContain("Timed out");
+  });
+
+  /**
+   * Token requests cannot be cancelled, so a slow background fetch can settle long after a newer
+   * explicit refresh has already reported a result
+   */
+  it("ignores a stale token result that settles after a newer request", async () => {
+    let failBackgroundFetch: (error: Error) => void;
+    provider.tokenHandler = () => new Promise((_, reject) => (failBackgroundFetch = reject));
+    await provider.initialise();
+
+    // Explicit refresh supersedes the still-pending background fetch, and succeeds
+    provider.tokenHandler = async () => MOCK_TOKEN;
+    await provider.refreshAppCheckToken();
+
+    // Background fetch now fails, and must not clobber the newer result
+    failBackgroundFetch(new Error("late failure"));
+    await flushPending();
+
+    expect(provider.appCheckToken()).toEqual(MOCK_TOKEN);
+    expect(provider.appCheckTokenError()).toBeUndefined();
+  });
+
+  /** As above, but with the outcomes reversed - a stale success must not overwrite a newer failure */
+  it("ignores a stale token success that settles after a newer request has failed", async () => {
+    let completeBackgroundFetch: (token: GetTokenResult) => void;
+    provider.tokenHandler = () => new Promise((resolve) => (completeBackgroundFetch = resolve));
+    await provider.initialise();
+
+    // Explicit refresh supersedes the still-pending background fetch, and fails
+    provider.tokenHandler = async () => {
+      throw new Error("no attestation");
+    };
+    await provider.refreshAppCheckToken();
+
+    // Background fetch now succeeds, and must not clobber the newer result
+    completeBackgroundFetch(MOCK_TOKEN);
+    await flushPending();
+
+    expect(provider.appCheckToken()).toBeUndefined();
+    expect(provider.appCheckTokenError()).toEqual("no attestation");
+  });
+
+  it("does not attempt a token refresh when appCheck setup failed", async () => {
+    provider.setupHandler = async () => {
+      throw new Error("appCheck unavailable");
+    };
+
+    await provider.refreshAppCheckToken();
+
+    expect(provider.tokenCallCount).toEqual(0);
+    // Original setup error preserved rather than replaced by a token error
+    expect(provider.appCheckTokenError()).toEqual("appCheck unavailable");
+  });
+
+  it("requests a forced refresh from the debug page, without joining a hung background fetch", async () => {
+    provider.tokenHandler = neverResolves;
+    await provider.initialise();
+    // Background fetch is now hanging. An explicit refresh must issue its own request
+    provider.tokenHandler = async () => MOCK_TOKEN;
+
+    await provider.refreshAppCheckToken();
+
+    expect(provider.appCheckToken()).toEqual(MOCK_TOKEN);
+    expect(provider.tokenForceRefreshCalls).toEqual([false, true]);
+  });
+});

--- a/src/app/feature/remote-function/providers/firebase.ts
+++ b/src/app/feature/remote-function/providers/firebase.ts
@@ -19,11 +19,23 @@ import { DeploymentService } from "src/app/shared/services/deployment/deployment
  */
 const APP_CHECK_DEBUG_TOKEN = "00000000-0000-4000-a000-000000000000";
 
+/** Max time to wait for an appCheck token before reporting it unavailable to the debug page */
+const APP_CHECK_TOKEN_TIMEOUT_MS = 30 * 1000;
+
 /**
  * Unified provider to support firestore functions
  * with app-check on both web and native
  *
+ * AppCheck is handled in two parts, as they have very different cost profiles:
+ * - Registering the provider is local and fast, so is awaited before invoking a function.
+ * - Retrieving a token can hang for minutes on native (e.g. iOS App Attest attestation), so is only
+ *   ever fetched in the background. The token retrieved here is never attached to a function call -
+ *   the firebase sdk fetches its own when invoking - it exists to populate the debug page, and to
+ *   prompt first-time attestation ahead of the sdk needing a token of its own.
  *
+ * AppCheck failures are reported via the `appCheckTokenError` signal and never rejected, so will not
+ * appear as an `initError` on the consuming `RemoteFunctionService`. Function calls are still
+ * attempted when appCheck is unavailable (and will be rejected by the backend if enforced)
  */
 export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
   // Provide public access to token and errors for use in debug page
@@ -40,18 +52,38 @@ export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
 
   private appCheckInitPromise?: Promise<void>;
 
+  /** Set if the appCheck provider could not be registered, in which case no token is retrievable */
+  private appCheckSetupFailed = false;
+
+  /** Incremented per token request, so that stale results can be discarded */
+  private appCheckTokenRequestId = 0;
+
+  /** Overridable in tests to avoid waiting on the full timeout */
+  protected appCheckTokenTimeoutMs = APP_CHECK_TOKEN_TIMEOUT_MS;
+
   constructor(private injector: Injector) {}
 
   /**
-   * Ensures service has initialised to register appCheck token ahead of function calls
-   * Can be called optimistically, or will be triggered on first function invocation
+   * Register the appCheck provider ahead of function calls, and trigger a background token fetch.
+   * Can be called optimistically, or will be triggered on first function invocation.
+   * Only ever runs once, and always resolves - see class notes
    **/
-  public async initialise(forceRefresh = false) {
-    if (forceRefresh || !this.appCheckInitPromise) {
-      // wrap init methods in promise to prevent duplicate requests
-      this.appCheckInitPromise = this.handleInitialise();
-    }
+  public async initialise() {
+    // wrap init methods in promise to prevent duplicate requests
+    this.appCheckInitPromise ??= this.handleInitialise();
     return this.appCheckInitPromise;
+  }
+
+  /**
+   * Fetch a fresh token for the debug page, bypassing any cached token.
+   * Never joins an in-flight background fetch, so that a hung fetch cannot block the page
+   */
+  public async refreshAppCheckToken() {
+    await this.initialise();
+    // Without a registered provider there is no token to retrieve, and setup is not retried, so
+    // leave the (more informative) setup error in place rather than replacing it with a token error
+    if (this.appCheckSetupFailed) return;
+    return this.updateAppCheckToken(true);
   }
 
   private async handleInitialise() {
@@ -60,28 +92,70 @@ export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
     firebaseService.ready();
     try {
       await this.setupAppCheck();
-      const token = await FirebaseAppCheck.getToken();
+    } catch (error) {
+      this.appCheckSetupFailed = true;
+      this.setAppCheckError("setup failed", error);
+      // NOTE - the failed promise is deliberately cached rather than cleared, as re-attempting
+      // setup on every invocation would stall each call for as long as this first failure took
+      return;
+    }
+    void this.updateAppCheckToken(false);
+  }
+
+  /**
+   * Retrieve an appCheck token and update the debug signals to reflect the outcome.
+   * Requests cannot be cancelled, so a slow request that settles after a newer one has already
+   * reported is discarded rather than allowed to overwrite it
+   */
+  private async updateAppCheckToken(forceRefresh: boolean) {
+    const requestId = ++this.appCheckTokenRequestId;
+    const isStale = () => requestId !== this.appCheckTokenRequestId;
+    try {
+      const token = await this.withTokenTimeout(this.getAppCheckToken(forceRefresh));
+      if (isStale()) {
+        console.log("[App check] ignoring stale token result");
+        return;
+      }
       this.appCheckToken.set(token);
       this.appCheckTokenError.set(undefined);
     } catch (error) {
-      console.error("[App check]", error);
-      this.appCheckTokenError.set(error instanceof Error ? error.message : String(error));
-      this.appCheckInitPromise = undefined; // Allow retry on failure
-      throw error;
+      if (isStale()) {
+        console.log("[App check] ignoring stale token error", error);
+        return;
+      }
+      this.appCheckToken.set(undefined);
+      this.setAppCheckError("token unavailable", error);
     }
   }
 
+  /**
+   * Reject if the request has not settled within `appCheckTokenTimeoutMs`.
+   * NOTE - this does not cancel the underlying request, which cannot be aborted
+   */
+  private async withTokenTimeout(request: Promise<GetTokenResult>) {
+    let timeoutRef: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutRef = setTimeout(
+        () => reject(new Error(`Timed out after ${this.appCheckTokenTimeoutMs}ms`)),
+        this.appCheckTokenTimeoutMs
+      );
+    });
+    // The request outlives a lost race, so ensure a later rejection is always handled
+    void request.catch(() => {});
+    return Promise.race([request, timeout]).finally(() => clearTimeout(timeoutRef));
+  }
+
+  private setAppCheckError(context: string, error: unknown) {
+    console.error(`[App check] ${context}`, error);
+    this.appCheckTokenError.set(error instanceof Error ? error.message : String(error));
+  }
+
   public async invoke(functionName: string, params: RemoteFunctionInvokeParams) {
-    // Ignore error here as it is captured in appCheckTokenError signal
-    // and we still want to try the function call (which might fail anyway if app check is enforced)
-    await this.initialise().catch(() => {});
+    // Ensures the appCheck provider is registered. Never rejects - see class notes
+    await this.initialise();
 
     let error: RemoteFunctionErrorResponse;
-    const data = await FirebaseFunctions.callByName({
-      name: functionName,
-      data: params,
-      region: this.region,
-    }).catch((err) => {
+    const data = await this.callFunction(functionName, params).catch((err) => {
       const { code, message, details, ...rest } = err;
       error = { code, message, details };
       console.error(`[Firebase Functions] ${functionName} `, { ...error, ...rest });
@@ -92,7 +166,21 @@ export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
   // TODO - support for separate callable vs http function
   // TODO - function streaming
 
-  private async setupAppCheck() {
+  // Plugin calls are wrapped below so that native calls can be stubbed in tests
+
+  protected async callFunction(functionName: string, params: RemoteFunctionInvokeParams) {
+    return FirebaseFunctions.callByName({
+      name: functionName,
+      data: params,
+      region: this.region,
+    });
+  }
+
+  protected async getAppCheckToken(forceRefresh: boolean) {
+    return FirebaseAppCheck.getToken({ forceRefresh });
+  }
+
+  protected async setupAppCheck() {
     // Native platform - provider configured
     if (Capacitor.isNativePlatform()) {
       await FirebaseAppCheck.initialize({ isTokenAutoRefreshEnabled: true });

--- a/src/app/feature/remote-function/providers/firebase.ts
+++ b/src/app/feature/remote-function/providers/firebase.ts
@@ -183,7 +183,13 @@ export class FirebaseFunctionProvider implements RemoteFunctionProviderBase {
   protected async setupAppCheck() {
     // Native platform - provider configured
     if (Capacitor.isNativePlatform()) {
-      await FirebaseAppCheck.initialize({ isTokenAutoRefreshEnabled: true });
+      // Attestation (ios App Attest, android Play Integrity) is unavailable on simulators and
+      // emulators, so non-production builds use the debug provider instead. Unlike web the token
+      // value cannot be passed from here, so must be set per-platform - see README
+      await FirebaseAppCheck.initialize({
+        isTokenAutoRefreshEnabled: true,
+        debugToken: !environment.production,
+      });
     } else {
       const siteKey = this.deploymentService.config.firebase?.appCheck?.recaptchaEnterpriseSiteKey;
       if (!siteKey) {

--- a/src/app/shared/services/asyncService.base.spec.ts
+++ b/src/app/shared/services/asyncService.base.spec.ts
@@ -1,0 +1,69 @@
+import { AsyncServiceBase } from "./asyncService.base";
+
+class TestAsyncService extends AsyncServiceBase {
+  public initCallCount = 0;
+
+  constructor(private initImplementation: () => Promise<void> = async () => {}) {
+    super("TestAsyncService");
+    this.registerInitFunction(this.init, "defer");
+  }
+
+  private init = async () => {
+    this.initCallCount++;
+    await this.initImplementation();
+  };
+}
+
+describe("AsyncServiceBase", () => {
+  it("resolves ready() and marks service ready after successful init", async () => {
+    const service = new TestAsyncService();
+    expect(service.isReady()).toEqual(false);
+
+    await service.ready();
+
+    expect(service.isReady()).toEqual(true);
+    expect(service.initError).toBeUndefined();
+    expect(service.initCallCount).toEqual(1);
+  });
+
+  it("only calls the init function once across multiple ready() calls", async () => {
+    const service = new TestAsyncService();
+
+    await Promise.all([service.ready(), service.ready(), service.ready()]);
+
+    expect(service.initCallCount).toEqual(1);
+  });
+
+  /**
+   * A failed init must not leave the service permanently unready, as init is only ever attempted
+   * once and dependent services would otherwise stall on the `ready()` timeout (default 60s)
+   */
+  it("resolves ready() without stalling when init fails", async () => {
+    const initError = new Error("init failed");
+    const service = new TestAsyncService(async () => {
+      throw initError;
+    });
+
+    const startTime = performance.now();
+    await service.ready();
+    const elapsed = performance.now() - startTime;
+
+    expect(elapsed).toBeLessThan(1000);
+    expect(service.isReady()).toEqual(true);
+    expect(service.initError).toBe(initError);
+  });
+
+  it("resolves subsequent ready() calls immediately after a failed init", async () => {
+    const service = new TestAsyncService(async () => {
+      throw new Error("init failed");
+    });
+    await service.ready();
+
+    const startTime = performance.now();
+    await service.ready();
+    const elapsed = performance.now() - startTime;
+
+    expect(elapsed).toBeLessThan(1000);
+    expect(service.initCallCount).toEqual(1);
+  });
+});

--- a/src/app/shared/services/asyncService.base.ts
+++ b/src/app/shared/services/asyncService.base.ts
@@ -32,6 +32,12 @@ export class AsyncServiceBase {
   private initFunction: () => Promise<void>;
 
   /**
+   * Error thrown by the init function, if it failed. The service will still be marked as ready
+   * (see `callInitFunction`), so this can be inspected by services that want to handle the failure
+   */
+  public initError?: unknown;
+
+  /**
    * @param serviceName Name of child service for use in logging
    */
   protected constructor(private serviceName: string) {}
@@ -120,11 +126,26 @@ export class AsyncServiceBase {
     this.initCalled = true;
     const startTime = performance.now();
     console.log(`%c ${this.serviceName || ""} `, "background: #deaa50; color: black");
-    await this.initFunction();
+    // A failed init must still mark the service as ready. Init is only ever attempted once, so
+    // otherwise `initialised$` would never emit and every future `ready()` call would stall for the
+    // full timeout (default 60s) before silently resolving anyway.
+    try {
+      await this.initFunction();
+    } catch (error) {
+      this.initError = error;
+    }
     this.initialised$.next(true);
     const endTime = performance.now();
     const totalTime = Math.round(endTime - startTime);
-    console.log(`%c ${this.serviceName} (${totalTime}ms) `, "background: #7ebd73; color: black");
+    if (this.initError) {
+      console.error(
+        `%c ${this.serviceName} (init failed after ${totalTime}ms) `,
+        "background: #bd7373; color: black",
+        this.initError
+      );
+    } else {
+      console.log(`%c ${this.serviceName} (${totalTime}ms) `, "background: #7ebd73; color: black");
+    }
   }
 
   /**


### PR DESCRIPTION
PR Checklist

- [x] PR title descriptive (can be used in release notes)

## Description

Remote functions took 1.5-2 minutes to trigger on iOS, against a few seconds on Android. Reported
against the `plh_parent_group` `join_remote` action, but affected every remote function invocation.

The cause was App Check: App Attest was never configured for iOS, so app check init failed on every
launch, and that failure was handled in a way that added ~90s to each call rather than failing fast.

### 1. Stop app check failures from stalling remote function calls

- `AsyncServiceBase` never marked a service as ready if its init function rejected. As init is only
  attempted once, every later `ready()` call waited the full timeout (default 60s) before silently
  resolving anyway. A failed init now still marks the service ready, exposing a new `initError`.
- `FirebaseFunctionProvider` cleared its cached init promise on failure, so every invocation re-ran
  app check setup and awaited a token. Registering the provider (local, fast) is still awaited and
  now only runs once; retrieving a token (which can hang for minutes on native, and only populates
  the debug page) now runs in the background and never blocks a call.

Also adds a timeout on token retrieval, discards stale token results that would overwrite a newer
result, and points the debug page's refresh button at the token rather than provider registration.
Unit tests added for both classes.

NOTE - iOS `FunctionsContextProvider` still blocks on app check with no timeout of its own, so this
part removes the stalls the app was adding, but part 2 is what fixes the underlying failure.

### 2. Enable App Check on iOS

- Added the missing `com.apple.developer.devicecheck.appattest-environment` entitlement, required by
  App Attest. `capacitor-firebase/app-check` uses App Attest on all iOS 14+ devices with no
  `DeviceCheck` fallback, and the project targets iOS 14 minimum, so `DeviceCheck` is never used.
- Non-production native builds now use the app check debug provider, as attestation is unavailable
  on simulators and emulators (already the case on web). The token cannot be passed from javascript
  on native, so `AppDelegate.swift` stores the same token used on web.
- Updated the feature README with iOS and debug provider setup.

## Required configuration changes

These changes have no effect on iOS until:

1. The deployment's corresponding app's configuration is updated in the Apple Developer console (App Attest capability enabled
  -  `Apple Developer Console -> Certificates, Identifiers & Profiles -> Identifiers -> Find the corresponding ID then tick the "App Attest" option and save`.
2. The `ios-release` workflow is run with the appropriate flag on the deployment repo.
   - The reusable action and deployment example have been updated as of https://github.com/IDEMSInternational/open-app-builder-actions/pull/33. The deployment level action will need to be copied over to repos, e.g. https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-my-content/pull/253
   - Then the action can be run with the `Allow Fastlane Match to create/update provisioning profiles` set to true. This will regenerate the provisioning profile for the relevant deployment based on the latest settings in the Apple dev console

## Testing

Verified on iOS that `join_remote` now completes in a few seconds rather than 1.5-2 minutes.

App Attest cannot be exercised on a simulator, so that path still needs confirming on a physical
device once the above configuration is in place - the remote function debug page reports app check
status directly.

## Git Issues

Relates to https://github.com/ParentingForLifelongHealth/plh-kids-teens-app-my-content/issues/250

## Screenshots/Videos

Demo of `plh_kids_teens_my` deployment on iOS:

https://github.com/user-attachments/assets/622fbaae-9699-4eba-8cd0-a702f7c1437b
